### PR TITLE
Add CI workflow and release documentation

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -3,7 +3,7 @@
 An MCP server bridging Claude and Apple Calendar via AppleScript on macOS.
 
 **Stack:** Python 3.10+, FastMCP, AppleScript (via `osascript`)
-**Version:** v0.1.0 | **Tests:** TBD | **Coverage:** TBD
+**Version:** v0.1.0 | **Tests:** 33 unit, 6 integration | **Coverage:** TBD
 
 ## Commands
 
@@ -69,6 +69,15 @@ Destructive operations require `CALENDAR_TEST_MODE=true` and `CALENDAR_TEST_NAME
 `{type}/issue-{num}-{description}` — e.g., `feature/issue-1-get-calendars`, `fix/issue-5-date-parsing`
 
 CHANGELOG.md is only updated on release branches, never on feature branches.
+
+## Release Workflow
+
+1. Run all tests: `make test` + `make test-integration`
+2. Run blind evals if tool descriptions changed (`evals/agent_tool_usability/`)
+3. Bump version in `pyproject.toml` and `.claude/CLAUDE.md`
+4. Run `./scripts/check_version_sync.sh`
+5. Update CHANGELOG.md (release branches only)
+6. Tag: `git tag vX.Y.Z` and push
 
 ## Key Files
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,54 @@
+name: Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  unit-tests:
+    name: Unit Tests
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .
+          pip install pytest pytest-asyncio pytest-cov radon
+
+      - name: Run unit tests
+        run: pytest tests/ -m "not integration" -v
+        timeout-minutes: 5
+
+      - name: Check code complexity
+        run: ./scripts/check_complexity.sh
+        continue-on-error: true
+
+      - name: Verify version sync
+        run: ./scripts/check_version_sync.sh
+
+  test-summary:
+    name: Test Summary
+    runs-on: ubuntu-latest
+    needs: [unit-tests]
+    if: always()
+
+    steps:
+      - name: Check test results
+        run: |
+          if [ "${{ needs.unit-tests.result }}" != "success" ]; then
+            echo "Unit tests failed"
+            exit 1
+          fi
+          echo "All required tests passed"

--- a/docs/research/calendar-api-gap-analysis.md
+++ b/docs/research/calendar-api-gap-analysis.md
@@ -55,7 +55,7 @@ Since UIDs are inaccessible, calendars must be identified by name. For duplicate
 | `recurrence` | ✅ | string (RRULE) or `missing value` | iCalendar RRULE format |
 | `excluded dates` | ✅ | list of dates or empty | For recurring event exceptions |
 | `stamp date` | ✅ | date | Last modified timestamp |
-| `sequence` | needs testing | integer | iCalendar sequence number |
+| `sequence` | ✅ | integer (0-based) | iCalendar sequence number |
 | `attendees` | ✅ (element) | list of attendee objects | Can query count; individual properties need testing |
 
 ### Date Format

--- a/scripts/check_version_sync.sh
+++ b/scripts/check_version_sync.sh
@@ -2,7 +2,7 @@
 # Verify version is consistent across pyproject.toml and CLAUDE.md
 
 PYPROJECT_VERSION=$(grep 'version = ' pyproject.toml | head -1 | sed 's/.*"\(.*\)".*/\1/')
-CLAUDE_VERSION=$(grep 'Version:' .claude/CLAUDE.md | head -1 | sed 's/.*v\([0-9.]*\).*/\1/')
+CLAUDE_VERSION=$(grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+' .claude/CLAUDE.md | head -1 | sed 's/v//')
 
 echo "pyproject.toml: $PYPROJECT_VERSION"
 echo "CLAUDE.md:      $CLAUDE_VERSION"


### PR DESCRIPTION
## Summary
- Add GitHub Actions CI workflow (unit tests on macos-latest, Python 3.12, complexity check, version sync)
- Document release workflow in CLAUDE.md
- Fix `check_version_sync.sh` regex to handle markdown bold formatting
- Update gap analysis with JXA `sequence` property finding

## Test plan
- [ ] CI workflow runs successfully on this PR
- [ ] `./scripts/check_version_sync.sh` passes locally
- [ ] Unit tests pass: `make test-unit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)