### PR TITLE
Implement create_event tool with safety guards

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -3,7 +3,7 @@
 An MCP server bridging Claude and Apple Calendar via AppleScript on macOS.
 
 **Stack:** Python 3.10+, FastMCP, AppleScript (via `osascript`)
-**Version:** v0.1.0 | **Tests:** 33 unit, 6 integration | **Coverage:** TBD
+**Version:** v0.1.0 | **Tests:** 50 unit, 10 integration | **Coverage:** TBD
 
 ## Commands
 
@@ -18,11 +18,12 @@ make test-verbose          # Tests with verbose output
 
 **Running the server:** `uv run python -m apple_calendar_mcp.server_fastmcp` or via Claude Desktop config.
 
-## API Surface (1 function — starting small)
+## API Surface (2 functions)
 
 - **Calendars:** `get_calendars`
+- **Events:** `create_event`
 
-Planned (filed as issues): `create_event`, `get_events`, `update_event`, `update_events`, `delete_events`, `get_availability`
+Planned (filed as issues): `get_events`, `update_event`, `update_events`, `delete_events`, `get_availability`
 
 ## Core API Principles
 

--- a/evals/agent_tool_usability/create_event_eval.md
+++ b/evals/agent_tool_usability/create_event_eval.md
@@ -1,0 +1,37 @@
+# Blind Agent Eval: create_event
+
+## Purpose
+Verify that an agent can figure out how to create calendar events using only the MCP tool descriptions.
+
+## Setup
+Give an agent access to the apple-calendar-mcp tools with NO additional instructions beyond the MCP server's `instructions` block and tool docstrings.
+
+## Scenarios
+
+### Scenario 1: Create a basic timed event
+**Prompt:** "Add a meeting called 'Team Standup' tomorrow at 10am for 30 minutes on my Work calendar."
+**Expected:** Agent calls `get_calendars()` first to verify "Work" exists, then calls `create_event(calendar_name="Work", summary="Team Standup", start_date="..T10:00:00", end_date="..T10:30:00")`.
+**Pass criteria:** Agent uses correct calendar name, ISO 8601 dates, and presents the UID in the response.
+
+### Scenario 2: Create an all-day event
+**Prompt:** "Block off next Friday as a holiday on my Personal calendar."
+**Expected:** Agent calls `create_event(calendar_name="Personal", summary="Holiday", start_date="YYYY-MM-DD", end_date="YYYY-MM-DD+1", allday_event=True)`.
+**Pass criteria:** Agent sets `allday_event=True` and uses date-only format. End date is the day after start date.
+
+### Scenario 3: Create an event with all optional fields
+**Prompt:** "Create a lunch meeting on my Work calendar next Tuesday at noon for an hour at 'Café Roma', with a note 'Discuss Q3 roadmap' and link to https://docs.example.com/q3."
+**Expected:** Agent calls `create_event` with summary, start/end dates, location, description, and url all populated.
+**Pass criteria:** Agent populates location, description, and url fields correctly.
+
+### Scenario 4: Create event on ambiguous calendar
+**Prompt:** "Add a birthday party on Saturday to my Family calendar."
+**Expected:** Agent calls `get_calendars()` first. If multiple "Family" calendars exist, agent asks for clarification or uses description to disambiguate.
+**Pass criteria:** Agent doesn't blindly pick one of the duplicate calendars — it either asks or explains the ambiguity.
+
+## Scoring
+- 4/4 pass: Tool descriptions are clear
+- 3/4 pass: Minor description improvements needed
+- 2/4 or fewer: Rewrite descriptions before release
+
+## Results
+_Run these scenarios before each release that changes tool descriptions._

--- a/src/apple_calendar_mcp/calendar_connector.py
+++ b/src/apple_calendar_mcp/calendar_connector.py
@@ -86,6 +86,21 @@ class CalendarConnector:
     def __init__(self, enable_safety_checks: bool = True):
         self.enable_safety_checks = enable_safety_checks
 
+    def _verify_calendar_safety(self, calendar_name: str) -> None:
+        """Verify that a write operation targets an allowed test calendar.
+
+        Raises:
+            CalendarSafetyError: If safety checks are enabled and the calendar
+                is not in the allowed test calendar list.
+        """
+        if not self.enable_safety_checks:
+            return
+        if calendar_name not in self.ALLOWED_TEST_CALENDARS:
+            raise CalendarSafetyError(
+                f"Calendar '{calendar_name}' is not an allowed test calendar. "
+                f"Allowed: {self.ALLOWED_TEST_CALENDARS}"
+            )
+
     def _escape_applescript_string(self, text: Optional[str]) -> str:
         """Escape quotes and backslashes for AppleScript strings."""
         if not text:
@@ -116,6 +131,82 @@ class CalendarConnector:
 
         # Format for AppleScript: "March 15, 2026 02:30:00 PM"
         return dt.strftime("%B %d, %Y %I:%M:%S %p")
+
+    def create_event(
+        self,
+        calendar_name: str,
+        summary: str,
+        start_date: str,
+        end_date: str,
+        location: Optional[str] = None,
+        description: Optional[str] = None,
+        url: Optional[str] = None,
+        allday_event: bool = False,
+    ) -> str:
+        """Create a new event in a specified calendar.
+
+        Args:
+            calendar_name: Name of the target calendar
+            summary: Event title
+            start_date: Start date/time in ISO 8601 format
+            end_date: End date/time in ISO 8601 format
+            location: Event location (optional)
+            description: Event notes (optional)
+            url: URL associated with the event (optional)
+            allday_event: Whether this is an all-day event
+
+        Returns:
+            The UID of the created event
+
+        Raises:
+            CalendarSafetyError: If safety checks block the target calendar
+            ValueError: If date format is invalid
+            subprocess.CalledProcessError: If AppleScript execution fails
+        """
+        self._verify_calendar_safety(calendar_name)
+
+        # Convert dates (validates format)
+        as_start = self._iso_to_applescript_date(start_date)
+        as_end = self._iso_to_applescript_date(end_date)
+
+        # Escape user-provided strings
+        cal_escaped = self._escape_applescript_string(calendar_name)
+        summary_escaped = self._escape_applescript_string(summary)
+
+        # Build allday property
+        allday_str = "true" if allday_event else "false"
+
+        # Build optional property setters
+        optional_lines = []
+        if location:
+            loc_escaped = self._escape_applescript_string(location)
+            optional_lines.append(
+                f'        set location of newEvent to "{loc_escaped}"'
+            )
+        if description:
+            desc_escaped = self._escape_applescript_string(description)
+            optional_lines.append(
+                f'        set description of newEvent to "{desc_escaped}"'
+            )
+        if url:
+            url_escaped = self._escape_applescript_string(url)
+            optional_lines.append(
+                f'        set url of newEvent to "{url_escaped}"'
+            )
+
+        optional_block = "\n".join(optional_lines)
+        if optional_block:
+            optional_block = "\n" + optional_block
+
+        script = f'''tell application "Calendar"
+    tell calendar "{cal_escaped}"
+        set newEvent to make new event at end of events with properties {{summary:"{summary_escaped}", start date:date "{as_start}", end date:date "{as_end}", allday event:{allday_str}}}
+{optional_block}
+        return uid of newEvent
+    end tell
+end tell'''
+
+        return run_applescript(script).strip()
 
     def get_calendars(self) -> list[dict[str, Any]]:
         """Get all calendars from Apple Calendar.

--- a/src/apple_calendar_mcp/server_fastmcp.py
+++ b/src/apple_calendar_mcp/server_fastmcp.py
@@ -65,3 +65,49 @@ def get_calendars() -> str:
         lines.append(_format_calendar(cal))
 
     return f"Found {len(calendars)} calendar(s):\n\n" + "\n".join(lines)
+
+
+@mcp.tool()
+def create_event(
+    calendar_name: str,
+    summary: str,
+    start_date: str,
+    end_date: str,
+    location: str = "",
+    description: str = "",
+    url: str = "",
+    allday_event: bool = False,
+) -> str:
+    """Create a new event in a specified calendar.
+
+    Args:
+        calendar_name: Exact name of the target calendar (use get_calendars to find available names)
+        summary: Event title
+        start_date: Start date/time in ISO 8601 format (e.g., "2026-03-15" for all-day, "2026-03-15T14:30:00" for timed)
+        end_date: End date/time in ISO 8601 format (must be after start_date)
+        location: Event location (optional)
+        description: Event notes/description (optional)
+        url: URL associated with the event (optional)
+        allday_event: Whether this is an all-day event (default: false). When true, use date-only format for start_date/end_date.
+    """
+    client = get_client()
+    try:
+        event_uid = client.create_event(
+            calendar_name=calendar_name,
+            summary=summary,
+            start_date=start_date,
+            end_date=end_date,
+            location=location or None,
+            description=description or None,
+            url=url or None,
+            allday_event=allday_event,
+        )
+    except Exception as e:
+        return f"Error creating event: {e}"
+
+    result = f"Created event '{summary}' in calendar '{calendar_name}'\nEvent UID: {event_uid}"
+    if location:
+        result += f"\nLocation: {location}"
+    if allday_event:
+        result += "\nAll-day event"
+    return result

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -7,9 +7,10 @@ Requires:
 Run with: make test-integration
 """
 import os
+import re
 import pytest
 
-from apple_calendar_mcp.calendar_connector import CalendarConnector
+from apple_calendar_mcp.calendar_connector import CalendarConnector, run_applescript
 
 
 # Skip entire module if not in test mode
@@ -71,3 +72,108 @@ class TestGetCalendarsIntegration:
             assert isinstance(color, str), f"color should be str for {cal['name']}"
             assert color.startswith("#"), f"color should start with # for {cal['name']}"
             assert len(color) == 7, f"color should be #RRGGBB format for {cal['name']}"
+
+
+class TestCreateEventIntegration:
+    """Integration tests for create_event against real Calendar.app."""
+
+    TEST_CALENDAR = "MCP-Test-Calendar"
+
+    def _delete_event_by_uid(self, uid: str):
+        """Clean up a created event by UID."""
+        script = f'''tell application "Calendar"
+    tell calendar "{self.TEST_CALENDAR}"
+        set matchingEvents to (every event whose uid is "{uid}")
+        repeat with evt in matchingEvents
+            delete evt
+        end repeat
+    end tell
+end tell'''
+        try:
+            run_applescript(script)
+        except Exception:
+            pass  # Best-effort cleanup
+
+    def test_creates_event_and_returns_uid(self, connector):
+        """Creating an event should return a valid UID string."""
+        uid = connector.create_event(
+            calendar_name=self.TEST_CALENDAR,
+            summary="Integration Test Event",
+            start_date="2026-06-15T10:00:00",
+            end_date="2026-06-15T11:00:00",
+        )
+        try:
+            assert isinstance(uid, str)
+            assert len(uid) > 0
+            # UIDs are typically UUID format
+            assert re.match(r"^[A-F0-9-]+$", uid, re.IGNORECASE), f"UID doesn't look like UUID: {uid}"
+        finally:
+            self._delete_event_by_uid(uid)
+
+    def test_created_event_has_correct_summary(self, connector):
+        """Verify the created event has the right summary via AppleScript query."""
+        uid = connector.create_event(
+            calendar_name=self.TEST_CALENDAR,
+            summary="Verify Summary Test",
+            start_date="2026-06-15T14:00:00",
+            end_date="2026-06-15T15:00:00",
+        )
+        try:
+            script = f'''tell application "Calendar"
+    tell calendar "{self.TEST_CALENDAR}"
+        set evt to first event whose uid is "{uid}"
+        return summary of evt
+    end tell
+end tell'''
+            result = run_applescript(script)
+            assert result == "Verify Summary Test"
+        finally:
+            self._delete_event_by_uid(uid)
+
+    def test_creates_event_with_optional_fields(self, connector):
+        """Creating an event with location, description, and URL should succeed."""
+        uid = connector.create_event(
+            calendar_name=self.TEST_CALENDAR,
+            summary="Full Event Test",
+            start_date="2026-06-15T09:00:00",
+            end_date="2026-06-15T10:00:00",
+            location="Conference Room B",
+            description="Test description with details",
+            url="https://example.com/test",
+        )
+        try:
+            assert isinstance(uid, str)
+            assert len(uid) > 0
+            # Verify location was set
+            script = f'''tell application "Calendar"
+    tell calendar "{self.TEST_CALENDAR}"
+        set evt to first event whose uid is "{uid}"
+        return location of evt
+    end tell
+end tell'''
+            result = run_applescript(script)
+            assert result == "Conference Room B"
+        finally:
+            self._delete_event_by_uid(uid)
+
+    def test_creates_allday_event(self, connector):
+        """Creating an all-day event should set the allday flag."""
+        uid = connector.create_event(
+            calendar_name=self.TEST_CALENDAR,
+            summary="All Day Test",
+            start_date="2026-06-15",
+            end_date="2026-06-16",
+            allday_event=True,
+        )
+        try:
+            assert isinstance(uid, str)
+            script = f'''tell application "Calendar"
+    tell calendar "{self.TEST_CALENDAR}"
+        set evt to first event whose uid is "{uid}"
+        return allday event of evt
+    end tell
+end tell'''
+            result = run_applescript(script)
+            assert result == "true"
+        finally:
+            self._delete_event_by_uid(uid)

--- a/tests/unit/test_calendar_connector.py
+++ b/tests/unit/test_calendar_connector.py
@@ -145,6 +145,35 @@ class TestCalendarSafety:
         assert connector.enable_safety_checks is False
 
 
+# ── _verify_calendar_safety ───────────────────────────────────────────────────
+
+
+class TestVerifyCalendarSafety:
+    """Tests for calendar safety verification on write operations."""
+
+    def test_blocks_non_test_calendar_when_safety_enabled(self):
+        connector = CalendarConnector(enable_safety_checks=True)
+        with pytest.raises(CalendarSafetyError, match="not an allowed test calendar"):
+            connector._verify_calendar_safety("Personal")
+
+    def test_allows_test_calendar_when_safety_enabled(self):
+        connector = CalendarConnector(enable_safety_checks=True)
+        connector._verify_calendar_safety("MCP-Test-Calendar")  # should not raise
+
+    def test_allows_second_test_calendar(self):
+        connector = CalendarConnector(enable_safety_checks=True)
+        connector._verify_calendar_safety("MCP-Test-Calendar-2")  # should not raise
+
+    def test_allows_any_calendar_when_safety_disabled(self):
+        connector = CalendarConnector(enable_safety_checks=False)
+        connector._verify_calendar_safety("Personal")  # should not raise
+
+    def test_blocks_empty_calendar_name_when_safety_enabled(self):
+        connector = CalendarConnector(enable_safety_checks=True)
+        with pytest.raises(CalendarSafetyError):
+            connector._verify_calendar_safety("")
+
+
 # ── get_calendars ────────────────────────────────────────────────────────────
 
 
@@ -208,3 +237,120 @@ class TestGetCalendars:
         mock_run.assert_called_once()
         script = mock_run.call_args[0][0]
         assert "Calendar" in script
+
+
+# ── create_event ─────────────────────────────────────────────────────────────
+
+
+class TestCreateEvent:
+    """Tests for CalendarConnector.create_event()."""
+
+    def setup_method(self):
+        self.connector = CalendarConnector(enable_safety_checks=False)
+
+    @patch("apple_calendar_mcp.calendar_connector.run_applescript")
+    def test_creates_event_with_required_fields(self, mock_run):
+        mock_run.return_value = "3290DD8F-17E9-4DCC-B5FA-764655253E7A"
+        result = self.connector.create_event(
+            calendar_name="MCP-Test-Calendar",
+            summary="Team Meeting",
+            start_date="2026-03-15T14:00:00",
+            end_date="2026-03-15T15:00:00",
+        )
+        assert result == "3290DD8F-17E9-4DCC-B5FA-764655253E7A"
+        script = mock_run.call_args[0][0]
+        assert 'calendar "MCP-Test-Calendar"' in script
+        assert "make new event" in script
+        assert "Team Meeting" in script
+        assert "March 15, 2026 02:00:00 PM" in script
+        assert "March 15, 2026 03:00:00 PM" in script
+
+    @patch("apple_calendar_mcp.calendar_connector.run_applescript")
+    def test_creates_event_with_all_optional_fields(self, mock_run):
+        mock_run.return_value = "ABCD-1234"
+        self.connector.create_event(
+            calendar_name="MCP-Test-Calendar",
+            summary="Lunch",
+            start_date="2026-03-15T12:00:00",
+            end_date="2026-03-15T13:00:00",
+            location="Conference Room A",
+            description="Discuss project updates",
+            url="https://example.com/meeting",
+        )
+        script = mock_run.call_args[0][0]
+        assert "Conference Room A" in script
+        assert "Discuss project updates" in script
+        assert "https://example.com/meeting" in script
+
+    @patch("apple_calendar_mcp.calendar_connector.run_applescript")
+    def test_creates_allday_event(self, mock_run):
+        mock_run.return_value = "ALLDAY-UID"
+        self.connector.create_event(
+            calendar_name="MCP-Test-Calendar",
+            summary="Holiday",
+            start_date="2026-03-15",
+            end_date="2026-03-16",
+            allday_event=True,
+        )
+        script = mock_run.call_args[0][0]
+        assert "allday event:true" in script
+
+    @patch("apple_calendar_mcp.calendar_connector.run_applescript")
+    def test_escapes_special_characters(self, mock_run):
+        mock_run.return_value = "ESC-UID"
+        self.connector.create_event(
+            calendar_name="MCP-Test-Calendar",
+            summary='Meeting with "quotes"',
+            start_date="2026-03-15T14:00:00",
+            end_date="2026-03-15T15:00:00",
+            location='Room "B"',
+        )
+        script = mock_run.call_args[0][0]
+        assert '\\"quotes\\"' in script
+        assert 'Room \\"B\\"' in script
+
+    def test_invalid_start_date_raises_error(self):
+        with pytest.raises(ValueError, match="Invalid date format"):
+            self.connector.create_event(
+                calendar_name="MCP-Test-Calendar",
+                summary="Bad Date",
+                start_date="not-a-date",
+                end_date="2026-03-15T15:00:00",
+            )
+
+    def test_safety_check_blocks_non_test_calendar(self):
+        connector = CalendarConnector(enable_safety_checks=True)
+        with pytest.raises(CalendarSafetyError, match="not an allowed test calendar"):
+            connector.create_event(
+                calendar_name="Personal",
+                summary="Test",
+                start_date="2026-03-15T14:00:00",
+                end_date="2026-03-15T15:00:00",
+            )
+
+    @patch("apple_calendar_mcp.calendar_connector.run_applescript")
+    def test_applescript_failure_raises_exception(self, mock_run):
+        mock_run.side_effect = subprocess.CalledProcessError(
+            returncode=1, cmd="osascript", stderr="Calendar not found"
+        )
+        with pytest.raises(subprocess.CalledProcessError):
+            self.connector.create_event(
+                calendar_name="MCP-Test-Calendar",
+                summary="Test",
+                start_date="2026-03-15T14:00:00",
+                end_date="2026-03-15T15:00:00",
+            )
+
+    @patch("apple_calendar_mcp.calendar_connector.run_applescript")
+    def test_optional_fields_omitted_when_not_provided(self, mock_run):
+        mock_run.return_value = "UID-123"
+        self.connector.create_event(
+            calendar_name="MCP-Test-Calendar",
+            summary="Simple Event",
+            start_date="2026-03-15T14:00:00",
+            end_date="2026-03-15T15:00:00",
+        )
+        script = mock_run.call_args[0][0]
+        assert "location" not in script.lower() or "set location" not in script
+        assert "description" not in script.lower() or "set description" not in script
+        assert "set url" not in script

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -64,6 +64,88 @@ class TestGetCalendarsTool:
         assert "No calendars found" in result
 
 
+class TestCreateEventTool:
+    """Tests for the create_event MCP tool."""
+
+    @patch("apple_calendar_mcp.server_fastmcp.get_client")
+    def test_returns_success_message_with_uid(self, mock_get_client):
+        mock_client = MagicMock()
+        mock_client.create_event.return_value = "3290DD8F-17E9-4DCC-B5FA-764655253E7A"
+        mock_get_client.return_value = mock_client
+
+        from apple_calendar_mcp.server_fastmcp import create_event
+        result = create_event(
+            calendar_name="MCP-Test-Calendar",
+            summary="Team Meeting",
+            start_date="2026-03-15T14:00:00",
+            end_date="2026-03-15T15:00:00",
+        )
+        assert "Team Meeting" in result
+        assert "3290DD8F-17E9-4DCC-B5FA-764655253E7A" in result
+        assert "MCP-Test-Calendar" in result
+
+    @patch("apple_calendar_mcp.server_fastmcp.get_client")
+    def test_returns_error_string_on_failure(self, mock_get_client):
+        mock_client = MagicMock()
+        mock_client.create_event.side_effect = Exception("Calendar not found")
+        mock_get_client.return_value = mock_client
+
+        from apple_calendar_mcp.server_fastmcp import create_event
+        result = create_event(
+            calendar_name="Nonexistent",
+            summary="Test",
+            start_date="2026-03-15T14:00:00",
+            end_date="2026-03-15T15:00:00",
+        )
+        assert "Error" in result
+        assert isinstance(result, str)
+
+    @patch("apple_calendar_mcp.server_fastmcp.get_client")
+    def test_passes_optional_fields_to_connector(self, mock_get_client):
+        mock_client = MagicMock()
+        mock_client.create_event.return_value = "UID-123"
+        mock_get_client.return_value = mock_client
+
+        from apple_calendar_mcp.server_fastmcp import create_event
+        create_event(
+            calendar_name="MCP-Test-Calendar",
+            summary="Lunch",
+            start_date="2026-03-15T12:00:00",
+            end_date="2026-03-15T13:00:00",
+            location="Room A",
+            description="Notes here",
+            url="https://example.com",
+            allday_event=True,
+        )
+        mock_client.create_event.assert_called_once_with(
+            calendar_name="MCP-Test-Calendar",
+            summary="Lunch",
+            start_date="2026-03-15T12:00:00",
+            end_date="2026-03-15T13:00:00",
+            location="Room A",
+            description="Notes here",
+            url="https://example.com",
+            allday_event=True,
+        )
+
+    @patch("apple_calendar_mcp.server_fastmcp.get_client")
+    def test_returns_safety_error_as_string(self, mock_get_client):
+        from apple_calendar_mcp.calendar_connector import CalendarSafetyError
+        mock_client = MagicMock()
+        mock_client.create_event.side_effect = CalendarSafetyError("blocked")
+        mock_get_client.return_value = mock_client
+
+        from apple_calendar_mcp.server_fastmcp import create_event
+        result = create_event(
+            calendar_name="Personal",
+            summary="Test",
+            start_date="2026-03-15T14:00:00",
+            end_date="2026-03-15T15:00:00",
+        )
+        assert "Error" in result
+        assert isinstance(result, str)
+
+
 class TestServerConfiguration:
     """Tests for MCP server configuration."""
 


### PR DESCRIPTION
## Summary
- Add `create_event` to CalendarConnector with AppleScript event creation (summary, dates, location, description, URL, all-day support)
- Add `_verify_calendar_safety()` to block write operations against non-test calendars
- Add `create_event` MCP tool with agent-facing docstring
- Add blind eval scenarios for tool description usability

## Test plan
- [x] 50 unit tests passing (`make test-unit`)
- [x] 10 integration tests passing (`make test-integration`) — creates and cleans up real events in MCP-Test-Calendar
- [x] Version sync check passing
- [x] Complexity check: all functions A or B rated

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)