### PR TITLE
Implement get_events with EventKit Swift helper (issue #2)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,9 +1,9 @@
 # Apple Calendar MCP Server
 
-An MCP server bridging Claude and Apple Calendar via AppleScript on macOS.
+An MCP server bridging Claude and Apple Calendar via AppleScript and EventKit on macOS.
 
-**Stack:** Python 3.10+, FastMCP, AppleScript (via `osascript`)
-**Version:** v0.1.0 | **Tests:** 50 unit, 10 integration | **Coverage:** TBD
+**Stack:** Python 3.10+, FastMCP, AppleScript (via `osascript`), Swift/EventKit (via `swift`)
+**Version:** v0.1.0 | **Tests:** 68 unit, 14 integration | **Coverage:** TBD
 
 ## Commands
 
@@ -18,12 +18,12 @@ make test-verbose          # Tests with verbose output
 
 **Running the server:** `uv run python -m apple_calendar_mcp.server_fastmcp` or via Claude Desktop config.
 
-## API Surface (2 functions)
+## API Surface (3 functions)
 
 - **Calendars:** `get_calendars`
-- **Events:** `create_event`
+- **Events:** `get_events`, `create_event`
 
-Planned (filed as issues): `get_events`, `update_event`, `update_events`, `delete_events`, `get_availability`
+Planned (filed as issues): `update_event`, `update_events`, `delete_events`, `get_availability`
 
 ## Core API Principles
 
@@ -50,7 +50,14 @@ Planned (filed as issues): `get_events`, `update_event`, `update_events`, `delet
 
 **String escaping:** Always use `_escape_applescript_string()` for user-provided text. Unescaped quotes break AppleScript blocks silently.
 
-**Performance:** `whose` clause with date filtering timed out on large calendars (5600+ events). Event filtering strategy needs careful design.
+**Performance:** `whose` clause with date filtering timed out on large calendars (5600+ events). AppleScript event reads are fundamentally too slow (~9s/event for index access, ~18s/property-batch for 306 events). `get_events` uses EventKit via Swift helper instead.
+
+## Hybrid Architecture
+
+- **Writes** (create, update, delete): AppleScript via `osascript` — fast for single-event operations
+- **Reads** (get_events): Swift/EventKit via `swift` subprocess — native date-range queries, sub-second on any calendar size
+
+The Swift helper at `src/apple_calendar_mcp/swift/get_events.swift` uses `EKEventStore` for fast predicate-based queries. First run triggers a macOS calendar access permission dialog.
 
 ## Calendar Safety
 
@@ -63,7 +70,7 @@ Destructive operations require `CALENDAR_TEST_MODE=true` and `CALENDAR_TEST_NAME
 | Unit tests | Every code change | `make test-unit` |
 | Integration tests | New/modified AppleScript operations | `make test-integration` (requires test calendar) |
 
-**Hard rule:** If you wrote or modified an AppleScript string in the connector, integration tests must cover that operation before merge. Unit tests mock `run_applescript()` and cannot catch AppleScript syntax errors.
+**Hard rule:** If you wrote or modified an AppleScript string in the connector, integration tests must cover that operation before merge. Unit tests mock `run_applescript()` and `run_swift_helper()` and cannot catch AppleScript/Swift errors.
 
 ## Branch Convention
 
@@ -82,6 +89,7 @@ CHANGELOG.md is only updated on release branches, never on feature branches.
 
 ## Key Files
 
-- `src/apple_calendar_mcp/calendar_connector.py` — Core AppleScript client
+- `src/apple_calendar_mcp/calendar_connector.py` — Core client (AppleScript + Swift helpers)
 - `src/apple_calendar_mcp/server_fastmcp.py` — FastMCP server wrapping the connector
+- `src/apple_calendar_mcp/swift/get_events.swift` — EventKit-based event query (fast reads)
 - `docs/research/calendar-api-gap-analysis.md` — What's possible, what's not

--- a/evals/agent_tool_usability/get_events_eval.md
+++ b/evals/agent_tool_usability/get_events_eval.md
@@ -1,0 +1,42 @@
+# Blind Eval: get_events Tool Description
+
+Test whether an agent can correctly use the `get_events` tool from its description alone.
+
+## Scenario 1: Basic daily schedule query
+
+**User prompt:** "What's on my Work calendar today?"
+
+**Expected agent behavior:**
+1. Call `get_calendars` to confirm "Work" exists
+2. Call `get_events` with `calendar_name="Work"`, `start_date="<today>T00:00:00"`, `end_date="<tomorrow>T00:00:00"`
+3. Present results in a readable format
+
+**Watch for:**
+- Agent uses correct ISO 8601 date format
+- Agent queries a single day (not a week or month)
+- Agent calls get_calendars first to verify the calendar name
+
+## Scenario 2: Multi-day range query
+
+**User prompt:** "Show me my Personal events for next week (March 16-22)."
+
+**Expected agent behavior:**
+1. Call `get_events` with `calendar_name="Personal"`, `start_date="2026-03-16T00:00:00"`, `end_date="2026-03-23T00:00:00"`
+
+**Watch for:**
+- Agent sets end_date to the day AFTER the last requested day (exclusive end)
+- Agent uses the exact calendar name
+
+## Scenario 3: Disambiguating calendars
+
+**User prompt:** "Do I have anything on my Family calendar this weekend?"
+
+**Expected agent behavior:**
+1. Call `get_calendars` — discovers two "Family" calendars
+2. Ask user which Family calendar they mean, using description to disambiguate
+3. Call `get_events` with the correct calendar name and weekend date range
+
+**Watch for:**
+- Agent recognizes duplicate calendar names
+- Agent doesn't blindly pick the first one
+- Agent asks for clarification

--- a/scripts/check_complexity.sh
+++ b/scripts/check_complexity.sh
@@ -1,18 +1,18 @@
 #!/bin/bash
 # Check cyclomatic complexity of Python source files
-# Fails if any function exceeds complexity threshold
+# Fails if any function has complexity grade C or worse (CC > 10)
+#
+# Radon grades: A (1-5), B (6-10), C (11-15), D (16-20), E (21-25), F (26+)
 
-THRESHOLD=10
-
-echo "Checking cyclomatic complexity (threshold: $THRESHOLD)..."
+echo "Checking cyclomatic complexity (max allowed: B, CC ≤ 10)..."
 
 if ! command -v radon &> /dev/null; then
     echo "radon not found. Install with: pip install radon"
     exit 1
 fi
 
-# Check complexity
-RESULT=$(radon cc src/ -n "$THRESHOLD" -s 2>&1)
+# Show only functions with grade C or worse (complexity > 10)
+RESULT=$(radon cc src/ -n C -s 2>&1)
 
 if [ -z "$RESULT" ]; then
     echo "All functions are within complexity threshold."

--- a/src/apple_calendar_mcp/calendar_connector.py
+++ b/src/apple_calendar_mcp/calendar_connector.py
@@ -3,6 +3,7 @@ import subprocess
 import json
 import os
 from datetime import datetime
+from pathlib import Path
 from typing import Any, Optional
 
 
@@ -25,6 +26,32 @@ def run_applescript(script: str, timeout: int = 60) -> str:
 
     result = subprocess.run(
         ["osascript", "-e", script],
+        capture_output=True,
+        text=True,
+        check=True,
+        timeout=timeout,
+    )
+    return result.stdout.strip()
+
+
+def run_swift_helper(script_name: str, args: list[str], timeout: int = 30) -> str:
+    """Execute a Swift helper script and return the result.
+
+    Args:
+        script_name: Name of the Swift script (without .swift extension)
+        args: Command-line arguments to pass to the script
+        timeout: Maximum seconds to wait (default: 30)
+
+    Returns:
+        The stdout output from the Swift script
+
+    Raises:
+        subprocess.TimeoutExpired: If script execution exceeds timeout
+        subprocess.CalledProcessError: If script execution fails
+    """
+    script_path = Path(__file__).parent / "swift" / f"{script_name}.swift"
+    result = subprocess.run(
+        ["swift", str(script_path)] + args,
         capture_output=True,
         text=True,
         check=True,
@@ -207,6 +234,64 @@ class CalendarConnector:
 end tell'''
 
         return run_applescript(script).strip()
+
+    def _validate_date(self, date_str: str) -> None:
+        """Validate that a string is a valid ISO 8601 date.
+
+        Raises:
+            ValueError: If the date format is invalid.
+        """
+        try:
+            if "T" in date_str:
+                datetime.fromisoformat(date_str.replace("Z", "+00:00"))
+            else:
+                datetime.fromisoformat(date_str + "T00:00:00")
+        except ValueError as e:
+            raise ValueError(
+                f"Invalid date format '{date_str}'. "
+                "Expected ISO 8601 format like '2026-03-15' or '2026-03-15T14:30:00'"
+            ) from e
+
+    def get_events(
+        self,
+        calendar_name: str,
+        start_date: str,
+        end_date: str,
+    ) -> list[dict[str, Any]]:
+        """Get events from a calendar within a date range.
+
+        Uses EventKit via Swift helper for fast native date-range queries.
+
+        Args:
+            calendar_name: Name of the calendar to query
+            start_date: Start of date range in ISO 8601 format
+            end_date: End of date range in ISO 8601 format
+
+        Returns:
+            List of event dicts with keys: uid, summary, start_date, end_date,
+            allday_event, location, description, url, status, calendar_name.
+
+        Raises:
+            ValueError: If date format is invalid or calendar not found
+            PermissionError: If EventKit calendar access is denied
+        """
+        self._validate_date(start_date)
+        self._validate_date(end_date)
+
+        result = run_swift_helper(
+            "get_events",
+            ["--calendar", calendar_name, "--start", start_date, "--end", end_date],
+        )
+        parsed = json.loads(result)
+
+        # Handle error responses from Swift helper
+        if isinstance(parsed, dict) and "error" in parsed:
+            if parsed["error"] == "calendar_access_denied":
+                raise PermissionError(parsed["message"])
+            else:
+                raise ValueError(parsed["message"])
+
+        return parsed
 
     def get_calendars(self) -> list[dict[str, Any]]:
         """Get all calendars from Apple Calendar.

--- a/src/apple_calendar_mcp/server_fastmcp.py
+++ b/src/apple_calendar_mcp/server_fastmcp.py
@@ -111,3 +111,57 @@ def create_event(
     if allday_event:
         result += "\nAll-day event"
     return result
+
+
+def _format_event(event: dict) -> str:
+    """Format an event dict as human-readable text."""
+    result = f"Title: {event['summary']}\n"
+    result += f"Start: {event['start_date']}\n"
+    result += f"End: {event['end_date']}\n"
+    if event.get("allday_event"):
+        result += "All-day event\n"
+    if event.get("location"):
+        result += f"Location: {event['location']}\n"
+    if event.get("description"):
+        result += f"Description: {event['description']}\n"
+    if event.get("url"):
+        result += f"URL: {event['url']}\n"
+    result += f"Status: {event.get('status', 'none')}\n"
+    result += f"UID: {event['uid']}\n"
+    return result
+
+
+@mcp.tool()
+def get_events(
+    calendar_name: str,
+    start_date: str,
+    end_date: str,
+) -> str:
+    """Get events from a calendar within a date range.
+
+    Returns all events in the specified calendar that overlap with the given
+    date range. Use get_calendars first to find available calendar names.
+
+    Args:
+        calendar_name: Exact name of the calendar to query (use get_calendars to find available names)
+        start_date: Start of date range in ISO 8601 format (e.g., "2026-03-15" or "2026-03-15T00:00:00")
+        end_date: End of date range in ISO 8601 format (must be after start_date)
+    """
+    client = get_client()
+    try:
+        events = client.get_events(
+            calendar_name=calendar_name,
+            start_date=start_date,
+            end_date=end_date,
+        )
+    except Exception as e:
+        return f"Error getting events: {e}"
+
+    if not events:
+        return f"No events found in '{calendar_name}' between {start_date} and {end_date}."
+
+    lines = []
+    for event in events:
+        lines.append(_format_event(event))
+
+    return f"Found {len(events)} event(s) in '{calendar_name}':\n\n" + "\n".join(lines)

--- a/src/apple_calendar_mcp/swift/get_events.swift
+++ b/src/apple_calendar_mcp/swift/get_events.swift
@@ -1,0 +1,158 @@
+import EventKit
+import Foundation
+
+// MARK: - Argument Parsing
+
+func printUsage() {
+    let msg = """
+    Usage: get_events.swift --calendar <name> --start <ISO8601> --end <ISO8601>
+
+    Queries Apple Calendar events using EventKit.
+    Outputs JSON array to stdout.
+    """
+    FileHandle.standardError.write(Data(msg.utf8))
+}
+
+func parseArgs() -> (calendar: String, start: String, end: String)? {
+    let args = CommandLine.arguments
+    var calendar: String?
+    var start: String?
+    var end: String?
+
+    var i = 1
+    while i < args.count {
+        switch args[i] {
+        case "--calendar":
+            i += 1; if i < args.count { calendar = args[i] }
+        case "--start":
+            i += 1; if i < args.count { start = args[i] }
+        case "--end":
+            i += 1; if i < args.count { end = args[i] }
+        default:
+            break
+        }
+        i += 1
+    }
+
+    guard let cal = calendar, let s = start, let e = end else {
+        return nil
+    }
+    return (cal, s, e)
+}
+
+// MARK: - Date Parsing
+
+func parseISO8601(_ str: String) -> Date? {
+    let formatter = ISO8601DateFormatter()
+    formatter.formatOptions = [.withInternetDateTime]
+    if let date = formatter.date(from: str) { return date }
+
+    // Try without timezone (assume local)
+    formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+    if let date = formatter.date(from: str) { return date }
+
+    // Try date-only or datetime without timezone
+    let df = DateFormatter()
+    df.locale = Locale(identifier: "en_US_POSIX")
+    for fmt in ["yyyy-MM-dd'T'HH:mm:ss", "yyyy-MM-dd"] {
+        df.dateFormat = fmt
+        if let date = df.date(from: str) { return date }
+    }
+    return nil
+}
+
+// MARK: - JSON Output
+
+func outputError(_ error: String, _ message: String) {
+    let obj: [String: String] = ["error": error, "message": message]
+    if let data = try? JSONSerialization.data(withJSONObject: obj),
+       let str = String(data: data, encoding: .utf8) {
+        print(str)
+    }
+}
+
+func eventToDict(_ event: EKEvent) -> [String: Any] {
+    let df = ISO8601DateFormatter()
+    df.formatOptions = [.withInternetDateTime]
+
+    var dict: [String: Any] = [
+        "uid": event.eventIdentifier ?? "",
+        "summary": event.title ?? "",
+        "start_date": df.string(from: event.startDate),
+        "end_date": df.string(from: event.endDate),
+        "allday_event": event.isAllDay,
+        "calendar_name": event.calendar.title,
+    ]
+
+    dict["location"] = event.location ?? ""
+    dict["description"] = event.notes ?? ""
+    dict["url"] = event.url?.absoluteString ?? ""
+
+    switch event.status {
+    case .none: dict["status"] = "none"
+    case .confirmed: dict["status"] = "confirmed"
+    case .tentative: dict["status"] = "tentative"
+    case .canceled: dict["status"] = "cancelled"
+    @unknown default: dict["status"] = "unknown"
+    }
+
+    return dict
+}
+
+// MARK: - Main
+
+guard let parsed = parseArgs() else {
+    outputError("invalid_args", "Required: --calendar <name> --start <ISO8601> --end <ISO8601>")
+    exit(0)
+}
+
+guard let startDate = parseISO8601(parsed.start) else {
+    outputError("invalid_date", "Cannot parse start date: \(parsed.start)")
+    exit(0)
+}
+
+guard let endDate = parseISO8601(parsed.end) else {
+    outputError("invalid_date", "Cannot parse end date: \(parsed.end)")
+    exit(0)
+}
+
+let store = EKEventStore()
+let semaphore = DispatchSemaphore(value: 0)
+var accessGranted = false
+var accessError: Error?
+
+store.requestFullAccessToEvents { granted, error in
+    accessGranted = granted
+    accessError = error
+    semaphore.signal()
+}
+
+semaphore.wait()
+
+if !accessGranted {
+    let msg = accessError?.localizedDescription ?? "Calendar access denied. Grant permission in System Settings > Privacy & Security > Calendars."
+    outputError("calendar_access_denied", msg)
+    exit(0)
+}
+
+// Find the calendar by name
+let allCalendars = store.calendars(for: .event)
+guard let calendar = allCalendars.first(where: { $0.title == parsed.calendar }) else {
+    let available = allCalendars.map { $0.title }.joined(separator: ", ")
+    outputError("calendar_not_found", "Calendar '\(parsed.calendar)' not found. Available: \(available)")
+    exit(0)
+}
+
+// Query events
+let predicate = store.predicateForEvents(withStart: startDate, end: endDate, calendars: [calendar])
+let events = store.events(matching: predicate)
+
+// Build JSON output
+let eventDicts = events.map { eventToDict($0) }
+
+if let data = try? JSONSerialization.data(withJSONObject: eventDicts, options: [.sortedKeys]),
+   let str = String(data: data, encoding: .utf8) {
+    print(str)
+} else {
+    outputError("serialization_error", "Failed to serialize events to JSON")
+}

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -19,11 +19,29 @@ pytestmark = pytest.mark.skipif(
     reason="Integration tests require CALENDAR_TEST_MODE=true",
 )
 
+TEST_CALENDAR = os.environ.get("CALENDAR_TEST_NAME", "MCP-Test-Calendar")
+
 
 @pytest.fixture
 def connector():
     """Create a CalendarConnector with safety checks enabled."""
     return CalendarConnector(enable_safety_checks=True)
+
+
+def _delete_event_by_uid(uid: str):
+    """Clean up a created event by UID."""
+    script = f'''tell application "Calendar"
+    tell calendar "{TEST_CALENDAR}"
+        set matchingEvents to (every event whose uid is "{uid}")
+        repeat with evt in matchingEvents
+            delete evt
+        end repeat
+    end tell
+end tell'''
+    try:
+        run_applescript(script)
+    except Exception:
+        pass  # Best-effort cleanup
 
 
 class TestGetCalendarsIntegration:
@@ -77,27 +95,10 @@ class TestGetCalendarsIntegration:
 class TestCreateEventIntegration:
     """Integration tests for create_event against real Calendar.app."""
 
-    TEST_CALENDAR = "MCP-Test-Calendar"
-
-    def _delete_event_by_uid(self, uid: str):
-        """Clean up a created event by UID."""
-        script = f'''tell application "Calendar"
-    tell calendar "{self.TEST_CALENDAR}"
-        set matchingEvents to (every event whose uid is "{uid}")
-        repeat with evt in matchingEvents
-            delete evt
-        end repeat
-    end tell
-end tell'''
-        try:
-            run_applescript(script)
-        except Exception:
-            pass  # Best-effort cleanup
-
     def test_creates_event_and_returns_uid(self, connector):
         """Creating an event should return a valid UID string."""
         uid = connector.create_event(
-            calendar_name=self.TEST_CALENDAR,
+            calendar_name=TEST_CALENDAR,
             summary="Integration Test Event",
             start_date="2026-06-15T10:00:00",
             end_date="2026-06-15T11:00:00",
@@ -105,22 +106,21 @@ end tell'''
         try:
             assert isinstance(uid, str)
             assert len(uid) > 0
-            # UIDs are typically UUID format
             assert re.match(r"^[A-F0-9-]+$", uid, re.IGNORECASE), f"UID doesn't look like UUID: {uid}"
         finally:
-            self._delete_event_by_uid(uid)
+            _delete_event_by_uid(uid)
 
     def test_created_event_has_correct_summary(self, connector):
         """Verify the created event has the right summary via AppleScript query."""
         uid = connector.create_event(
-            calendar_name=self.TEST_CALENDAR,
+            calendar_name=TEST_CALENDAR,
             summary="Verify Summary Test",
             start_date="2026-06-15T14:00:00",
             end_date="2026-06-15T15:00:00",
         )
         try:
             script = f'''tell application "Calendar"
-    tell calendar "{self.TEST_CALENDAR}"
+    tell calendar "{TEST_CALENDAR}"
         set evt to first event whose uid is "{uid}"
         return summary of evt
     end tell
@@ -128,12 +128,12 @@ end tell'''
             result = run_applescript(script)
             assert result == "Verify Summary Test"
         finally:
-            self._delete_event_by_uid(uid)
+            _delete_event_by_uid(uid)
 
     def test_creates_event_with_optional_fields(self, connector):
         """Creating an event with location, description, and URL should succeed."""
         uid = connector.create_event(
-            calendar_name=self.TEST_CALENDAR,
+            calendar_name=TEST_CALENDAR,
             summary="Full Event Test",
             start_date="2026-06-15T09:00:00",
             end_date="2026-06-15T10:00:00",
@@ -144,9 +144,8 @@ end tell'''
         try:
             assert isinstance(uid, str)
             assert len(uid) > 0
-            # Verify location was set
             script = f'''tell application "Calendar"
-    tell calendar "{self.TEST_CALENDAR}"
+    tell calendar "{TEST_CALENDAR}"
         set evt to first event whose uid is "{uid}"
         return location of evt
     end tell
@@ -154,12 +153,12 @@ end tell'''
             result = run_applescript(script)
             assert result == "Conference Room B"
         finally:
-            self._delete_event_by_uid(uid)
+            _delete_event_by_uid(uid)
 
     def test_creates_allday_event(self, connector):
         """Creating an all-day event should set the allday flag."""
         uid = connector.create_event(
-            calendar_name=self.TEST_CALENDAR,
+            calendar_name=TEST_CALENDAR,
             summary="All Day Test",
             start_date="2026-06-15",
             end_date="2026-06-16",
@@ -168,7 +167,7 @@ end tell'''
         try:
             assert isinstance(uid, str)
             script = f'''tell application "Calendar"
-    tell calendar "{self.TEST_CALENDAR}"
+    tell calendar "{TEST_CALENDAR}"
         set evt to first event whose uid is "{uid}"
         return allday event of evt
     end tell
@@ -176,4 +175,81 @@ end tell'''
             result = run_applescript(script)
             assert result == "true"
         finally:
-            self._delete_event_by_uid(uid)
+            _delete_event_by_uid(uid)
+
+
+class TestGetEventsIntegration:
+    """Integration tests for get_events against real Calendar.app via EventKit."""
+
+    def test_get_events_returns_created_event(self, connector):
+        """Create an event, then verify get_events returns it."""
+        uid = connector.create_event(
+            calendar_name=TEST_CALENDAR,
+            summary="GetEvents Test",
+            start_date="2026-07-01T10:00:00",
+            end_date="2026-07-01T11:00:00",
+        )
+        try:
+            events = connector.get_events(
+                calendar_name=TEST_CALENDAR,
+                start_date="2026-07-01T00:00:00",
+                end_date="2026-07-02T00:00:00",
+            )
+            summaries = [e["summary"] for e in events]
+            assert "GetEvents Test" in summaries
+        finally:
+            _delete_event_by_uid(uid)
+
+    def test_date_range_filtering(self, connector):
+        """Event outside date range should not be returned."""
+        uid = connector.create_event(
+            calendar_name=TEST_CALENDAR,
+            summary="Outside Range Test",
+            start_date="2026-08-01T10:00:00",
+            end_date="2026-08-01T11:00:00",
+        )
+        try:
+            events = connector.get_events(
+                calendar_name=TEST_CALENDAR,
+                start_date="2026-07-01T00:00:00",
+                end_date="2026-07-02T00:00:00",
+            )
+            summaries = [e["summary"] for e in events]
+            assert "Outside Range Test" not in summaries
+        finally:
+            _delete_event_by_uid(uid)
+
+    def test_event_has_expected_keys(self, connector):
+        """Returned event dicts should have all expected keys."""
+        uid = connector.create_event(
+            calendar_name=TEST_CALENDAR,
+            summary="Keys Test Event",
+            start_date="2026-07-02T10:00:00",
+            end_date="2026-07-02T11:00:00",
+            location="Test Location",
+        )
+        try:
+            events = connector.get_events(
+                calendar_name=TEST_CALENDAR,
+                start_date="2026-07-02T00:00:00",
+                end_date="2026-07-03T00:00:00",
+            )
+            test_events = [e for e in events if e["summary"] == "Keys Test Event"]
+            assert len(test_events) == 1
+            event = test_events[0]
+            for key in ["uid", "summary", "start_date", "end_date", "allday_event",
+                         "location", "description", "url", "status", "calendar_name"]:
+                assert key in event, f"Missing key '{key}' in event"
+            assert event["location"] == "Test Location"
+            assert event["calendar_name"] == TEST_CALENDAR
+        finally:
+            _delete_event_by_uid(uid)
+
+    def test_empty_date_range_returns_empty_list(self, connector):
+        """Date range with no events should return empty list."""
+        events = connector.get_events(
+            calendar_name=TEST_CALENDAR,
+            start_date="2099-01-01T00:00:00",
+            end_date="2099-01-02T00:00:00",
+        )
+        assert events == []

--- a/tests/unit/test_calendar_connector.py
+++ b/tests/unit/test_calendar_connector.py
@@ -1,12 +1,14 @@
 """Unit tests for CalendarConnector — core helpers and get_calendars."""
 import json
 import subprocess
+from pathlib import Path
 from unittest.mock import patch, MagicMock
 
 import pytest
 
 from apple_calendar_mcp.calendar_connector import (
     run_applescript,
+    run_swift_helper,
     CalendarConnector,
     CalendarSafetyError,
 )
@@ -65,6 +67,59 @@ class TestRunApplescript:
         )
         with pytest.raises(subprocess.CalledProcessError):
             run_applescript("script")
+
+
+# ── run_swift_helper ─────────────────────────────────────────────────────────
+
+
+class TestRunSwiftHelper:
+    """Tests for the run_swift_helper function."""
+
+    @patch("apple_calendar_mcp.calendar_connector.subprocess.run")
+    def test_returns_stdout_stripped(self, mock_run):
+        mock_run.return_value = MagicMock(stdout='  [{"uid": "123"}]  \n')
+        result = run_swift_helper("get_events", ["--calendar", "Work"])
+        assert result == '[{"uid": "123"}]'
+
+    @patch("apple_calendar_mcp.calendar_connector.subprocess.run")
+    def test_calls_swift_with_script_path_and_args(self, mock_run):
+        mock_run.return_value = MagicMock(stdout="[]")
+        run_swift_helper("get_events", ["--calendar", "Work", "--start", "2026-03-15"])
+        call_args = mock_run.call_args
+        cmd = call_args[0][0]
+        assert cmd[0] == "swift"
+        assert cmd[1].endswith("get_events.swift")
+        assert "--calendar" in cmd
+        assert "Work" in cmd
+
+    @patch("apple_calendar_mcp.calendar_connector.subprocess.run")
+    def test_script_path_relative_to_package(self, mock_run):
+        mock_run.return_value = MagicMock(stdout="[]")
+        run_swift_helper("get_events", [])
+        cmd = mock_run.call_args[0][0]
+        script_path = Path(cmd[1])
+        assert script_path.parent.name == "swift"
+        assert script_path.parent.parent.name == "apple_calendar_mcp"
+
+    @patch("apple_calendar_mcp.calendar_connector.subprocess.run")
+    def test_custom_timeout(self, mock_run):
+        mock_run.return_value = MagicMock(stdout="[]")
+        run_swift_helper("get_events", [], timeout=120)
+        assert mock_run.call_args[1]["timeout"] == 120
+
+    @patch("apple_calendar_mcp.calendar_connector.subprocess.run")
+    def test_called_process_error_propagates(self, mock_run):
+        mock_run.side_effect = subprocess.CalledProcessError(
+            returncode=1, cmd="swift", stderr="compilation error"
+        )
+        with pytest.raises(subprocess.CalledProcessError):
+            run_swift_helper("get_events", [])
+
+    @patch("apple_calendar_mcp.calendar_connector.subprocess.run")
+    def test_timeout_expired_propagates(self, mock_run):
+        mock_run.side_effect = subprocess.TimeoutExpired(cmd="swift", timeout=30)
+        with pytest.raises(subprocess.TimeoutExpired):
+            run_swift_helper("get_events", [])
 
 
 # ── _escape_applescript_string ───────────────────────────────────────────────
@@ -354,3 +409,75 @@ class TestCreateEvent:
         assert "location" not in script.lower() or "set location" not in script
         assert "description" not in script.lower() or "set description" not in script
         assert "set url" not in script
+
+
+# ── get_events ──────────────────────────────────────────────────────────────
+
+
+class TestGetEvents:
+    """Tests for CalendarConnector.get_events()."""
+
+    def setup_method(self):
+        self.connector = CalendarConnector()
+
+    @patch("apple_calendar_mcp.calendar_connector.run_swift_helper")
+    def test_calls_swift_helper_with_correct_args(self, mock_swift):
+        mock_swift.return_value = "[]"
+        self.connector.get_events(
+            calendar_name="Work",
+            start_date="2026-03-15T00:00:00",
+            end_date="2026-03-16T00:00:00",
+        )
+        mock_swift.assert_called_once_with(
+            "get_events",
+            ["--calendar", "Work", "--start", "2026-03-15T00:00:00", "--end", "2026-03-16T00:00:00"],
+        )
+
+    @patch("apple_calendar_mcp.calendar_connector.run_swift_helper")
+    def test_parses_json_response(self, mock_swift):
+        mock_swift.return_value = json.dumps([
+            {"uid": "ABC-123", "summary": "Meeting", "start_date": "2026-03-15T14:00:00Z",
+             "end_date": "2026-03-15T15:00:00Z", "allday_event": False, "location": "",
+             "description": "", "url": "", "status": "confirmed", "calendar_name": "Work"},
+        ])
+        result = self.connector.get_events("Work", "2026-03-15T00:00:00", "2026-03-16T00:00:00")
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert result[0]["uid"] == "ABC-123"
+        assert result[0]["summary"] == "Meeting"
+
+    @patch("apple_calendar_mcp.calendar_connector.run_swift_helper")
+    def test_returns_empty_list_when_no_events(self, mock_swift):
+        mock_swift.return_value = "[]"
+        result = self.connector.get_events("Work", "2026-03-15T00:00:00", "2026-03-16T00:00:00")
+        assert result == []
+
+    def test_invalid_start_date_raises_error(self):
+        with pytest.raises(ValueError, match="Invalid date format"):
+            self.connector.get_events("Work", "not-a-date", "2026-03-16T00:00:00")
+
+    def test_invalid_end_date_raises_error(self):
+        with pytest.raises(ValueError, match="Invalid date format"):
+            self.connector.get_events("Work", "2026-03-15T00:00:00", "not-a-date")
+
+    @patch("apple_calendar_mcp.calendar_connector.run_swift_helper")
+    def test_handles_authorization_error(self, mock_swift):
+        mock_swift.return_value = json.dumps(
+            {"error": "calendar_access_denied", "message": "Access denied"}
+        )
+        with pytest.raises(PermissionError, match="Access denied"):
+            self.connector.get_events("Work", "2026-03-15T00:00:00", "2026-03-16T00:00:00")
+
+    @patch("apple_calendar_mcp.calendar_connector.run_swift_helper")
+    def test_handles_calendar_not_found_error(self, mock_swift):
+        mock_swift.return_value = json.dumps(
+            {"error": "calendar_not_found", "message": "Calendar 'Foo' not found."}
+        )
+        with pytest.raises(ValueError, match="Calendar 'Foo' not found"):
+            self.connector.get_events("Foo", "2026-03-15T00:00:00", "2026-03-16T00:00:00")
+
+    @patch("apple_calendar_mcp.calendar_connector.run_swift_helper")
+    def test_date_only_format_accepted(self, mock_swift):
+        mock_swift.return_value = "[]"
+        self.connector.get_events("Work", "2026-03-15", "2026-03-16")
+        mock_swift.assert_called_once()

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -146,6 +146,57 @@ class TestCreateEventTool:
         assert isinstance(result, str)
 
 
+class TestGetEventsTool:
+    """Tests for the get_events MCP tool."""
+
+    @patch("apple_calendar_mcp.server_fastmcp.get_client")
+    def test_returns_formatted_event_list(self, mock_get_client):
+        mock_client = MagicMock()
+        mock_client.get_events.return_value = [
+            {"uid": "ABC-123", "summary": "Team Meeting", "start_date": "2026-03-15T14:00:00Z",
+             "end_date": "2026-03-15T15:00:00Z", "allday_event": False, "location": "Room 4",
+             "description": "Weekly sync", "url": "", "status": "confirmed", "calendar_name": "Work"},
+        ]
+        mock_get_client.return_value = mock_client
+
+        from apple_calendar_mcp.server_fastmcp import get_events
+        result = get_events(calendar_name="Work", start_date="2026-03-15T00:00:00", end_date="2026-03-16T00:00:00")
+        assert "Team Meeting" in result
+        assert "Room 4" in result
+        assert isinstance(result, str)
+
+    @patch("apple_calendar_mcp.server_fastmcp.get_client")
+    def test_returns_no_events_message(self, mock_get_client):
+        mock_client = MagicMock()
+        mock_client.get_events.return_value = []
+        mock_get_client.return_value = mock_client
+
+        from apple_calendar_mcp.server_fastmcp import get_events
+        result = get_events(calendar_name="Work", start_date="2026-03-15T00:00:00", end_date="2026-03-16T00:00:00")
+        assert "No events found" in result
+
+    @patch("apple_calendar_mcp.server_fastmcp.get_client")
+    def test_returns_error_string_on_failure(self, mock_get_client):
+        mock_client = MagicMock()
+        mock_client.get_events.side_effect = ValueError("Calendar 'Foo' not found")
+        mock_get_client.return_value = mock_client
+
+        from apple_calendar_mcp.server_fastmcp import get_events
+        result = get_events(calendar_name="Foo", start_date="2026-03-15T00:00:00", end_date="2026-03-16T00:00:00")
+        assert "Error" in result
+        assert isinstance(result, str)
+
+    @patch("apple_calendar_mcp.server_fastmcp.get_client")
+    def test_returns_permission_error_as_string(self, mock_get_client):
+        mock_client = MagicMock()
+        mock_client.get_events.side_effect = PermissionError("Calendar access denied")
+        mock_get_client.return_value = mock_client
+
+        from apple_calendar_mcp.server_fastmcp import get_events
+        result = get_events(calendar_name="Work", start_date="2026-03-15T00:00:00", end_date="2026-03-16T00:00:00")
+        assert "Error" in result
+
+
 class TestServerConfiguration:
     """Tests for MCP server configuration."""
 


### PR DESCRIPTION
## Summary
- Add `get_events` using Swift/EventKit for fast date-range queries (sub-second vs 47s+ with AppleScript)
- Introduce hybrid architecture: AppleScript for writes, Swift/EventKit for reads
- Add `run_swift_helper()` subprocess runner parallel to `run_applescript()`
- Fix `check_complexity.sh` bug: `-n` flag takes letter grade, not number
- Refactor integration test cleanup into shared `_delete_event_by_uid()` helper

## Performance
| Approach | 5602-event calendar | 306-event calendar |
|----------|--------------------|--------------------|
| AppleScript `whose` | **Timed out** | **Timed out** |
| AppleScript index | **47s** (5 events) | — |
| Swift/EventKit | **0.7s** (30-day query) | **< 0.5s** |

## Test plan
- [x] 68 unit tests passing (`make test-unit`)
- [x] 14 integration tests passing (`make test-integration`)
- [x] Version sync check passing
- [x] Complexity check passing (all functions A or B rated)
- [x] Swift script type-checks cleanly (`swiftc -typecheck`)

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)