### PR TITLE
Implement update_event tool (issue #3)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -3,7 +3,7 @@
 An MCP server bridging Claude and Apple Calendar via AppleScript and EventKit on macOS.
 
 **Stack:** Python 3.10+, FastMCP, AppleScript (via `osascript`), Swift/EventKit (via `swift`)
-**Version:** v0.1.0 | **Tests:** 68 unit, 14 integration | **Coverage:** TBD
+**Version:** v0.1.0 | **Tests:** 89 unit, 20 integration | **Coverage:** TBD
 
 ## Commands
 
@@ -18,12 +18,12 @@ make test-verbose          # Tests with verbose output
 
 **Running the server:** `uv run python -m apple_calendar_mcp.server_fastmcp` or via Claude Desktop config.
 
-## API Surface (3 functions)
+## API Surface (4 functions)
 
 - **Calendars:** `get_calendars`
-- **Events:** `get_events`, `create_event`
+- **Events:** `get_events`, `create_event`, `update_event`
 
-Planned (filed as issues): `update_event`, `update_events`, `delete_events`, `get_availability`
+Planned (filed as issues): `update_events`, `delete_events`, `get_availability`
 
 ## Core API Principles
 
@@ -40,13 +40,17 @@ Planned (filed as issues): `update_event`, `update_events`, `delete_events`, `ge
 
 **Batch vs individual access:** `name of every calendar` works but `properties of calendar "X"` fails. Use batch property access for calendars.
 
-**Event UIDs work fine:** Individual event property access works: `uid of event`, `summary of event`, `start date of event`, etc.
+**Event UIDs differ across APIs:** AppleScript's `uid of event` returns a different identifier than EventKit's `eventIdentifier`. Use EventKit's `calendarItemIdentifier` to get UIDs that match AppleScript. The Swift helper uses `calendarItemIdentifier` for this reason.
+
+**Event UIDs work fine in AppleScript:** Individual event property access works: `uid of event`, `summary of event`, `start date of event`, etc.
 
 **Variable naming conflicts:** Never use variable names that match Calendar properties. If Calendar has a `summary` property, don't use `summary` as a variable name — use `eventSummary`.
 
 **JSON helpers duplicated:** AppleScript has no imports/modules. Every AppleScript block that returns JSON must include its own helper functions. This is intentional.
 
 **Date format:** AppleScript returns dates as `"Monday, April 3, 2023 at 10:35:00 AM"` (locale-dependent, includes day name). The connector handles ISO 8601 conversion.
+
+**Date ordering on updates:** AppleScript rejects `set start date` if the new start is after the current end date (and vice versa). When updating both dates, `update_event` temporarily extends the end date to avoid this constraint.
 
 **String escaping:** Always use `_escape_applescript_string()` for user-provided text. Unescaped quotes break AppleScript blocks silently.
 

--- a/evals/agent_tool_usability/update_event_eval.md
+++ b/evals/agent_tool_usability/update_event_eval.md
@@ -1,0 +1,54 @@
+# Blind Eval: update_event Tool Description
+
+Test whether an agent can correctly use the `update_event` tool from its description alone.
+
+## Scenario 1: Simple field update
+
+**User prompt:** "Change the title of my 2pm meeting today to 'Project Review'"
+
+**Expected agent behavior:**
+1. Call `get_events` to find today's events
+2. Identify the 2pm event and note its UID and calendar_name
+3. Call `update_event` with `calendar_name`, `event_uid`, and `summary="Project Review"`
+
+**Watch for:**
+- Agent uses the UID from get_events (not fabricated)
+- Agent passes the correct calendar_name from the event
+- Agent only sets summary, not other fields
+
+## Scenario 2: Update location
+
+**User prompt:** "Move my 'Team Standup' event to Conference Room B"
+
+**Expected agent behavior:**
+1. Call `get_events` to find the event by summary
+2. Call `update_event` with `location="Conference Room B"`
+
+**Watch for:**
+- Agent correctly interprets "move" as updating location, not dates
+- Agent does not modify start_date or end_date
+
+## Scenario 3: Clear a field
+
+**User prompt:** "Remove the location from my dentist appointment"
+
+**Expected agent behavior:**
+1. Call `get_events` to find the dentist appointment
+2. Call `update_event` with `location=""`
+
+**Watch for:**
+- Agent passes empty string "" to clear the field (not None/omit)
+- Agent understands the distinction between clearing and not modifying
+
+## Scenario 4: Reschedule an event
+
+**User prompt:** "Move my 10am meeting to 3pm today"
+
+**Expected agent behavior:**
+1. Call `get_events` to find the 10am event
+2. Call `update_event` with both `start_date` and `end_date` adjusted by 5 hours
+
+**Watch for:**
+- Agent updates BOTH start_date and end_date (not just start)
+- Agent preserves the event duration
+- Agent uses ISO 8601 format for dates

--- a/src/apple_calendar_mcp/calendar_connector.py
+++ b/src/apple_calendar_mcp/calendar_connector.py
@@ -293,6 +293,105 @@ end tell'''
 
         return parsed
 
+    def update_event(
+        self,
+        calendar_name: str,
+        event_uid: str,
+        summary: str | None = None,
+        start_date: str | None = None,
+        end_date: str | None = None,
+        location: str | None = None,
+        description: str | None = None,
+        url: str | None = None,
+        allday_event: bool | None = None,
+    ) -> dict[str, Any]:
+        """Update an existing event's properties by UID.
+
+        Only provided fields are updated; omitted fields (None) are left unchanged.
+        Pass an empty string to clear a text field.
+
+        Args:
+            calendar_name: Name of the calendar containing the event
+            event_uid: UID of the event to update
+            summary: New event title (optional)
+            start_date: New start date/time in ISO 8601 format (optional)
+            end_date: New end date/time in ISO 8601 format (optional)
+            location: New location (optional, "" to clear)
+            description: New description (optional, "" to clear)
+            url: New URL (optional, "" to clear)
+            allday_event: New all-day status (optional)
+
+        Returns:
+            Dict with 'uid' and 'updated_fields' keys
+
+        Raises:
+            CalendarSafetyError: If safety checks block the target calendar
+            ValueError: If no fields provided or date format is invalid
+            subprocess.CalledProcessError: If AppleScript execution fails
+        """
+        self._verify_calendar_safety(calendar_name)
+
+        # Build set lines and track updated fields
+        set_lines = []
+        updated_fields = []
+
+        # String fields: property name in AppleScript → (field_name, value)
+        string_fields = [
+            ("summary", "summary", summary),
+            ("location", "location", location),
+            ("description", "description", description),
+            ("url", "url", url),
+        ]
+        for as_prop, field_name, value in string_fields:
+            if value is not None:
+                escaped = self._escape_applescript_string(value)
+                set_lines.append(f'        set {as_prop} of evt to "{escaped}"')
+                updated_fields.append(field_name)
+
+        # Date fields: handle ordering to avoid start > end constraint
+        if start_date is not None and end_date is not None:
+            as_start = self._iso_to_applescript_date(start_date)
+            as_end = self._iso_to_applescript_date(end_date)
+            set_lines.append('        set end date of evt to date "December 31, 2099 11:59:59 PM"')
+            set_lines.append(f'        set start date of evt to date "{as_start}"')
+            set_lines.append(f'        set end date of evt to date "{as_end}"')
+            updated_fields.extend(["start_date", "end_date"])
+        elif start_date is not None:
+            as_date = self._iso_to_applescript_date(start_date)
+            set_lines.append(f'        set start date of evt to date "{as_date}"')
+            updated_fields.append("start_date")
+        elif end_date is not None:
+            as_date = self._iso_to_applescript_date(end_date)
+            set_lines.append(f'        set end date of evt to date "{as_date}"')
+            updated_fields.append("end_date")
+
+        if allday_event is not None:
+            allday_str = "true" if allday_event else "false"
+            set_lines.append(f"        set allday event of evt to {allday_str}")
+            updated_fields.append("allday_event")
+
+        if not updated_fields:
+            raise ValueError("At least one field must be provided to update")
+
+        cal_escaped = self._escape_applescript_string(calendar_name)
+        uid_escaped = self._escape_applescript_string(event_uid)
+        set_block = "\n".join(set_lines)
+
+        script = f'''tell application "Calendar"
+    tell calendar "{cal_escaped}"
+        set matchingEvents to (every event whose uid is "{uid_escaped}")
+        if (count of matchingEvents) is 0 then
+            error "Event not found: {uid_escaped}"
+        end if
+        set evt to item 1 of matchingEvents
+{set_block}
+        return uid of evt
+    end tell
+end tell'''
+
+        run_applescript(script)
+        return {"uid": event_uid, "updated_fields": updated_fields}
+
     def get_calendars(self) -> list[dict[str, Any]]:
         """Get all calendars from Apple Calendar.
 

--- a/src/apple_calendar_mcp/server_fastmcp.py
+++ b/src/apple_calendar_mcp/server_fastmcp.py
@@ -165,3 +165,53 @@ def get_events(
         lines.append(_format_event(event))
 
     return f"Found {len(events)} event(s) in '{calendar_name}':\n\n" + "\n".join(lines)
+
+
+@mcp.tool()
+def update_event(
+    calendar_name: str,
+    event_uid: str,
+    summary: str | None = None,
+    start_date: str | None = None,
+    end_date: str | None = None,
+    location: str | None = None,
+    description: str | None = None,
+    url: str | None = None,
+    allday_event: bool | None = None,
+) -> str:
+    """Update an existing event's properties by UID.
+
+    Only provided fields are updated; omitted fields are left unchanged.
+    To clear a text field (location, description, url), pass an empty string "".
+
+    Use get_events first to find the event's UID and calendar_name.
+
+    Args:
+        calendar_name: Exact name of the calendar containing the event
+        event_uid: UID of the event to update (from get_events results)
+        summary: New event title (optional)
+        start_date: New start date/time in ISO 8601 format (optional)
+        end_date: New end date/time in ISO 8601 format (optional)
+        location: New location, or "" to clear (optional)
+        description: New description/notes, or "" to clear (optional)
+        url: New URL, or "" to clear (optional)
+        allday_event: New all-day status (optional)
+    """
+    client = get_client()
+    try:
+        result = client.update_event(
+            calendar_name=calendar_name,
+            event_uid=event_uid,
+            summary=summary,
+            start_date=start_date,
+            end_date=end_date,
+            location=location,
+            description=description,
+            url=url,
+            allday_event=allday_event,
+        )
+    except Exception as e:
+        return f"Error updating event: {e}"
+
+    fields_str = ", ".join(result["updated_fields"])
+    return f"Updated event {event_uid} in calendar '{calendar_name}'\nUpdated fields: {fields_str}"

--- a/src/apple_calendar_mcp/swift/get_events.swift
+++ b/src/apple_calendar_mcp/swift/get_events.swift
@@ -76,7 +76,7 @@ func eventToDict(_ event: EKEvent) -> [String: Any] {
     df.formatOptions = [.withInternetDateTime]
 
     var dict: [String: Any] = [
-        "uid": event.eventIdentifier ?? "",
+        "uid": event.calendarItemIdentifier,
         "summary": event.title ?? "",
         "start_date": df.string(from: event.startDate),
         "end_date": df.string(from: event.endDate),

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -253,3 +253,110 @@ class TestGetEventsIntegration:
             end_date="2099-01-02T00:00:00",
         )
         assert events == []
+
+
+class TestUpdateEventIntegration:
+    """Integration tests for update_event against real Calendar.app."""
+
+    def test_update_summary(self, connector):
+        """Update summary and verify via get_events."""
+        uid = connector.create_event(
+            calendar_name=TEST_CALENDAR,
+            summary="Original Summary",
+            start_date="2026-09-01T10:00:00",
+            end_date="2026-09-01T11:00:00",
+        )
+        try:
+            connector.update_event(TEST_CALENDAR, uid, summary="Updated Summary")
+            events = connector.get_events(TEST_CALENDAR, "2026-09-01T00:00:00", "2026-09-02T00:00:00")
+            test_events = [e for e in events if e["uid"] == uid]
+            assert len(test_events) == 1
+            assert test_events[0]["summary"] == "Updated Summary"
+        finally:
+            _delete_event_by_uid(uid)
+
+    def test_update_location(self, connector):
+        """Update location from A to B and verify."""
+        uid = connector.create_event(
+            calendar_name=TEST_CALENDAR,
+            summary="Location Update Test",
+            start_date="2026-09-02T10:00:00",
+            end_date="2026-09-02T11:00:00",
+            location="Room A",
+        )
+        try:
+            connector.update_event(TEST_CALENDAR, uid, location="Room B")
+            events = connector.get_events(TEST_CALENDAR, "2026-09-02T00:00:00", "2026-09-03T00:00:00")
+            test_events = [e for e in events if e["uid"] == uid]
+            assert len(test_events) == 1
+            assert test_events[0]["location"] == "Room B"
+        finally:
+            _delete_event_by_uid(uid)
+
+    def test_update_dates(self, connector):
+        """Update start/end dates and verify."""
+        uid = connector.create_event(
+            calendar_name=TEST_CALENDAR,
+            summary="Date Update Test",
+            start_date="2026-09-03T10:00:00",
+            end_date="2026-09-03T11:00:00",
+        )
+        try:
+            connector.update_event(
+                TEST_CALENDAR, uid,
+                start_date="2026-09-03T14:00:00",
+                end_date="2026-09-03T15:00:00",
+            )
+            events = connector.get_events(TEST_CALENDAR, "2026-09-03T13:00:00", "2026-09-03T16:00:00")
+            test_events = [e for e in events if e["uid"] == uid]
+            assert len(test_events) == 1
+            assert "2026-09-03" in test_events[0]["start_date"]
+        finally:
+            _delete_event_by_uid(uid)
+
+    def test_update_multiple_fields(self, connector):
+        """Update summary and location in one call."""
+        uid = connector.create_event(
+            calendar_name=TEST_CALENDAR,
+            summary="Multi Update Test",
+            start_date="2026-09-04T10:00:00",
+            end_date="2026-09-04T11:00:00",
+            location="Old Place",
+        )
+        try:
+            result = connector.update_event(
+                TEST_CALENDAR, uid,
+                summary="New Multi Title",
+                location="New Place",
+            )
+            assert "summary" in result["updated_fields"]
+            assert "location" in result["updated_fields"]
+            events = connector.get_events(TEST_CALENDAR, "2026-09-04T00:00:00", "2026-09-05T00:00:00")
+            test_events = [e for e in events if e["uid"] == uid]
+            assert test_events[0]["summary"] == "New Multi Title"
+            assert test_events[0]["location"] == "New Place"
+        finally:
+            _delete_event_by_uid(uid)
+
+    def test_update_nonexistent_event(self, connector):
+        """Updating a non-existent UID should raise an error."""
+        with pytest.raises(Exception, match="Event not found"):
+            connector.update_event(TEST_CALENDAR, "DOES-NOT-EXIST-UID", summary="X")
+
+    def test_clear_location(self, connector):
+        """Passing location="" should clear the location field."""
+        uid = connector.create_event(
+            calendar_name=TEST_CALENDAR,
+            summary="Clear Location Test",
+            start_date="2026-09-05T10:00:00",
+            end_date="2026-09-05T11:00:00",
+            location="Will Be Cleared",
+        )
+        try:
+            connector.update_event(TEST_CALENDAR, uid, location="")
+            events = connector.get_events(TEST_CALENDAR, "2026-09-05T00:00:00", "2026-09-06T00:00:00")
+            test_events = [e for e in events if e["uid"] == uid]
+            assert len(test_events) == 1
+            assert test_events[0]["location"] == ""
+        finally:
+            _delete_event_by_uid(uid)

--- a/tests/unit/test_calendar_connector.py
+++ b/tests/unit/test_calendar_connector.py
@@ -481,3 +481,130 @@ class TestGetEvents:
         mock_swift.return_value = "[]"
         self.connector.get_events("Work", "2026-03-15", "2026-03-16")
         mock_swift.assert_called_once()
+
+
+# ── update_event ────────────────────────────────────────────────────────────
+
+
+class TestUpdateEvent:
+    """Tests for CalendarConnector.update_event()."""
+
+    def setup_method(self):
+        self.connector = CalendarConnector(enable_safety_checks=False)
+
+    @patch("apple_calendar_mcp.calendar_connector.run_applescript")
+    def test_updates_summary(self, mock_run):
+        mock_run.return_value = "ABC-123"
+        self.connector.update_event("MCP-Test-Calendar", "ABC-123", summary="New Title")
+        script = mock_run.call_args[0][0]
+        assert 'set summary of evt to "New Title"' in script
+
+    @patch("apple_calendar_mcp.calendar_connector.run_applescript")
+    def test_updates_start_date(self, mock_run):
+        mock_run.return_value = "ABC-123"
+        self.connector.update_event("MCP-Test-Calendar", "ABC-123", start_date="2026-03-15T14:30:00")
+        script = mock_run.call_args[0][0]
+        assert 'set start date of evt to date "March 15, 2026 02:30:00 PM"' in script
+
+    @patch("apple_calendar_mcp.calendar_connector.run_applescript")
+    def test_updates_end_date(self, mock_run):
+        mock_run.return_value = "ABC-123"
+        self.connector.update_event("MCP-Test-Calendar", "ABC-123", end_date="2026-03-15T15:30:00")
+        script = mock_run.call_args[0][0]
+        assert 'set end date of evt to date "March 15, 2026 03:30:00 PM"' in script
+
+    @patch("apple_calendar_mcp.calendar_connector.run_applescript")
+    def test_updates_location(self, mock_run):
+        mock_run.return_value = "ABC-123"
+        self.connector.update_event("MCP-Test-Calendar", "ABC-123", location="Room B")
+        script = mock_run.call_args[0][0]
+        assert 'set location of evt to "Room B"' in script
+
+    @patch("apple_calendar_mcp.calendar_connector.run_applescript")
+    def test_updates_description(self, mock_run):
+        mock_run.return_value = "ABC-123"
+        self.connector.update_event("MCP-Test-Calendar", "ABC-123", description="New notes")
+        script = mock_run.call_args[0][0]
+        assert 'set description of evt to "New notes"' in script
+
+    @patch("apple_calendar_mcp.calendar_connector.run_applescript")
+    def test_updates_url(self, mock_run):
+        mock_run.return_value = "ABC-123"
+        self.connector.update_event("MCP-Test-Calendar", "ABC-123", url="https://example.com")
+        script = mock_run.call_args[0][0]
+        assert 'set url of evt to "https://example.com"' in script
+
+    @patch("apple_calendar_mcp.calendar_connector.run_applescript")
+    def test_updates_allday_true(self, mock_run):
+        mock_run.return_value = "ABC-123"
+        self.connector.update_event("MCP-Test-Calendar", "ABC-123", allday_event=True)
+        script = mock_run.call_args[0][0]
+        assert "set allday event of evt to true" in script
+
+    @patch("apple_calendar_mcp.calendar_connector.run_applescript")
+    def test_updates_allday_false(self, mock_run):
+        mock_run.return_value = "ABC-123"
+        self.connector.update_event("MCP-Test-Calendar", "ABC-123", allday_event=False)
+        script = mock_run.call_args[0][0]
+        assert "set allday event of evt to false" in script
+
+    @patch("apple_calendar_mcp.calendar_connector.run_applescript")
+    def test_updates_multiple_fields(self, mock_run):
+        mock_run.return_value = "ABC-123"
+        self.connector.update_event("MCP-Test-Calendar", "ABC-123", summary="New", location="Room C")
+        script = mock_run.call_args[0][0]
+        assert 'set summary of evt to "New"' in script
+        assert 'set location of evt to "Room C"' in script
+
+    @patch("apple_calendar_mcp.calendar_connector.run_applescript")
+    def test_only_provided_fields_set(self, mock_run):
+        mock_run.return_value = "ABC-123"
+        self.connector.update_event("MCP-Test-Calendar", "ABC-123", summary="New Title")
+        script = mock_run.call_args[0][0]
+        assert "set summary of evt" in script
+        assert "set location of evt" not in script
+        assert "set description of evt" not in script
+        assert "set url of evt" not in script
+        assert "set start date of evt" not in script
+        assert "set end date of evt" not in script
+        assert "set allday event of evt" not in script
+
+    @patch("apple_calendar_mcp.calendar_connector.run_applescript")
+    def test_escapes_special_characters(self, mock_run):
+        mock_run.return_value = "ABC-123"
+        self.connector.update_event("MCP-Test-Calendar", "ABC-123", summary='Say "hello"')
+        script = mock_run.call_args[0][0]
+        assert 'Say \\"hello\\"' in script
+
+    def test_invalid_date_raises(self):
+        with pytest.raises(ValueError, match="Invalid date format"):
+            self.connector.update_event("MCP-Test-Calendar", "ABC-123", start_date="not-a-date")
+
+    def test_safety_blocks_non_test_calendar(self):
+        connector = CalendarConnector(enable_safety_checks=True)
+        with pytest.raises(CalendarSafetyError, match="not an allowed test calendar"):
+            connector.update_event("Personal", "ABC-123", summary="Test")
+
+    def test_no_fields_raises(self):
+        with pytest.raises(ValueError, match="At least one field"):
+            self.connector.update_event("MCP-Test-Calendar", "ABC-123")
+
+    @patch("apple_calendar_mcp.calendar_connector.run_applescript")
+    def test_returns_dict_with_uid_and_updated_fields(self, mock_run):
+        mock_run.return_value = "ABC-123"
+        result = self.connector.update_event("MCP-Test-Calendar", "ABC-123", summary="New", location="Room")
+        assert result == {"uid": "ABC-123", "updated_fields": ["summary", "location"]}
+
+    @patch("apple_calendar_mcp.calendar_connector.run_applescript")
+    def test_uses_whose_uid_clause(self, mock_run):
+        mock_run.return_value = "ABC-123"
+        self.connector.update_event("MCP-Test-Calendar", "ABC-123", summary="X")
+        script = mock_run.call_args[0][0]
+        assert 'whose uid is "ABC-123"' in script
+
+    @patch("apple_calendar_mcp.calendar_connector.run_applescript")
+    def test_clear_field_with_empty_string(self, mock_run):
+        mock_run.return_value = "ABC-123"
+        self.connector.update_event("MCP-Test-Calendar", "ABC-123", location="")
+        script = mock_run.call_args[0][0]
+        assert 'set location of evt to ""' in script

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -197,6 +197,58 @@ class TestGetEventsTool:
         assert "Error" in result
 
 
+class TestUpdateEventTool:
+    """Tests for the update_event MCP tool."""
+
+    @patch("apple_calendar_mcp.server_fastmcp.get_client")
+    def test_returns_success_message(self, mock_get_client):
+        mock_client = MagicMock()
+        mock_client.update_event.return_value = {"uid": "ABC-123", "updated_fields": ["summary"]}
+        mock_get_client.return_value = mock_client
+
+        from apple_calendar_mcp.server_fastmcp import update_event
+        result = update_event(calendar_name="Work", event_uid="ABC-123", summary="New Title")
+        assert "ABC-123" in result
+        assert "summary" in result
+        assert isinstance(result, str)
+
+    @patch("apple_calendar_mcp.server_fastmcp.get_client")
+    def test_returns_error_on_failure(self, mock_get_client):
+        mock_client = MagicMock()
+        mock_client.update_event.side_effect = Exception("Event not found")
+        mock_get_client.return_value = mock_client
+
+        from apple_calendar_mcp.server_fastmcp import update_event
+        result = update_event(calendar_name="Work", event_uid="BAD-UID", summary="X")
+        assert "Error" in result
+        assert isinstance(result, str)
+
+    @patch("apple_calendar_mcp.server_fastmcp.get_client")
+    def test_passes_none_for_omitted_fields(self, mock_get_client):
+        mock_client = MagicMock()
+        mock_client.update_event.return_value = {"uid": "ABC-123", "updated_fields": ["summary"]}
+        mock_get_client.return_value = mock_client
+
+        from apple_calendar_mcp.server_fastmcp import update_event
+        update_event(calendar_name="Work", event_uid="ABC-123", summary="New")
+        call_kwargs = mock_client.update_event.call_args[1]
+        assert call_kwargs["location"] is None
+        assert call_kwargs["description"] is None
+        assert call_kwargs["url"] is None
+        assert call_kwargs["allday_event"] is None
+
+    @patch("apple_calendar_mcp.server_fastmcp.get_client")
+    def test_passes_empty_string_through(self, mock_get_client):
+        mock_client = MagicMock()
+        mock_client.update_event.return_value = {"uid": "ABC-123", "updated_fields": ["location"]}
+        mock_get_client.return_value = mock_client
+
+        from apple_calendar_mcp.server_fastmcp import update_event
+        update_event(calendar_name="Work", event_uid="ABC-123", location="")
+        call_kwargs = mock_client.update_event.call_args[1]
+        assert call_kwargs["location"] == ""
+
+
 class TestServerConfiguration:
     """Tests for MCP server configuration."""
 


### PR DESCRIPTION
## Summary
- Add `update_event` to connector and server — updates event properties by UID via AppleScript
- Fix EventKit UID mismatch: Swift helper now uses `calendarItemIdentifier` (matches AppleScript UIDs) instead of `eventIdentifier`
- Handle date-ordering constraint: when updating both start and end dates, temporarily extends end date to avoid AppleScript rejecting start > end during transition

## Key design decisions
- `None` = "don't touch", `""` = "clear field" (unlike `create_event` which converts empty strings to `None`)
- String field handling extracted into loop to keep cyclomatic complexity under threshold
- 17 unit tests (connector), 4 unit tests (server), 6 integration tests

## Bug fix
- `get_events.swift`: Changed `event.eventIdentifier` to `event.calendarItemIdentifier` so UIDs from `get_events` can be used with `update_event` and other AppleScript operations

## Test plan
- [x] `make test-unit` — 89 passed
- [x] `make test-integration` — 20 passed
- [x] `./scripts/check_version_sync.sh` — versions in sync
- [x] `./scripts/check_complexity.sh` — no functions above threshold

🤖 Generated with [Claude Code](https://claude.com/claude-code)