### PR TITLE
Implement delete_events tool with batch support (issue #4)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -3,7 +3,7 @@
 An MCP server bridging Claude and Apple Calendar via AppleScript and EventKit on macOS.
 
 **Stack:** Python 3.10+, FastMCP, AppleScript (via `osascript`), Swift/EventKit (via `swift`)
-**Version:** v0.1.0 | **Tests:** 89 unit, 20 integration | **Coverage:** TBD
+**Version:** v0.1.0 | **Tests:** 102 unit, 24 integration | **Coverage:** TBD
 
 ## Commands
 
@@ -18,12 +18,12 @@ make test-verbose          # Tests with verbose output
 
 **Running the server:** `uv run python -m apple_calendar_mcp.server_fastmcp` or via Claude Desktop config.
 
-## API Surface (4 functions)
+## API Surface (5 functions)
 
 - **Calendars:** `get_calendars`
-- **Events:** `get_events`, `create_event`, `update_event`
+- **Events:** `get_events`, `create_event`, `update_event`, `delete_events`
 
-Planned (filed as issues): `update_events`, `delete_events`, `get_availability`
+Planned (filed as issues): `update_events`, `get_availability`
 
 ## Core API Principles
 

--- a/evals/agent_tool_usability/delete_events_eval.md
+++ b/evals/agent_tool_usability/delete_events_eval.md
@@ -1,0 +1,49 @@
+# Blind Eval: delete_events Tool Description
+
+Test whether an agent can correctly use the `delete_events` tool from its description alone.
+
+## Scenario 1: Delete a single event by UID
+
+**User prompt:** "Delete the event with UID ABC-123 from my Work calendar."
+
+**Expected agent behavior:**
+1. Call `delete_events` with `calendar_name="Work"` and `event_uid="ABC-123"`
+
+**Watch for:**
+- Agent passes the UID as a string, not a list
+- Agent includes the correct calendar_name
+
+## Scenario 2: Delete multiple events
+
+**User prompt:** "Delete all three of my test events: ABC-123, DEF-456, GHI-789 from Work"
+
+**Expected agent behavior:**
+1. Call `delete_events` with `event_uid=["ABC-123", "DEF-456", "GHI-789"]`
+
+**Watch for:**
+- Agent passes a list of UIDs in a single call (not three separate calls)
+- Agent uses the list form of event_uid
+
+## Scenario 3: Find and delete an event
+
+**User prompt:** "Cancel my dentist appointment next Tuesday"
+
+**Expected agent behavior:**
+1. Call `get_events` to find the dentist appointment and note its UID and calendar_name
+2. Call `delete_events` with the discovered UID and calendar_name
+
+**Watch for:**
+- Agent uses get_events first to find the UID (not fabricated)
+- Agent passes the correct calendar_name from the event
+
+## Scenario 4: Handle partial failure
+
+**User prompt:** "Delete events ABC-123 and DEF-456 from my Work calendar"
+
+**Expected agent behavior:**
+1. Call `delete_events` with `event_uid=["ABC-123", "DEF-456"]`
+2. If result mentions not-found UIDs, inform user which ones weren't found
+
+**Watch for:**
+- Agent reports partial success clearly to the user
+- Agent does not retry the not-found UIDs

--- a/src/apple_calendar_mcp/calendar_connector.py
+++ b/src/apple_calendar_mcp/calendar_connector.py
@@ -392,6 +392,55 @@ end tell'''
         run_applescript(script)
         return {"uid": event_uid, "updated_fields": updated_fields}
 
+    def delete_events(
+        self,
+        calendar_name: str,
+        event_uids: str | list[str],
+    ) -> dict[str, Any]:
+        """Delete one or more events by UID.
+
+        Args:
+            calendar_name: Name of the calendar containing the events
+            event_uids: Single UID string or list of UIDs to delete
+
+        Returns:
+            Dict with 'deleted_uids' and 'not_found_uids' keys
+
+        Raises:
+            CalendarSafetyError: If safety checks block the target calendar
+            ValueError: If event_uids is empty
+        """
+        self._verify_calendar_safety(calendar_name)
+
+        uids = [event_uids] if isinstance(event_uids, str) else event_uids
+        if not uids:
+            raise ValueError("At least one event UID must be provided")
+
+        cal_escaped = self._escape_applescript_string(calendar_name)
+        deleted_uids = []
+        not_found_uids = []
+
+        for uid in uids:
+            uid_escaped = self._escape_applescript_string(uid)
+            script = f'''tell application "Calendar"
+    tell calendar "{cal_escaped}"
+        set matchingEvents to (every event whose uid is "{uid_escaped}")
+        if (count of matchingEvents) is 0 then
+            error "Event not found: {uid_escaped}"
+        end if
+        repeat with evt in matchingEvents
+            delete evt
+        end repeat
+    end tell
+end tell'''
+            try:
+                run_applescript(script)
+                deleted_uids.append(uid)
+            except subprocess.CalledProcessError:
+                not_found_uids.append(uid)
+
+        return {"deleted_uids": deleted_uids, "not_found_uids": not_found_uids}
+
     def get_calendars(self) -> list[dict[str, Any]]:
         """Get all calendars from Apple Calendar.
 

--- a/src/apple_calendar_mcp/server_fastmcp.py
+++ b/src/apple_calendar_mcp/server_fastmcp.py
@@ -215,3 +215,37 @@ def update_event(
 
     fields_str = ", ".join(result["updated_fields"])
     return f"Updated event {event_uid} in calendar '{calendar_name}'\nUpdated fields: {fields_str}"
+
+
+@mcp.tool()
+def delete_events(
+    calendar_name: str,
+    event_uid: str | list[str],
+) -> str:
+    """Delete one or more events from a calendar by UID.
+
+    Accepts a single UID or a list of UIDs for batch deletion. Events that
+    don't exist are reported but don't cause the entire operation to fail.
+
+    Use get_events first to find the event UID(s) and calendar_name.
+
+    Args:
+        calendar_name: Exact name of the calendar containing the event(s)
+        event_uid: UID of a single event (str) or list of UIDs to delete
+    """
+    client = get_client()
+    try:
+        result = client.delete_events(
+            calendar_name=calendar_name,
+            event_uids=event_uid,
+        )
+    except Exception as e:
+        return f"Error deleting event(s): {e}"
+
+    deleted = result["deleted_uids"]
+    not_found = result["not_found_uids"]
+
+    msg = f"Deleted {len(deleted)} event(s) from calendar '{calendar_name}'"
+    if not_found:
+        msg += f"\nNot found ({len(not_found)}): {', '.join(not_found)}"
+    return msg

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -360,3 +360,78 @@ class TestUpdateEventIntegration:
             assert test_events[0]["location"] == ""
         finally:
             _delete_event_by_uid(uid)
+
+
+class TestDeleteEventsIntegration:
+    """Integration tests for delete_events against real Calendar.app."""
+
+    def test_delete_single_event(self, connector):
+        """Create event, delete it, verify it's gone via get_events."""
+        uid = connector.create_event(
+            calendar_name=TEST_CALENDAR,
+            summary="Delete Single Test",
+            start_date="2026-10-01T10:00:00",
+            end_date="2026-10-01T11:00:00",
+        )
+        try:
+            # Verify event exists
+            events = connector.get_events(TEST_CALENDAR, "2026-10-01T00:00:00", "2026-10-02T00:00:00")
+            assert any(e["uid"] == uid for e in events)
+
+            # Delete it
+            result = connector.delete_events(TEST_CALENDAR, uid)
+            assert uid in result["deleted_uids"]
+            assert result["not_found_uids"] == []
+
+            # Verify it's gone
+            events = connector.get_events(TEST_CALENDAR, "2026-10-01T00:00:00", "2026-10-02T00:00:00")
+            assert not any(e["uid"] == uid for e in events)
+        finally:
+            _delete_event_by_uid(uid)
+
+    def test_delete_multiple_events(self, connector):
+        """Create 3 events, delete all, verify gone."""
+        uids = []
+        for i in range(3):
+            uid = connector.create_event(
+                calendar_name=TEST_CALENDAR,
+                summary=f"Batch Delete Test {i}",
+                start_date="2026-10-02T10:00:00",
+                end_date="2026-10-02T11:00:00",
+            )
+            uids.append(uid)
+        try:
+            result = connector.delete_events(TEST_CALENDAR, uids)
+            assert len(result["deleted_uids"]) == 3
+            assert result["not_found_uids"] == []
+
+            events = connector.get_events(TEST_CALENDAR, "2026-10-02T00:00:00", "2026-10-03T00:00:00")
+            for uid in uids:
+                assert not any(e["uid"] == uid for e in events)
+        finally:
+            for uid in uids:
+                _delete_event_by_uid(uid)
+
+    def test_delete_nonexistent_event(self, connector):
+        """Deleting a non-existent UID should report it as not found."""
+        result = connector.delete_events(TEST_CALENDAR, "DOES-NOT-EXIST-UID")
+        assert result["deleted_uids"] == []
+        assert "DOES-NOT-EXIST-UID" in result["not_found_uids"]
+
+    def test_delete_already_deleted(self, connector):
+        """Deleting an event twice — second attempt reports not found."""
+        uid = connector.create_event(
+            calendar_name=TEST_CALENDAR,
+            summary="Double Delete Test",
+            start_date="2026-10-03T10:00:00",
+            end_date="2026-10-03T11:00:00",
+        )
+        try:
+            result1 = connector.delete_events(TEST_CALENDAR, uid)
+            assert uid in result1["deleted_uids"]
+
+            result2 = connector.delete_events(TEST_CALENDAR, uid)
+            assert result2["deleted_uids"] == []
+            assert uid in result2["not_found_uids"]
+        finally:
+            _delete_event_by_uid(uid)

--- a/tests/unit/test_calendar_connector.py
+++ b/tests/unit/test_calendar_connector.py
@@ -608,3 +608,83 @@ class TestUpdateEvent:
         self.connector.update_event("MCP-Test-Calendar", "ABC-123", location="")
         script = mock_run.call_args[0][0]
         assert 'set location of evt to ""' in script
+
+
+# ── delete_events ──────────────────────────────────────────────────────────
+
+
+class TestDeleteEvents:
+    """Tests for CalendarConnector.delete_events()."""
+
+    def setup_method(self):
+        self.connector = CalendarConnector(enable_safety_checks=False)
+
+    @patch("apple_calendar_mcp.calendar_connector.run_applescript")
+    def test_deletes_single_event(self, mock_run):
+        mock_run.return_value = ""
+        result = self.connector.delete_events("MCP-Test-Calendar", "ABC-123")
+        assert result["deleted_uids"] == ["ABC-123"]
+        assert result["not_found_uids"] == []
+        script = mock_run.call_args[0][0]
+        assert 'whose uid is "ABC-123"' in script
+        assert "delete evt" in script
+
+    @patch("apple_calendar_mcp.calendar_connector.run_applescript")
+    def test_deletes_multiple_events(self, mock_run):
+        mock_run.return_value = ""
+        result = self.connector.delete_events("MCP-Test-Calendar", ["UID-1", "UID-2", "UID-3"])
+        assert result["deleted_uids"] == ["UID-1", "UID-2", "UID-3"]
+        assert result["not_found_uids"] == []
+        assert mock_run.call_count == 3
+
+    @patch("apple_calendar_mcp.calendar_connector.run_applescript")
+    def test_normalizes_single_uid_to_list(self, mock_run):
+        mock_run.return_value = ""
+        result = self.connector.delete_events("MCP-Test-Calendar", "SINGLE-UID")
+        assert isinstance(result["deleted_uids"], list)
+        assert result["deleted_uids"] == ["SINGLE-UID"]
+
+    @patch("apple_calendar_mcp.calendar_connector.run_applescript")
+    def test_escapes_uid_in_script(self, mock_run):
+        mock_run.return_value = ""
+        self.connector.delete_events("MCP-Test-Calendar", 'UID-with-"quotes"')
+        script = mock_run.call_args[0][0]
+        assert 'UID-with-\\"quotes\\"' in script
+
+    def test_safety_blocks_non_test_calendar(self):
+        connector = CalendarConnector(enable_safety_checks=True)
+        with pytest.raises(CalendarSafetyError, match="not an allowed test calendar"):
+            connector.delete_events("Personal", "ABC-123")
+
+    def test_empty_list_raises(self):
+        with pytest.raises(ValueError, match="At least one event UID"):
+            self.connector.delete_events("MCP-Test-Calendar", [])
+
+    @patch("apple_calendar_mcp.calendar_connector.run_applescript")
+    def test_not_found_uid(self, mock_run):
+        mock_run.side_effect = subprocess.CalledProcessError(
+            returncode=1, cmd="osascript", stderr="Event not found"
+        )
+        result = self.connector.delete_events("MCP-Test-Calendar", "BAD-UID")
+        assert result["deleted_uids"] == []
+        assert result["not_found_uids"] == ["BAD-UID"]
+
+    @patch("apple_calendar_mcp.calendar_connector.run_applescript")
+    def test_batch_partial_failure(self, mock_run):
+        def side_effect(script):
+            if "UID-2" in script:
+                raise subprocess.CalledProcessError(
+                    returncode=1, cmd="osascript", stderr="Event not found"
+                )
+            return ""
+        mock_run.side_effect = side_effect
+        result = self.connector.delete_events("MCP-Test-Calendar", ["UID-1", "UID-2", "UID-3"])
+        assert result["deleted_uids"] == ["UID-1", "UID-3"]
+        assert result["not_found_uids"] == ["UID-2"]
+
+    @patch("apple_calendar_mcp.calendar_connector.run_applescript")
+    def test_uses_delete_keyword(self, mock_run):
+        mock_run.return_value = ""
+        self.connector.delete_events("MCP-Test-Calendar", "ABC-123")
+        script = mock_run.call_args[0][0]
+        assert "delete evt" in script

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -249,6 +249,66 @@ class TestUpdateEventTool:
         assert call_kwargs["location"] == ""
 
 
+class TestDeleteEventsTool:
+    """Tests for the delete_events MCP tool."""
+
+    @patch("apple_calendar_mcp.server_fastmcp.get_client")
+    def test_returns_success_message(self, mock_get_client):
+        mock_client = MagicMock()
+        mock_client.delete_events.return_value = {
+            "deleted_uids": ["ABC-123"],
+            "not_found_uids": [],
+        }
+        mock_get_client.return_value = mock_client
+
+        from apple_calendar_mcp.server_fastmcp import delete_events
+        result = delete_events(calendar_name="Work", event_uid="ABC-123")
+        assert "Deleted 1 event(s)" in result
+        assert "Work" in result
+        assert isinstance(result, str)
+
+    @patch("apple_calendar_mcp.server_fastmcp.get_client")
+    def test_returns_error_on_failure(self, mock_get_client):
+        mock_client = MagicMock()
+        mock_client.delete_events.side_effect = Exception("Calendar not found")
+        mock_get_client.return_value = mock_client
+
+        from apple_calendar_mcp.server_fastmcp import delete_events
+        result = delete_events(calendar_name="Nonexistent", event_uid="ABC-123")
+        assert "Error" in result
+        assert isinstance(result, str)
+
+    @patch("apple_calendar_mcp.server_fastmcp.get_client")
+    def test_returns_partial_success_message(self, mock_get_client):
+        mock_client = MagicMock()
+        mock_client.delete_events.return_value = {
+            "deleted_uids": ["UID-1", "UID-3"],
+            "not_found_uids": ["UID-2"],
+        }
+        mock_get_client.return_value = mock_client
+
+        from apple_calendar_mcp.server_fastmcp import delete_events
+        result = delete_events(calendar_name="Work", event_uid=["UID-1", "UID-2", "UID-3"])
+        assert "Deleted 2 event(s)" in result
+        assert "not found" in result.lower() or "UID-2" in result
+
+    @patch("apple_calendar_mcp.server_fastmcp.get_client")
+    def test_accepts_list_of_uids(self, mock_get_client):
+        mock_client = MagicMock()
+        mock_client.delete_events.return_value = {
+            "deleted_uids": ["UID-1", "UID-2"],
+            "not_found_uids": [],
+        }
+        mock_get_client.return_value = mock_client
+
+        from apple_calendar_mcp.server_fastmcp import delete_events
+        delete_events(calendar_name="Work", event_uid=["UID-1", "UID-2"])
+        mock_client.delete_events.assert_called_once_with(
+            calendar_name="Work",
+            event_uids=["UID-1", "UID-2"],
+        )
+
+
 class TestServerConfiguration:
     """Tests for MCP server configuration."""
 


### PR DESCRIPTION
## Summary
- Adds `delete_events` to connector and server layers — accepts single UID (str) or batch (list[str]) per API principle #4
- Partial failures collected gracefully: returns `deleted_uids` and `not_found_uids` separately
- 9 connector unit tests, 4 server unit tests, 4 integration tests, blind eval scenarios

## Test plan
- [x] `make test-unit` — 102 passed
- [x] `make test-integration` — 24 passed (all existing + 4 new delete tests)
- [x] Complexity check — no grade C+ functions
- [x] Version sync — consistent

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)