### PR TITLE
release: v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] - 2026-03-15
+
+### Added
+
+- `get_calendars` tool — list all available calendars (#11)
+- `create_event` tool with calendar safety guards (#11)
+- `get_events` tool using EventKit Swift helper for fast reads (#13)
+- `update_event` tool with UID fix and date-ordering handling (#15)
+- `delete_events` tool with single and batch support (#17)
+- Swift/EventKit helper for sub-second event queries on large calendars (#13)
+- Calendar safety system requiring `CALENDAR_TEST_MODE` and `CALENDAR_TEST_NAME` for destructive operations
+- CI workflow with unit tests and validation checks (#8)
+- Release workflow skill and tag script (#19)
+- Reproducible dependency installs via `uv.lock` (#16)
+- Integration test conftest with automatic test calendar setup/teardown

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,55 @@
+"""Integration test fixtures — manages test calendar lifecycle.
+
+Creates an MCP-Test-Calendar in Calendar.app before the test session
+and removes it (with all events) after the session completes.
+"""
+
+import os
+import subprocess
+
+import pytest
+
+TEST_CALENDAR = os.environ.get("CALENDAR_TEST_NAME", "MCP-Test-Calendar")
+
+
+def _run_applescript(script: str) -> str:
+    """Run an AppleScript and return stripped stdout."""
+    result = subprocess.run(
+        ["osascript", "-e", script],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"AppleScript failed: {result.stderr.strip()}")
+    return result.stdout.strip()
+
+
+def _calendar_exists(name: str) -> bool:
+    """Check if a calendar with the given name exists."""
+    names = _run_applescript('tell application "Calendar" to name of every calendar')
+    return name in [n.strip() for n in names.split(",")]
+
+
+@pytest.fixture(scope="session", autouse=True)
+def ensure_test_calendar():
+    """Create the test calendar before tests, delete it after."""
+    if os.environ.get("CALENDAR_TEST_MODE") != "true":
+        yield
+        return
+
+    # Create calendar if it doesn't exist
+    created = False
+    if not _calendar_exists(TEST_CALENDAR):
+        _run_applescript(
+            f'tell application "Calendar" to make new calendar with properties {{name:"{TEST_CALENDAR}"}}'
+        )
+        created = True
+
+    yield
+
+    # Teardown: delete the calendar only if we created it
+    if created and _calendar_exists(TEST_CALENDAR):
+        _run_applescript(
+            f'tell application "Calendar" to delete calendar "{TEST_CALENDAR}"'
+        )

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -2,7 +2,7 @@
 
 Requires:
     - CALENDAR_TEST_MODE=true environment variable
-    - A calendar named "MCP-Test-Calendar" in Calendar.app
+    - The test calendar is created/deleted automatically by conftest.py
 
 Run with: make test-integration
 """


### PR DESCRIPTION
## Summary

- Initial release of Apple Calendar MCP server (v0.1.0)
- All 5 tools: `get_calendars`, `create_event`, `get_events`, `update_event`, `delete_events`
- CHANGELOG.md created
- Integration test conftest with automatic test calendar setup/teardown

## Validation

- Version sync check: passing
- Complexity check: passing
- Unit tests: 102 passed
- Integration tests: 24 passed

## Test plan

- [x] `./scripts/check_version_sync.sh`
- [x] `./scripts/check_complexity.sh`
- [x] `make test` (102 passed)
- [x] `make test-integration` (24 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)