### PR TITLE
Add bug report issue template (issue #9)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,74 @@
+name: Bug Report
+description: Report a bug with the Apple Calendar MCP server
+labels: ["bug"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Bug description
+      description: A clear description of what the bug is.
+      placeholder: What happened?
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Steps to reproduce the behavior.
+      placeholder: |
+        1. Call `get_events` with ...
+        2. ...
+        3. See error
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What you expected to happen.
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: What actually happened. Include error messages or logs if available.
+    validations:
+      required: true
+
+  - type: input
+    id: macos-version
+    attributes:
+      label: macOS version
+      description: "Run: sw_vers -productVersion"
+      placeholder: "15.3"
+    validations:
+      required: true
+
+  - type: input
+    id: python-version
+    attributes:
+      label: Python version
+      description: "Run: python --version"
+      placeholder: "3.12.13"
+    validations:
+      required: true
+
+  - type: input
+    id: server-version
+    attributes:
+      label: MCP server version
+      placeholder: "0.1.0"
+    validations:
+      required: false
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Any other context — logs, screenshots, Calendar.app configuration, Claude Desktop config, etc.
+    validations:
+      required: false


### PR DESCRIPTION
## Summary

- Adds a YAML-based bug report issue form at `.github/ISSUE_TEMPLATE/bug_report.yml`
- Structured fields: description, steps to reproduce, expected/actual behavior, macOS version, Python version, server version, additional context
- Auto-applies `bug` label

Closes #9

## Test plan

- [x] YAML syntax validated
- [ ] Verify form renders correctly on GitHub "New Issue" page after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)