### PR TITLE
release: v0.1.1

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -3,7 +3,7 @@
 An MCP server bridging Claude and Apple Calendar via AppleScript and EventKit on macOS.
 
 **Stack:** Python 3.10+, FastMCP, AppleScript (via `osascript`), Swift/EventKit (via `swift`)
-**Version:** v0.1.0 | **Tests:** 102 unit, 24 integration | **Coverage:** TBD
+**Version:** v0.1.1 | **Tests:** 102 unit, 24 integration | **Coverage:** TBD
 
 ## Commands
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.1] - 2026-03-16
+
+### Added
+
+- Project README with setup, usage, tools reference, and architecture overview (#26)
+- Bug report issue template (#23)
+- Feature request issue template (#24)
+- Reusable test calendar setup/teardown module and standalone scripts (#25)
+
 ## [0.1.0] - 2026-03-15
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "apple-calendar-mcp"
-version = "0.1.0"
+version = "0.1.1"
 description = "MCP server for Apple Calendar integration"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -39,7 +39,7 @@ wheels = [
 
 [[package]]
 name = "apple-calendar-mcp"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## Summary

- Version bump to 0.1.1
- CHANGELOG entry for v0.1.1

### Changes in this release
- Project README (#26)
- Bug report issue template (#23)
- Feature request issue template (#24)
- Reusable test calendar setup/teardown module and scripts (#25)

## Validation

- [x] Version sync check
- [x] Complexity check
- [x] Unit tests (102 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)