### PR TITLE
Add performance benchmarks and document findings (issue #7)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -14,6 +14,7 @@ make test-integration      # Real Calendar tests (requires test calendar)
 make test-verbose          # Tests with verbose output
 ./scripts/check_complexity.sh       # Cyclomatic complexity check
 ./scripts/check_version_sync.sh     # Version consistency across files
+./scripts/benchmark_performance.sh [calendar]  # Performance benchmarks (real Calendar.app)
 ```
 
 **Running the server:** `uv run python -m apple_calendar_mcp.server_fastmcp` or via Claude Desktop config.

--- a/docs/research/calendar-api-gap-analysis.md
+++ b/docs/research/calendar-api-gap-analysis.md
@@ -94,19 +94,46 @@ This is a blocking issue for `get_events`. Potential strategies:
 
 Per OmniFocus benchmarks: ~17ms per property read. Calendar likely similar. With 10 properties per event × 100 events = ~17 seconds. Minimizing property reads is critical.
 
+### Solution: EventKit via Swift Helper
+
+The `whose` clause timeout was resolved by implementing a Swift helper (`src/apple_calendar_mcp/swift/get_events.swift`) that uses EventKit's `EKEventStore` with native predicate-based queries. This provides sub-second reads on any calendar size.
+
+### Benchmarks (2026-03-16, 16 calendars, Work calendar: 1376 events)
+
+| Operation | Method | Time | Notes |
+|-----------|--------|------|-------|
+| `get_calendars` | AppleScript (batch) | ~6.4s | Slow — 16 calendars, batch property reads |
+| `get_events` (1 month) | EventKit/Swift | ~0.4s | Fast — native predicate filtering |
+| `get_events` (1 year) | EventKit/Swift | ~0.5s | Scales well |
+| `get_events` (10 years, 1376 events) | EventKit/Swift | ~0.8s | Sub-second even for large ranges |
+| `get_availability` (1 month) | EventKit + Python | ~0.4s | Inherits get_events performance |
+| `get_availability` (1 year) | EventKit + Python | ~0.5s | |
+| `create_event` | AppleScript | ~1.7s | Single event, acceptable |
+| `update_event` | AppleScript (`whose uid`) | ~2.6s | UID lookup + property set |
+| `delete_events` (single) | AppleScript (`whose uid`) | ~2.4s | Single UID lookup |
+| `delete_events` (batch, 5) | AppleScript (`whose uid` × 5) | ~14.5s | Linear scaling, N separate invocations |
+
+**Key observations:**
+- **Read operations (EventKit)** are sub-second regardless of calendar size
+- **Write operations (AppleScript)** are 1–3s per operation due to IPC overhead
+- **Batch delete scales linearly** — each UID requires a separate AppleScript invocation
+- **get_calendars is surprisingly slow** at ~6.4s for AppleScript batch property reads
+- Write performance is acceptable for typical single-event use (create, update, delete one)
+- Batch delete of 10+ events may feel slow; consider EventKit migration if this becomes a common use case
+
 ---
 
-## Write Operations (not yet tested)
+## Write Operations
 
-These need testing against a test calendar:
+All write operations implemented and tested via AppleScript:
 
-| Operation | AppleScript Command | Priority |
-|-----------|-------------------|----------|
-| Create calendar | `make new calendar with properties {name:"X"}` | P1 |
-| Create event | `make new event at end of events of cal with properties {summary:"X", start date:D, end date:D}` | P1 |
-| Update event | `set summary of evt to "X"` | P1 |
-| Delete event | `delete evt` | P1 |
-| Delete calendar | `delete cal` | P2 |
+| Operation | AppleScript Command | Status | Timing |
+|-----------|-------------------|--------|--------|
+| Create calendar | `make new calendar with properties {name:"X"}` | ✅ Implemented (test setup) | <1s |
+| Create event | `make new event at end of events of cal with properties {...}` | ✅ Implemented | ~1.7s |
+| Update event | `set summary of evt to "X"` (via `whose uid`) | ✅ Implemented | ~2.6s |
+| Delete event | `delete evt` (via `whose uid`) | ✅ Implemented | ~2.4s |
+| Delete calendar | `delete cal` | ✅ Implemented (test teardown) | <1s |
 
 ---
 

--- a/scripts/benchmark_performance.sh
+++ b/scripts/benchmark_performance.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Run performance benchmarks against real Calendar.app.
+# Usage: ./scripts/benchmark_performance.sh [read-calendar-name]
+#
+# Write operations use MCP-Test-Calendar (created automatically).
+# Read operations use the specified calendar (default: MCP-Test-Calendar).
+# Pass a calendar with many events to test large-calendar performance.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+READ_CALENDAR="${1:-MCP-Test-Calendar}"
+
+# Ensure test calendar exists
+"${SCRIPT_DIR}/scripts/test_setup.sh" >/dev/null
+
+echo "Read calendar: ${READ_CALENDAR}"
+echo ""
+
+CALENDAR_TEST_MODE=true CALENDAR_TEST_NAME="MCP-Test-Calendar" \
+    "${SCRIPT_DIR}/venv/bin/python" -m tests.benchmarks.performance \
+    --read-calendar "${READ_CALENDAR}" \
+    --test-calendar "MCP-Test-Calendar"

--- a/tests/benchmarks/performance.py
+++ b/tests/benchmarks/performance.py
@@ -1,0 +1,189 @@
+"""Performance benchmarks for Apple Calendar MCP operations.
+
+Measures real-world timing of each operation against Calendar.app.
+Requires CALENDAR_TEST_MODE=true for write operations.
+
+Usage:
+    python tests/benchmarks/performance.py [--read-calendar NAME]
+
+Options:
+    --read-calendar NAME   Calendar to use for read benchmarks (default: MCP-Test-Calendar)
+"""
+
+import argparse
+import sys
+import time
+
+from apple_calendar_mcp.calendar_connector import CalendarConnector
+from tests.helpers.calendar_setup import create_test_calendar
+
+
+def benchmark(fn, label, iterations=1):
+    """Run a function and report timing."""
+    times = []
+    result = None
+    for _ in range(iterations):
+        start = time.perf_counter()
+        result = fn()
+        elapsed = time.perf_counter() - start
+        times.append(elapsed)
+
+    mean = sum(times) / len(times)
+    if iterations > 1:
+        print(f"  {label}: {mean:.3f}s (mean of {iterations}, min={min(times):.3f}s, max={max(times):.3f}s)")
+    else:
+        print(f"  {label}: {mean:.3f}s")
+    return result
+
+
+def run_benchmarks(read_calendar: str, test_calendar: str):
+    """Run all benchmarks and print results."""
+    connector = CalendarConnector(enable_safety_checks=False)
+
+    # Ensure test calendar exists
+    create_test_calendar(test_calendar)
+
+    print("=" * 60)
+    print("Apple Calendar MCP — Performance Benchmarks")
+    print("=" * 60)
+
+    # --- get_calendars ---
+    print("\n[get_calendars]")
+    calendars = benchmark(connector.get_calendars, "List all calendars", iterations=3)
+    cal_names = [c["name"] for c in calendars]
+    print(f"  Found {len(calendars)} calendars")
+
+    if read_calendar not in cal_names:
+        print(f"\n  WARNING: Calendar '{read_calendar}' not found.")
+        print(f"  Available: {', '.join(cal_names)}")
+        print(f"  Using '{test_calendar}' for all benchmarks.")
+        read_calendar = test_calendar
+
+    # --- get_events (read calendar, various ranges) ---
+    print(f"\n[get_events] (calendar: {read_calendar})")
+
+    benchmark(
+        lambda: connector.get_events(read_calendar, "2026-03-01", "2026-03-31"),
+        "1-month range",
+        iterations=3,
+    )
+
+    benchmark(
+        lambda: connector.get_events(read_calendar, "2026-01-01", "2026-12-31"),
+        "1-year range",
+        iterations=3,
+    )
+
+    events = benchmark(
+        lambda: connector.get_events(read_calendar, "2020-01-01", "2030-12-31"),
+        "10-year range",
+        iterations=3,
+    )
+    print(f"  Events in 10-year range: {len(events)}")
+
+    # --- get_availability ---
+    print(f"\n[get_availability] (calendar: {read_calendar})")
+
+    benchmark(
+        lambda: connector.get_availability([read_calendar], "2026-03-01", "2026-03-31"),
+        "1-month range",
+        iterations=3,
+    )
+
+    benchmark(
+        lambda: connector.get_availability([read_calendar], "2026-01-01", "2026-12-31"),
+        "1-year range",
+        iterations=3,
+    )
+
+    # --- Write operations (test calendar only) ---
+    print(f"\n[create_event] (calendar: {test_calendar})")
+
+    created_uids = []
+
+    def create_and_track():
+        uid = connector.create_event(
+            calendar_name=test_calendar,
+            summary="Benchmark Event",
+            start_date="2027-06-15T10:00:00",
+            end_date="2027-06-15T11:00:00",
+        )
+        created_uids.append(uid)
+        return uid
+
+    benchmark(create_and_track, "Create single event", iterations=3)
+
+    # --- update_event ---
+    print(f"\n[update_event] (calendar: {test_calendar})")
+
+    if created_uids:
+        uid = created_uids[0]
+        benchmark(
+            lambda: connector.update_event(test_calendar, uid, summary="Updated Benchmark"),
+            "Update summary (whose uid lookup)",
+            iterations=3,
+        )
+
+        benchmark(
+            lambda: connector.update_event(test_calendar, uid, location="Room A"),
+            "Update location",
+            iterations=3,
+        )
+
+    # --- delete_events ---
+    print(f"\n[delete_events] (calendar: {test_calendar})")
+
+    if len(created_uids) >= 1:
+        uid = created_uids.pop()
+        benchmark(
+            lambda: connector.delete_events(test_calendar, uid),
+            "Delete single event",
+        )
+
+    # Batch delete remaining
+    if created_uids:
+        benchmark(
+            lambda: connector.delete_events(test_calendar, created_uids),
+            f"Batch delete {len(created_uids)} events",
+        )
+        created_uids.clear()
+
+    # Batch delete benchmark (create 5, delete all)
+    batch_uids = []
+    for i in range(5):
+        uid = connector.create_event(
+            calendar_name=test_calendar,
+            summary=f"Batch Bench {i}",
+            start_date="2027-07-01T10:00:00",
+            end_date="2027-07-01T11:00:00",
+        )
+        batch_uids.append(uid)
+
+    benchmark(
+        lambda: connector.delete_events(test_calendar, batch_uids),
+        "Batch delete 5 events",
+    )
+
+    print("\n" + "=" * 60)
+    print("Benchmarks complete.")
+    print("=" * 60)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Performance benchmarks for Apple Calendar MCP")
+    parser.add_argument(
+        "--read-calendar",
+        default="MCP-Test-Calendar",
+        help="Calendar for read benchmarks (default: MCP-Test-Calendar)",
+    )
+    parser.add_argument(
+        "--test-calendar",
+        default="MCP-Test-Calendar",
+        help="Calendar for write benchmarks (default: MCP-Test-Calendar)",
+    )
+    args = parser.parse_args()
+    run_benchmarks(args.read_calendar, args.test_calendar)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Adds benchmark script (`scripts/benchmark_performance.sh`) and Python module (`tests/benchmarks/performance.py`)
- Updates gap analysis with benchmark results and write operation status
- Updates CLAUDE.md with benchmark command

### Benchmark Results (16 calendars, Work calendar: 1376 events)

| Operation | Method | Time |
|-----------|--------|------|
| get_calendars | AppleScript | ~6.4s |
| get_events (1 year) | EventKit/Swift | ~0.5s |
| get_events (10 years, 1376 events) | EventKit/Swift | ~0.8s |
| create_event | AppleScript | ~1.7s |
| update_event | AppleScript (whose uid) | ~2.6s |
| delete_events (single) | AppleScript (whose uid) | ~2.4s |
| delete_events (batch 5) | AppleScript (whose uid × 5) | ~14.5s |

**Conclusion:** Read operations (EventKit) are sub-second. Write operations are 1-3s each, acceptable for single-event use. Batch delete scales linearly and may warrant EventKit migration if heavy batch usage emerges.

Closes #7

## Test plan

- [x] `make test` — 119 unit tests pass
- [x] `make test-integration` — 26 integration tests pass
- [x] `./scripts/benchmark_performance.sh Work` — produces timing results

🤖 Generated with [Claude Code](https://claude.com/claude-code)