### PR TITLE
release: v0.2.0

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -3,7 +3,7 @@
 An MCP server bridging Claude and Apple Calendar via AppleScript and EventKit on macOS.
 
 **Stack:** Python 3.10+, FastMCP, AppleScript (via `osascript`), Swift/EventKit (via `swift`)
-**Version:** v0.1.1 | **Tests:** 119 unit, 24 integration | **Coverage:** TBD
+**Version:** v0.2.0 | **Tests:** 119 unit, 26 integration | **Coverage:** TBD
 
 ## Commands
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.0] - 2026-03-16
+
+### Added
+
+- `get_availability` tool with multi-calendar support for free/busy lookup (#28)
+- Performance benchmark script and module (`scripts/benchmark_performance.sh`) (#29)
+- Performance benchmarks documented in gap analysis with timing data (#29)
+
+### Fixed
+
+- UTC-to-local timezone conversion for EventKit dates in availability calculations (#28)
+
 ## [0.1.1] - 2026-03-16
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "apple-calendar-mcp"
-version = "0.1.1"
+version = "0.2.0"
 description = "MCP server for Apple Calendar integration"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/apple_calendar_mcp/calendar_connector.py
+++ b/src/apple_calendar_mcp/calendar_connector.py
@@ -465,6 +465,32 @@ end tell'''
                 "Expected ISO 8601 format like '2026-03-15' or '2026-03-15T14:30:00'"
             ) from e
 
+    def _build_busy_blocks(self, events: list[dict]) -> list[tuple[datetime, datetime]]:
+        """Build sorted, merged busy blocks from a list of events."""
+        blocks = []
+        for event in events:
+            evt_start = self._parse_iso_datetime(event["start_date"])
+            evt_end = self._parse_iso_datetime(event["end_date"])
+
+            if event.get("allday_event"):
+                evt_start = evt_start.replace(hour=0, minute=0, second=0)
+                evt_end = evt_end.replace(hour=0, minute=0, second=0)
+                if evt_end == evt_start:
+                    evt_end += timedelta(days=1)
+
+            blocks.append((evt_start, evt_end))
+
+        blocks.sort(key=lambda b: b[0])
+
+        merged = []
+        for start, end in blocks:
+            if merged and start <= merged[-1][1]:
+                merged[-1] = (merged[-1][0], max(merged[-1][1], end))
+            else:
+                merged.append((start, end))
+
+        return merged
+
     def get_availability(
         self,
         calendar_names: list[str],
@@ -495,44 +521,16 @@ end tell'''
         range_start = self._parse_iso_datetime(start_date)
         range_end = self._parse_iso_datetime(end_date)
 
-        # Collect all events across calendars
         all_events = []
         for cal_name in calendar_names:
-            events = self.get_events(cal_name, start_date, end_date)
-            all_events.extend(events)
+            all_events.extend(self.get_events(cal_name, start_date, end_date))
 
-        # Build busy blocks from events
-        busy_blocks = []
-        for event in all_events:
-            evt_start = self._parse_iso_datetime(event["start_date"])
-            evt_end = self._parse_iso_datetime(event["end_date"])
+        merged = self._build_busy_blocks(all_events)
 
-            # All-day events block the full day(s)
-            if event.get("allday_event"):
-                evt_start = evt_start.replace(hour=0, minute=0, second=0)
-                evt_end = evt_end.replace(hour=0, minute=0, second=0)
-                if evt_end == evt_start:
-                    evt_end += timedelta(days=1)
-
-            busy_blocks.append((evt_start, evt_end))
-
-        # Sort by start time
-        busy_blocks.sort(key=lambda b: b[0])
-
-        # Merge overlapping/adjacent blocks
-        merged = []
-        for start, end in busy_blocks:
-            if merged and start <= merged[-1][1]:
-                merged[-1] = (merged[-1][0], max(merged[-1][1], end))
-            else:
-                merged.append((start, end))
-
-        # Compute free slots (gaps between busy blocks within the range)
         free_slots = []
         cursor = range_start
 
         for busy_start, busy_end in merged:
-            # Clamp to range
             busy_start = max(busy_start, range_start)
             busy_end = min(busy_end, range_end)
 
@@ -545,7 +543,6 @@ end tell'''
                 })
             cursor = max(cursor, busy_end)
 
-        # Gap after last busy block
         if cursor < range_end:
             duration = int((range_end - cursor).total_seconds() / 60)
             free_slots.append({

--- a/uv.lock
+++ b/uv.lock
@@ -39,7 +39,7 @@ wheels = [
 
 [[package]]
 name = "apple-calendar-mcp"
-version = "0.1.1"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## Summary

- Version bump to 0.2.0
- CHANGELOG entry for v0.2.0
- Refactored get_availability to reduce cyclomatic complexity

### Changes in this release
- `get_availability` tool with multi-calendar free/busy lookup (#28)
- Performance benchmark script and documentation (#29)
- UTC-to-local timezone fix for EventKit dates (#28)

## Validation

- [x] Version sync check
- [x] Complexity check
- [x] Unit tests (119 passed)
- [x] Integration tests (26 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)