### PR TITLE
Fix safety checks and EventKit caching for Claude Desktop (issue #33)

### DIFF
--- a/src/apple_calendar_mcp/server_fastmcp.py
+++ b/src/apple_calendar_mcp/server_fastmcp.py
@@ -24,11 +24,15 @@ _client: Optional[CalendarConnector] = None
 
 
 def get_client() -> CalendarConnector:
-    """Get or create the Calendar client."""
+    """Get or create the Calendar client.
+
+    Safety checks are enabled only when CALENDAR_TEST_MODE=true (integration tests).
+    In production (Claude Desktop), safety checks are off so all calendars are writable.
+    """
     global _client
     if _client is None:
-        _in_pytest = os.environ.get("PYTEST_CURRENT_TEST") is not None
-        _client = CalendarConnector(enable_safety_checks=not _in_pytest)
+        _test_mode = os.environ.get("CALENDAR_TEST_MODE") == "true"
+        _client = CalendarConnector(enable_safety_checks=_test_mode)
     return _client
 
 

--- a/src/apple_calendar_mcp/swift/get_events.swift
+++ b/src/apple_calendar_mcp/swift/get_events.swift
@@ -135,6 +135,9 @@ if !accessGranted {
     exit(0)
 }
 
+// Refresh sources to pick up recently-created events
+store.refreshSourcesIfNecessary()
+
 // Find the calendar by name
 let allCalendars = store.calendars(for: .event)
 guard let calendar = allCalendars.first(where: { $0.title == parsed.calendar }) else {


### PR DESCRIPTION
## Summary

Fixes two issues found during Claude Desktop testing:

1. **Safety checks blocked real calendar writes** — `enable_safety_checks` was `True` by default in production, blocking writes to non-test calendars. Now only enabled when `CALENDAR_TEST_MODE=true` (integration tests).

2. **Recently-created events not visible** — Added `refreshSourcesIfNecessary()` to the Swift helper so EventKit picks up events created via Calendar.app UI.

Also filed #35 for missing `create_calendar`/`delete_calendar` tools.

Closes #33

## Test plan

- [x] `make test` — 119 unit tests pass
- [x] `make test-integration` — 26 integration tests pass
- [ ] Retest in Claude Desktop after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)