### PR TITLE
Add create_calendar and delete_calendar tools (issue #35)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -19,9 +19,9 @@ make test-verbose          # Tests with verbose output
 
 **Running the server:** `uv run python -m apple_calendar_mcp.server_fastmcp` or via Claude Desktop config.
 
-## API Surface (6 functions)
+## API Surface (8 functions)
 
-- **Calendars:** `get_calendars`
+- **Calendars:** `get_calendars`, `create_calendar`, `delete_calendar`
 - **Events:** `get_events`, `create_event`, `update_event`, `delete_events`
 - **Availability:** `get_availability`
 

--- a/src/apple_calendar_mcp/calendar_connector.py
+++ b/src/apple_calendar_mcp/calendar_connector.py
@@ -627,3 +627,43 @@ end toHex
 '''
         result = run_applescript(script)
         return json.loads(result)
+
+    def create_calendar(self, name: str) -> dict[str, str]:
+        """Create a new calendar in Apple Calendar.
+
+        Args:
+            name: Name for the new calendar
+
+        Returns:
+            Dict with 'name' key of the created calendar
+
+        Raises:
+            subprocess.CalledProcessError: If AppleScript execution fails
+        """
+        escaped = self._escape_applescript_string(name)
+        run_applescript(
+            f'tell application "Calendar" to make new calendar with properties {{name:"{escaped}"}}'
+        )
+        return {"name": name}
+
+    def delete_calendar(self, name: str) -> dict[str, str]:
+        """Delete a calendar from Apple Calendar.
+
+        Args:
+            name: Name of the calendar to delete
+
+        Returns:
+            Dict with 'name' key of the deleted calendar
+
+        Raises:
+            CalendarSafetyError: If safety checks block the target calendar
+            ValueError: If the calendar doesn't exist
+            subprocess.CalledProcessError: If AppleScript execution fails
+        """
+        self._verify_calendar_safety(name)
+        escaped = self._escape_applescript_string(name)
+        try:
+            run_applescript(f'tell application "Calendar" to delete calendar "{escaped}"')
+        except subprocess.CalledProcessError as e:
+            raise ValueError(f"Calendar '{name}' not found or could not be deleted") from e
+        return {"name": name}

--- a/src/apple_calendar_mcp/server_fastmcp.py
+++ b/src/apple_calendar_mcp/server_fastmcp.py
@@ -74,6 +74,38 @@ def get_calendars() -> str:
 
 
 @mcp.tool()
+def create_calendar(name: str) -> str:
+    """Create a new calendar in Apple Calendar.
+
+    Args:
+        name: Name for the new calendar
+    """
+    client = get_client()
+    try:
+        result = client.create_calendar(name=name)
+    except Exception as e:
+        return f"Error creating calendar: {e}"
+    return f"Created calendar '{result['name']}'"
+
+
+@mcp.tool()
+def delete_calendar(name: str) -> str:
+    """Delete a calendar from Apple Calendar.
+
+    This permanently removes the calendar and all its events. Use with caution.
+
+    Args:
+        name: Exact name of the calendar to delete (use get_calendars to find available names)
+    """
+    client = get_client()
+    try:
+        result = client.delete_calendar(name=name)
+    except Exception as e:
+        return f"Error deleting calendar: {e}"
+    return f"Deleted calendar '{result['name']}'"
+
+
+@mcp.tool()
 def create_event(
     calendar_name: str,
     summary: str,

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -44,6 +44,30 @@ end tell'''
         pass  # Best-effort cleanup
 
 
+class TestCalendarManagementIntegration:
+    """Integration tests for create_calendar and delete_calendar."""
+
+    def test_create_and_delete_calendar(self, connector):
+        """Create a calendar, verify it exists, delete it, verify it's gone."""
+        cal_name = "MCP-Test-Calendar-2"
+        try:
+            result = connector.create_calendar(cal_name)
+            assert result["name"] == cal_name
+
+            calendars = connector.get_calendars()
+            names = [c["name"] for c in calendars]
+            assert cal_name in names
+        finally:
+            try:
+                connector.delete_calendar(cal_name)
+            except Exception:
+                pass
+
+        calendars = connector.get_calendars()
+        names = [c["name"] for c in calendars]
+        assert cal_name not in names
+
+
 class TestGetCalendarsIntegration:
     """Integration tests for get_calendars against real Calendar.app."""
 

--- a/tests/unit/test_calendar_connector.py
+++ b/tests/unit/test_calendar_connector.py
@@ -294,6 +294,63 @@ class TestGetCalendars:
         assert "Calendar" in script
 
 
+# ── create_calendar ─────────────────────────────────────────────────────────
+
+
+class TestCreateCalendar:
+    """Tests for CalendarConnector.create_calendar()."""
+
+    def setup_method(self):
+        self.connector = CalendarConnector(enable_safety_checks=False)
+
+    @patch("apple_calendar_mcp.calendar_connector.run_applescript")
+    def test_creates_calendar(self, mock_run):
+        mock_run.return_value = "calendar id ABC-123"
+        result = self.connector.create_calendar("New Calendar")
+        assert result == {"name": "New Calendar"}
+        script = mock_run.call_args[0][0]
+        assert 'make new calendar' in script
+        assert 'name:"New Calendar"' in script
+
+    @patch("apple_calendar_mcp.calendar_connector.run_applescript")
+    def test_escapes_special_characters(self, mock_run):
+        mock_run.return_value = "calendar id ABC-123"
+        self.connector.create_calendar('Cal with "quotes"')
+        script = mock_run.call_args[0][0]
+        assert 'Cal with \\"quotes\\"' in script
+
+
+# ── delete_calendar ─────────────────────────────────────────────────────────
+
+
+class TestDeleteCalendar:
+    """Tests for CalendarConnector.delete_calendar()."""
+
+    def setup_method(self):
+        self.connector = CalendarConnector(enable_safety_checks=False)
+
+    @patch("apple_calendar_mcp.calendar_connector.run_applescript")
+    def test_deletes_calendar(self, mock_run):
+        mock_run.return_value = ""
+        result = self.connector.delete_calendar("Old Calendar")
+        assert result == {"name": "Old Calendar"}
+        script = mock_run.call_args[0][0]
+        assert 'delete calendar "Old Calendar"' in script
+
+    @patch("apple_calendar_mcp.calendar_connector.run_applescript")
+    def test_not_found_raises_error(self, mock_run):
+        mock_run.side_effect = subprocess.CalledProcessError(
+            returncode=1, cmd="osascript", stderr="Calendar not found"
+        )
+        with pytest.raises(ValueError, match="not found"):
+            self.connector.delete_calendar("Nonexistent")
+
+    def test_safety_blocks_non_test_calendar(self):
+        connector = CalendarConnector(enable_safety_checks=True)
+        with pytest.raises(CalendarSafetyError, match="not an allowed test calendar"):
+            connector.delete_calendar("Personal")
+
+
 # ── create_event ─────────────────────────────────────────────────────────────
 
 

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -64,6 +64,58 @@ class TestGetCalendarsTool:
         assert "No calendars found" in result
 
 
+class TestCreateCalendarTool:
+    """Tests for the create_calendar MCP tool."""
+
+    @patch("apple_calendar_mcp.server_fastmcp.get_client")
+    def test_returns_success_message(self, mock_get_client):
+        mock_client = MagicMock()
+        mock_client.create_calendar.return_value = {"name": "New Calendar"}
+        mock_get_client.return_value = mock_client
+
+        from apple_calendar_mcp.server_fastmcp import create_calendar
+        result = create_calendar(name="New Calendar")
+        assert "Created calendar" in result
+        assert "New Calendar" in result
+
+    @patch("apple_calendar_mcp.server_fastmcp.get_client")
+    def test_returns_error_on_failure(self, mock_get_client):
+        mock_client = MagicMock()
+        mock_client.create_calendar.side_effect = Exception("AppleScript failed")
+        mock_get_client.return_value = mock_client
+
+        from apple_calendar_mcp.server_fastmcp import create_calendar
+        result = create_calendar(name="Bad Calendar")
+        assert "Error" in result
+        assert isinstance(result, str)
+
+
+class TestDeleteCalendarTool:
+    """Tests for the delete_calendar MCP tool."""
+
+    @patch("apple_calendar_mcp.server_fastmcp.get_client")
+    def test_returns_success_message(self, mock_get_client):
+        mock_client = MagicMock()
+        mock_client.delete_calendar.return_value = {"name": "Old Calendar"}
+        mock_get_client.return_value = mock_client
+
+        from apple_calendar_mcp.server_fastmcp import delete_calendar
+        result = delete_calendar(name="Old Calendar")
+        assert "Deleted calendar" in result
+        assert "Old Calendar" in result
+
+    @patch("apple_calendar_mcp.server_fastmcp.get_client")
+    def test_returns_error_on_failure(self, mock_get_client):
+        mock_client = MagicMock()
+        mock_client.delete_calendar.side_effect = ValueError("Calendar 'X' not found")
+        mock_get_client.return_value = mock_client
+
+        from apple_calendar_mcp.server_fastmcp import delete_calendar
+        result = delete_calendar(name="X")
+        assert "Error" in result
+        assert isinstance(result, str)
+
+
 class TestCreateEventTool:
     """Tests for the create_event MCP tool."""
 


### PR DESCRIPTION
## Summary

- Adds `create_calendar(name)` and `delete_calendar(name)` to connector and server
- `delete_calendar` uses safety checks (same pattern as other write ops)
- String escaping on calendar names

Closes #35

## Test plan

- [x] `make test` — 132 unit tests pass (9 new)
- [x] `make test-integration` — 28 integration tests pass (1 new: create + verify + delete + verify gone)

🤖 Generated with [Claude Code](https://claude.com/claude-code)