### PR TITLE
Fix timezone mismatch: return local time from Swift helper (issue #37)

### DIFF
--- a/src/apple_calendar_mcp/server_fastmcp.py
+++ b/src/apple_calendar_mcp/server_fastmcp.py
@@ -18,7 +18,7 @@ EVENTS: Events have summary (title), start/end dates, location, description (not
 
 RECURRING EVENTS: Recurring events share the same UID across all occurrences. Each occurrence has a unique occurrence_date. The is_recurring field indicates if an event is part of a series. The recurrence_rule field contains the iCalendar RRULE (e.g., "FREQ=WEEKLY;INTERVAL=1;BYDAY=MO,WE,FR"). Note: update_event by UID modifies the entire series — single-occurrence modification is not yet supported.
 
-DATES: All dates use ISO 8601 format (e.g., "2026-03-15" or "2026-03-15T14:30:00"). The server handles conversion to/from AppleScript's locale-dependent date format.
+DATES: All dates use ISO 8601 format in local time, without timezone suffix (e.g., "2026-03-15" or "2026-03-15T14:30:00"). Returned event timestamps are also in local time. Do NOT append "Z" to dates — they are not UTC.
 """)
 
 # Initialize Calendar client (lazy)

--- a/src/apple_calendar_mcp/swift/get_events.swift
+++ b/src/apple_calendar_mcp/swift/get_events.swift
@@ -72,8 +72,11 @@ func outputError(_ error: String, _ message: String) {
 }
 
 func eventToDict(_ event: EKEvent) -> [String: Any] {
-    let df = ISO8601DateFormatter()
-    df.formatOptions = [.withInternetDateTime]
+    // Use local time (no Z suffix) so returned timestamps match query parameter conventions.
+    // This ensures round-trips work: read a timestamp, use it to query again.
+    let df = DateFormatter()
+    df.dateFormat = "yyyy-MM-dd'T'HH:mm:ss"
+    df.locale = Locale(identifier: "en_US_POSIX")
 
     var dict: [String: Any] = [
         "uid": event.calendarItemIdentifier,

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -588,6 +588,32 @@ class TestRoundTripIntegration:
         finally:
             _delete_event_by_uid(uid)
 
+    def test_returned_timestamps_without_z_suffix(self, connector):
+        """Simulate Claude stripping Z from timestamps — should still find the event."""
+        uid = connector.create_event(
+            calendar_name=TEST_CALENDAR,
+            summary="Stripped Z Test",
+            start_date="2027-03-20T14:00:00",
+            end_date="2027-03-20T15:00:00",
+        )
+        try:
+            events = connector.get_events(TEST_CALENDAR, "2027-03-20", "2027-03-21")
+            matches = [e for e in events if e["uid"] == uid]
+            assert len(matches) == 1
+
+            # Strip any Z suffix (simulating what Claude Desktop does)
+            returned_start = matches[0]["start_date"].rstrip("Z")
+            returned_end = matches[0]["end_date"].rstrip("Z")
+
+            # Should still find the event
+            events2 = connector.get_events(TEST_CALENDAR, returned_start, returned_end)
+            matches2 = [e for e in events2 if e["uid"] == uid]
+            assert len(matches2) == 1, (
+                f"Event not found with stripped-Z timestamps: start={returned_start}, end={returned_end}"
+            )
+        finally:
+            _delete_event_by_uid(uid)
+
     def test_update_then_read_back(self, connector):
         """Create → update → read back → verify only updated fields changed."""
         uid = connector.create_event(

--- a/tests/unit/test_calendar_connector.py
+++ b/tests/unit/test_calendar_connector.py
@@ -507,8 +507,8 @@ class TestGetEvents:
     @patch("apple_calendar_mcp.calendar_connector.run_swift_helper")
     def test_parses_json_response(self, mock_swift):
         mock_swift.return_value = json.dumps([
-            {"uid": "ABC-123", "summary": "Meeting", "start_date": "2026-03-15T14:00:00Z",
-             "end_date": "2026-03-15T15:00:00Z", "allday_event": False, "location": "",
+            {"uid": "ABC-123", "summary": "Meeting", "start_date": "2026-03-15T14:00:00",
+             "end_date": "2026-03-15T15:00:00", "allday_event": False, "location": "",
              "description": "", "url": "", "status": "confirmed", "calendar_name": "Work"},
         ])
         result = self.connector.get_events("Work", "2026-03-15T00:00:00", "2026-03-16T00:00:00")

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -253,8 +253,8 @@ class TestGetEventsTool:
     def test_returns_formatted_event_list(self, mock_get_client):
         mock_client = MagicMock()
         mock_client.get_events.return_value = [
-            {"uid": "ABC-123", "summary": "Team Meeting", "start_date": "2026-03-15T14:00:00Z",
-             "end_date": "2026-03-15T15:00:00Z", "allday_event": False, "location": "Room 4",
+            {"uid": "ABC-123", "summary": "Team Meeting", "start_date": "2026-03-15T14:00:00",
+             "end_date": "2026-03-15T15:00:00", "allday_event": False, "location": "Room 4",
              "description": "Weekly sync", "url": "", "status": "confirmed", "calendar_name": "Work"},
         ]
         mock_get_client.return_value = mock_client


### PR DESCRIPTION
## Summary

Changed Swift helper `eventToDict()` to format dates in local time (no Z suffix) instead of UTC. This fixes the round-trip failure where Claude strips the Z from returned timestamps and re-queries, causing events to be missed.

**Before:** `start_date: "2026-03-16T21:00:00Z"` (UTC) → Claude queries `21:00:00` → interpreted as 9 PM local → misses 5 PM event
**After:** `start_date: "2026-03-16T17:00:00"` (local) → Claude queries `17:00:00` → finds 5 PM event

Also updated server instructions to clarify dates are local time.

Closes #37

## Test plan

- [x] `make test` — 134 unit tests pass (mocks updated to local time)
- [x] `make test-integration` — 38 integration tests pass (1 new stripped-Z round-trip test)
- [x] New `test_returned_timestamps_without_z_suffix` reproduces and verifies the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)