### PR TITLE
release: v0.3.1

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -3,7 +3,7 @@
 An MCP server bridging Claude and Apple Calendar via AppleScript and EventKit on macOS.
 
 **Stack:** Python 3.10+, FastMCP, AppleScript (via `osascript`), Swift/EventKit (via `swift`)
-**Version:** v0.3.0 | **Tests:** 134 unit, 37 integration | **Coverage:** TBD
+**Version:** v0.3.1 | **Tests:** 134 unit, 38 integration | **Coverage:** TBD
 
 ## Commands
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.1] - 2026-03-16
+
+### Fixed
+
+- Timezone mismatch: Swift helper now returns local time instead of UTC, fixing round-trip query failures (#48)
+
+### Added
+
+- Gap analysis research: attendees, alerts, text search, travel time, attachments, calendar properties (#52)
+- Filed #49 (attendees), #50 (alerts), #51 (text search) for v0.5.0
+
 ## [0.3.0] - 2026-03-16
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "apple-calendar-mcp"
-version = "0.3.0"
+version = "0.3.1"
 description = "MCP server for Apple Calendar integration"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -39,7 +39,7 @@ wheels = [
 
 [[package]]
 name = "apple-calendar-mcp"
-version = "0.3.0"
+version = "0.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## Summary

- Version bump to 0.3.1
- CHANGELOG entry for v0.3.1

### Changes in this release
- Fixed timezone mismatch: Swift helper returns local time instead of UTC (#48)
- Gap analysis research: attendees, alerts, text search, travel time documented (#52)
- Filed #49, #50, #51 on v0.5.0 for feature expansion

## Validation

- [x] Version sync check
- [x] Complexity check
- [x] Unit tests (134 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)