### PR TITLE
Migrate get_calendars to EventKit/Swift (issue #40)

### DIFF
--- a/src/apple_calendar_mcp/calendar_connector.py
+++ b/src/apple_calendar_mcp/calendar_connector.py
@@ -60,35 +60,6 @@ def run_swift_helper(script_name: str, args: list[str], timeout: int = 30) -> st
     return result.stdout.strip()
 
 
-# AppleScript helper functions for JSON escaping
-#
-# NOTE: These helpers will be embedded in every AppleScript block that returns JSON.
-# AppleScript does not support imports or modules, so each block must be
-# completely self-contained. This duplication is intentional.
-#
-# DO NOT attempt to refactor this duplication — it will break AppleScript execution.
-APPLESCRIPT_JSON_HELPERS = '''
--- Helper to escape JSON strings
-on escapeJSON(txt)
-    set txt to my replaceText(txt, "\\\\", "\\\\\\\\")
-    set txt to my replaceText(txt, "\\"", "\\\\\\"")
-    set txt to my replaceText(txt, linefeed, "\\\\n")
-    set txt to my replaceText(txt, return, "\\\\r")
-    set txt to my replaceText(txt, tab, "\\\\t")
-    return txt
-end escapeJSON
-
--- Helper to replace text
-on replaceText(sourceText, oldText, newText)
-    set AppleScript's text item delimiters to oldText
-    set textItems to text items of sourceText
-    set AppleScript's text item delimiters to newText
-    set resultText to textItems as text
-    set AppleScript's text item delimiters to ""
-    return resultText
-end replaceText
-'''
-
 
 class CalendarSafetyError(Exception):
     """Raised when calendar safety checks fail."""
@@ -564,69 +535,25 @@ end tell'''
     def get_calendars(self) -> list[dict[str, Any]]:
         """Get all calendars from Apple Calendar.
 
+        Uses EventKit via Swift helper for fast native access.
+
         Returns:
             List of calendar dicts with keys: name, writable, description, color.
-            Note: Calendar UIDs are not accessible via AppleScript (AppleEvent error -10000).
             Calendars are identified by name. Duplicate names may exist across accounts.
+
+        Raises:
+            PermissionError: If EventKit calendar access is denied
         """
-        script = f'''
-{APPLESCRIPT_JSON_HELPERS}
+        result = run_swift_helper("get_calendars", [])
+        parsed = json.loads(result)
 
-tell application "Calendar"
-    set calNames to name of every calendar
-    set calWritable to writable of every calendar
-    set calDescs to description of every calendar
-    set calColors to color of every calendar
-    set calCount to count of calNames
-    set jsonResult to "["
-    repeat with i from 1 to calCount
-        set calName to item i of calNames
-        set calWrite to item i of calWritable
-        set calDesc to item i of calDescs
-        -- Colors are returned as list of {{R, G, B}} per calendar (16-bit values)
-        set calColor to item i of calColors
-        set colorR to item 1 of calColor
-        set colorG to item 2 of calColor
-        set colorB to item 3 of calColor
-        -- Convert 16-bit RGB to hex
-        set hexR to my toHex(colorR div 256)
-        set hexG to my toHex(colorG div 256)
-        set hexB to my toHex(colorB div 256)
-        set hexColor to "#" & hexR & hexG & hexB
+        if isinstance(parsed, dict) and "error" in parsed:
+            if parsed["error"] == "calendar_access_denied":
+                raise PermissionError(parsed["message"])
+            else:
+                raise ValueError(parsed["message"])
 
-        -- Handle missing description
-        if calDesc is missing value then
-            set calDesc to ""
-        end if
-
-        -- Handle boolean writable
-        if calWrite then
-            set writeStr to "true"
-        else
-            set writeStr to "false"
-        end if
-
-        set jsonItem to "{{\\"name\\":\\"" & my escapeJSON(calName) & "\\",\\"writable\\":" & writeStr & ",\\"description\\":\\"" & my escapeJSON(calDesc) & "\\",\\"color\\":\\"" & hexColor & "\\"}}"
-        if i > 1 then
-            set jsonResult to jsonResult & ","
-        end if
-        set jsonResult to jsonResult & jsonItem
-    end repeat
-    set jsonResult to jsonResult & "]"
-    return jsonResult
-end tell
-
-on toHex(val)
-    set hexChars to "0123456789ABCDEF"
-    if val < 0 then set val to 0
-    if val > 255 then set val to 255
-    set hi to (val div 16) + 1
-    set lo to (val mod 16) + 1
-    return (character hi of hexChars) & (character lo of hexChars)
-end toHex
-'''
-        result = run_applescript(script)
-        return json.loads(result)
+        return parsed
 
     def create_calendar(self, name: str) -> dict[str, str]:
         """Create a new calendar in Apple Calendar.

--- a/src/apple_calendar_mcp/swift/get_calendars.swift
+++ b/src/apple_calendar_mcp/swift/get_calendars.swift
@@ -1,0 +1,65 @@
+import EventKit
+import Foundation
+
+// MARK: - JSON Output
+
+func outputError(_ error: String, _ message: String) {
+    let obj: [String: String] = ["error": error, "message": message]
+    if let data = try? JSONSerialization.data(withJSONObject: obj),
+       let str = String(data: data, encoding: .utf8) {
+        print(str)
+    }
+}
+
+func cgColorToHex(_ cgColor: CGColor?) -> String {
+    guard let color = cgColor,
+          let components = color.components,
+          components.count >= 3 else {
+        return "#000000"
+    }
+    let r = Int(components[0] * 255)
+    let g = Int(components[1] * 255)
+    let b = Int(components[2] * 255)
+    return String(format: "#%02X%02X%02X", r, g, b)
+}
+
+// MARK: - Main
+
+let store = EKEventStore()
+let semaphore = DispatchSemaphore(value: 0)
+var accessGranted = false
+var accessError: Error?
+
+store.requestFullAccessToEvents { granted, error in
+    accessGranted = granted
+    accessError = error
+    semaphore.signal()
+}
+
+semaphore.wait()
+
+if !accessGranted {
+    let msg = accessError?.localizedDescription ?? "Calendar access denied. Grant permission in System Settings > Privacy & Security > Calendars."
+    outputError("calendar_access_denied", msg)
+    exit(0)
+}
+
+store.refreshSourcesIfNecessary()
+
+let calendars = store.calendars(for: .event)
+
+let calendarDicts: [[String: Any]] = calendars.map { cal in
+    [
+        "name": cal.title,
+        "writable": cal.allowsContentModifications,
+        "description": (cal as EKCalendar).value(forKey: "notes") as? String ?? "",
+        "color": cgColorToHex(cal.cgColor),
+    ]
+}
+
+if let data = try? JSONSerialization.data(withJSONObject: calendarDicts, options: [.sortedKeys]),
+   let str = String(data: data, encoding: .utf8) {
+    print(str)
+} else {
+    outputError("serialization_error", "Failed to serialize calendars to JSON")
+}

--- a/tests/unit/test_calendar_connector.py
+++ b/tests/unit/test_calendar_connector.py
@@ -238,9 +238,9 @@ class TestGetCalendars:
     def setup_method(self):
         self.connector = CalendarConnector()
 
-    @patch("apple_calendar_mcp.calendar_connector.run_applescript")
-    def test_returns_list_of_calendar_dicts(self, mock_run):
-        mock_run.return_value = json.dumps([
+    @patch("apple_calendar_mcp.calendar_connector.run_swift_helper")
+    def test_returns_list_of_calendar_dicts(self, mock_swift):
+        mock_swift.return_value = json.dumps([
             {"name": "Personal", "writable": True, "description": "", "color": "#0072FF"},
             {"name": "Work", "writable": True, "description": "", "color": "#FF0023"},
         ])
@@ -250,9 +250,9 @@ class TestGetCalendars:
         assert result[0]["name"] == "Personal"
         assert result[1]["name"] == "Work"
 
-    @patch("apple_calendar_mcp.calendar_connector.run_applescript")
-    def test_calendar_has_expected_keys(self, mock_run):
-        mock_run.return_value = json.dumps([
+    @patch("apple_calendar_mcp.calendar_connector.run_swift_helper")
+    def test_calendar_has_expected_keys(self, mock_swift):
+        mock_swift.return_value = json.dumps([
             {"name": "Personal", "writable": True, "description": "my cal", "color": "#0072FF"},
         ])
         result = self.connector.get_calendars()
@@ -262,36 +262,42 @@ class TestGetCalendars:
         assert "description" in cal
         assert "color" in cal
 
-    @patch("apple_calendar_mcp.calendar_connector.run_applescript")
-    def test_empty_calendar_list(self, mock_run):
-        mock_run.return_value = json.dumps([])
+    @patch("apple_calendar_mcp.calendar_connector.run_swift_helper")
+    def test_empty_calendar_list(self, mock_swift):
+        mock_swift.return_value = json.dumps([])
         result = self.connector.get_calendars()
         assert result == []
 
-    @patch("apple_calendar_mcp.calendar_connector.run_applescript")
-    def test_read_only_calendar(self, mock_run):
-        mock_run.return_value = json.dumps([
+    @patch("apple_calendar_mcp.calendar_connector.run_swift_helper")
+    def test_read_only_calendar(self, mock_swift):
+        mock_swift.return_value = json.dumps([
             {"name": "Holidays", "writable": False, "description": "US Holidays", "color": "#8882FE"},
         ])
         result = self.connector.get_calendars()
         assert result[0]["writable"] is False
 
-    @patch("apple_calendar_mcp.calendar_connector.run_applescript")
-    def test_calendar_with_empty_description(self, mock_run):
-        mock_run.return_value = json.dumps([
+    @patch("apple_calendar_mcp.calendar_connector.run_swift_helper")
+    def test_calendar_with_empty_description(self, mock_swift):
+        mock_swift.return_value = json.dumps([
             {"name": "Work", "writable": True, "description": "", "color": "#FF0000"},
         ])
         result = self.connector.get_calendars()
         assert result[0]["description"] == ""
 
-    @patch("apple_calendar_mcp.calendar_connector.run_applescript")
-    def test_calls_applescript(self, mock_run):
-        """Verify get_calendars executes an AppleScript command."""
-        mock_run.return_value = json.dumps([])
+    @patch("apple_calendar_mcp.calendar_connector.run_swift_helper")
+    def test_calls_swift_helper(self, mock_swift):
+        """Verify get_calendars uses the Swift helper."""
+        mock_swift.return_value = json.dumps([])
         self.connector.get_calendars()
-        mock_run.assert_called_once()
-        script = mock_run.call_args[0][0]
-        assert "Calendar" in script
+        mock_swift.assert_called_once_with("get_calendars", [])
+
+    @patch("apple_calendar_mcp.calendar_connector.run_swift_helper")
+    def test_handles_access_denied(self, mock_swift):
+        mock_swift.return_value = json.dumps(
+            {"error": "calendar_access_denied", "message": "Access denied"}
+        )
+        with pytest.raises(PermissionError, match="Access denied"):
+            self.connector.get_calendars()
 
 
 # ── create_calendar ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Replaces AppleScript batch property reads with EventKit Swift helper
- Removes `APPLESCRIPT_JSON_HELPERS` constant (no longer used)
- Adds permission error handling (same pattern as get_events)

### Performance

| | Before (AppleScript) | After (EventKit) | Improvement |
|--|---|---|---|
| get_calendars | ~6.4s | ~0.36s | **18x faster** |

### Notes

- EventKit returns 14 calendars vs AppleScript's 16 — Siri Suggestions and Scheduled Reminders are not event-type calendars and are correctly excluded
- Color conversion uses CGColor → hex (slight differences from AppleScript's 16-bit RGB conversion possible)

Closes #40

## Test plan

- [x] `make test` — 135 unit tests pass (1 new access denied test, mocks updated)
- [x] `make test-integration` — 38 integration tests pass
- [x] Benchmark: 6.4s → 0.36s

🤖 Generated with [Claude Code](https://claude.com/claude-code)