### PR TITLE
Migrate delete_events to EventKit/Swift (issue #41, PR 2/3)

### DIFF
--- a/src/apple_calendar_mcp/calendar_connector.py
+++ b/src/apple_calendar_mcp/calendar_connector.py
@@ -374,30 +374,22 @@ end tell'''
         if not uids:
             raise ValueError("At least one event UID must be provided")
 
-        cal_escaped = self._escape_applescript_string(calendar_name)
-        deleted_uids = []
-        not_found_uids = []
-
+        args = ["--calendar", calendar_name]
         for uid in uids:
-            uid_escaped = self._escape_applescript_string(uid)
-            script = f'''tell application "Calendar"
-    tell calendar "{cal_escaped}"
-        set matchingEvents to (every event whose uid is "{uid_escaped}")
-        if (count of matchingEvents) is 0 then
-            error "Event not found: {uid_escaped}"
-        end if
-        repeat with evt in matchingEvents
-            delete evt
-        end repeat
-    end tell
-end tell'''
-            try:
-                run_applescript(script)
-                deleted_uids.append(uid)
-            except subprocess.CalledProcessError:
-                not_found_uids.append(uid)
+            args += ["--uid", uid]
 
-        return {"deleted_uids": deleted_uids, "not_found_uids": not_found_uids}
+        result = run_swift_helper("delete_events", args)
+        parsed = json.loads(result)
+
+        if isinstance(parsed, dict) and "error" in parsed:
+            if parsed["error"] == "calendar_access_denied":
+                raise PermissionError(parsed["message"])
+            elif parsed["error"] == "calendar_not_found":
+                raise ValueError(parsed["message"])
+            else:
+                raise RuntimeError(parsed["message"])
+
+        return {"deleted_uids": parsed["deleted_uids"], "not_found_uids": parsed["not_found_uids"]}
 
     def _parse_iso_datetime(self, date_str: str) -> datetime:
         """Parse an ISO 8601 date string to a naive local-time datetime.

--- a/src/apple_calendar_mcp/swift/delete_events.swift
+++ b/src/apple_calendar_mcp/swift/delete_events.swift
@@ -1,0 +1,118 @@
+import EventKit
+import Foundation
+
+// MARK: - Argument Parsing
+
+func parseArgs() -> (calendar: String, uids: [String])? {
+    let args = CommandLine.arguments
+    var calendar: String?
+    var uids: [String] = []
+
+    var i = 1
+    while i < args.count {
+        switch args[i] {
+        case "--calendar":
+            i += 1; if i < args.count { calendar = args[i] }
+        case "--uid":
+            i += 1; if i < args.count { uids.append(args[i]) }
+        default:
+            break
+        }
+        i += 1
+    }
+
+    guard let cal = calendar, !uids.isEmpty else {
+        return nil
+    }
+    return (cal, uids)
+}
+
+// MARK: - JSON Output
+
+func outputError(_ error: String, _ message: String) {
+    let obj: [String: String] = ["error": error, "message": message]
+    if let data = try? JSONSerialization.data(withJSONObject: obj),
+       let str = String(data: data, encoding: .utf8) {
+        print(str)
+    }
+}
+
+// MARK: - Main
+
+guard let parsed = parseArgs() else {
+    outputError("invalid_args", "Required: --calendar <name> --uid <uid> [--uid <uid> ...]")
+    exit(0)
+}
+
+let store = EKEventStore()
+let semaphore = DispatchSemaphore(value: 0)
+var accessGranted = false
+var accessError: Error?
+
+store.requestFullAccessToEvents { granted, error in
+    accessGranted = granted
+    accessError = error
+    semaphore.signal()
+}
+
+semaphore.wait()
+
+if !accessGranted {
+    let msg = accessError?.localizedDescription ?? "Calendar access denied."
+    outputError("calendar_access_denied", msg)
+    exit(0)
+}
+
+store.refreshSourcesIfNecessary()
+
+// Find the calendar by name
+let allCalendars = store.calendars(for: .event)
+guard let calendar = allCalendars.first(where: { $0.title == parsed.calendar }) else {
+    let available = allCalendars.map { $0.title }.joined(separator: ", ")
+    outputError("calendar_not_found", "Calendar '\(parsed.calendar)' not found. Available: \(available)")
+    exit(0)
+}
+
+// Delete events by UID using direct calendarItem lookup
+var deletedUids: [String] = []
+var notFoundUids: [String] = []
+
+for uid in parsed.uids {
+    let items = store.calendarItems(withExternalIdentifier: uid)
+    let matches = items.compactMap { $0 as? EKEvent }.filter { $0.calendar.title == parsed.calendar }
+    if matches.isEmpty {
+        notFoundUids.append(uid)
+    } else {
+        do {
+            for event in matches {
+                try store.remove(event, span: .thisEvent, commit: false)
+            }
+            deletedUids.append(uid)
+        } catch {
+            notFoundUids.append(uid)
+        }
+    }
+}
+
+// Commit all deletions at once
+if !deletedUids.isEmpty {
+    do {
+        try store.commit()
+    } catch {
+        outputError("delete_failed", "Failed to commit deletions: \(error.localizedDescription)")
+        exit(0)
+    }
+}
+
+// Output result
+let result: [String: Any] = [
+    "deleted_uids": deletedUids,
+    "not_found_uids": notFoundUids,
+]
+
+if let data = try? JSONSerialization.data(withJSONObject: result, options: [.sortedKeys]),
+   let str = String(data: data, encoding: .utf8) {
+    print(str)
+} else {
+    outputError("serialization_error", "Failed to serialize result to JSON")
+}

--- a/tests/unit/test_calendar_connector.py
+++ b/tests/unit/test_calendar_connector.py
@@ -850,37 +850,31 @@ class TestDeleteEvents:
     def setup_method(self):
         self.connector = CalendarConnector(enable_safety_checks=False)
 
-    @patch("apple_calendar_mcp.calendar_connector.run_applescript")
-    def test_deletes_single_event(self, mock_run):
-        mock_run.return_value = ""
+    @patch("apple_calendar_mcp.calendar_connector.run_swift_helper")
+    def test_deletes_single_event(self, mock_swift):
+        mock_swift.return_value = json.dumps({"deleted_uids": ["ABC-123"], "not_found_uids": []})
         result = self.connector.delete_events("MCP-Test-Calendar", "ABC-123")
         assert result["deleted_uids"] == ["ABC-123"]
         assert result["not_found_uids"] == []
-        script = mock_run.call_args[0][0]
-        assert 'whose uid is "ABC-123"' in script
-        assert "delete evt" in script
+        args = mock_swift.call_args[0][1]
+        assert "--uid" in args
+        assert "ABC-123" in args
 
-    @patch("apple_calendar_mcp.calendar_connector.run_applescript")
-    def test_deletes_multiple_events(self, mock_run):
-        mock_run.return_value = ""
+    @patch("apple_calendar_mcp.calendar_connector.run_swift_helper")
+    def test_deletes_multiple_events(self, mock_swift):
+        mock_swift.return_value = json.dumps({"deleted_uids": ["UID-1", "UID-2", "UID-3"], "not_found_uids": []})
         result = self.connector.delete_events("MCP-Test-Calendar", ["UID-1", "UID-2", "UID-3"])
         assert result["deleted_uids"] == ["UID-1", "UID-2", "UID-3"]
-        assert result["not_found_uids"] == []
-        assert mock_run.call_count == 3
+        args = mock_swift.call_args[0][1]
+        # All UIDs passed in single call
+        assert args.count("--uid") == 3
 
-    @patch("apple_calendar_mcp.calendar_connector.run_applescript")
-    def test_normalizes_single_uid_to_list(self, mock_run):
-        mock_run.return_value = ""
+    @patch("apple_calendar_mcp.calendar_connector.run_swift_helper")
+    def test_normalizes_single_uid_to_list(self, mock_swift):
+        mock_swift.return_value = json.dumps({"deleted_uids": ["SINGLE-UID"], "not_found_uids": []})
         result = self.connector.delete_events("MCP-Test-Calendar", "SINGLE-UID")
         assert isinstance(result["deleted_uids"], list)
         assert result["deleted_uids"] == ["SINGLE-UID"]
-
-    @patch("apple_calendar_mcp.calendar_connector.run_applescript")
-    def test_escapes_uid_in_script(self, mock_run):
-        mock_run.return_value = ""
-        self.connector.delete_events("MCP-Test-Calendar", 'UID-with-"quotes"')
-        script = mock_run.call_args[0][0]
-        assert 'UID-with-\\"quotes\\"' in script
 
     def test_safety_blocks_non_test_calendar(self):
         connector = CalendarConnector(enable_safety_checks=True)
@@ -891,31 +885,16 @@ class TestDeleteEvents:
         with pytest.raises(ValueError, match="At least one event UID"):
             self.connector.delete_events("MCP-Test-Calendar", [])
 
-    @patch("apple_calendar_mcp.calendar_connector.run_applescript")
-    def test_not_found_uid(self, mock_run):
-        mock_run.side_effect = subprocess.CalledProcessError(
-            returncode=1, cmd="osascript", stderr="Event not found"
-        )
+    @patch("apple_calendar_mcp.calendar_connector.run_swift_helper")
+    def test_not_found_uid(self, mock_swift):
+        mock_swift.return_value = json.dumps({"deleted_uids": [], "not_found_uids": ["BAD-UID"]})
         result = self.connector.delete_events("MCP-Test-Calendar", "BAD-UID")
         assert result["deleted_uids"] == []
         assert result["not_found_uids"] == ["BAD-UID"]
 
-    @patch("apple_calendar_mcp.calendar_connector.run_applescript")
-    def test_batch_partial_failure(self, mock_run):
-        def side_effect(script):
-            if "UID-2" in script:
-                raise subprocess.CalledProcessError(
-                    returncode=1, cmd="osascript", stderr="Event not found"
-                )
-            return ""
-        mock_run.side_effect = side_effect
+    @patch("apple_calendar_mcp.calendar_connector.run_swift_helper")
+    def test_batch_partial_failure(self, mock_swift):
+        mock_swift.return_value = json.dumps({"deleted_uids": ["UID-1", "UID-3"], "not_found_uids": ["UID-2"]})
         result = self.connector.delete_events("MCP-Test-Calendar", ["UID-1", "UID-2", "UID-3"])
         assert result["deleted_uids"] == ["UID-1", "UID-3"]
         assert result["not_found_uids"] == ["UID-2"]
-
-    @patch("apple_calendar_mcp.calendar_connector.run_applescript")
-    def test_uses_delete_keyword(self, mock_run):
-        mock_run.return_value = ""
-        self.connector.delete_events("MCP-Test-Calendar", "ABC-123")
-        script = mock_run.call_args[0][0]
-        assert "delete evt" in script


### PR DESCRIPTION
## Summary

Second of 3 PRs migrating write operations from AppleScript to EventKit/Swift.

- New `delete_events.swift` helper using `EKEventStore.remove()` with batch `commit()`
- Uses `calendarItems(withExternalIdentifier:)` for direct UID lookup (no date-range scanning)
- All UIDs passed in single Swift invocation (was N separate AppleScript calls)

### Performance

| | Before (AppleScript) | After (EventKit) | Improvement |
|--|---|---|---|
| delete single | ~2.4s | ~0.4s | **6x faster** |
| delete batch 5 | ~14.5s | ~0.5s | **29x faster** |

Batch delete now takes nearly the same time as single delete thanks to `store.commit()`.

## Test plan

- [x] `make test` — 132 unit tests pass
- [x] `make test-integration` — 38 integration tests pass
- [x] Benchmark: single 6x, batch 29x faster

🤖 Generated with [Claude Code](https://claude.com/claude-code)