### PR TITLE
Migrate update_event to EventKit/Swift (issue #41, PR 3/3)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -58,12 +58,15 @@ Planned (filed as issues): `update_events`
 
 **Performance:** `whose` clause with date filtering timed out on large calendars (5600+ events). AppleScript event reads are fundamentally too slow (~9s/event for index access, ~18s/property-batch for 306 events). `get_events` uses EventKit via Swift helper instead.
 
-## Hybrid Architecture
+## Architecture
 
-- **Writes** (create, update, delete): AppleScript via `osascript` — fast for single-event operations
-- **Reads** (get_events): Swift/EventKit via `swift` subprocess — native date-range queries, sub-second on any calendar size
+All event operations use Swift/EventKit via `swift` subprocess for native performance:
 
-The Swift helper at `src/apple_calendar_mcp/swift/get_events.swift` uses `EKEventStore` for fast predicate-based queries. First run triggers a macOS calendar access permission dialog.
+- **Reads** (get_events, get_calendars, get_availability): EventKit predicate queries, sub-second
+- **Writes** (create_event, update_event, delete_events): EventKit save/remove with batch commit
+- **Calendar management** (create_calendar, delete_calendar): AppleScript (simple, fast enough)
+
+Swift helpers at `src/apple_calendar_mcp/swift/` use `EKEventStore`. First run triggers a macOS calendar access permission dialog. Scripts are interpreted by `swift` (cached after first compilation).
 
 ## Calendar Safety
 

--- a/src/apple_calendar_mcp/calendar_connector.py
+++ b/src/apple_calendar_mcp/calendar_connector.py
@@ -289,65 +289,56 @@ class CalendarConnector:
         """
         self._verify_calendar_safety(calendar_name)
 
-        # Build set lines and track updated fields
-        set_lines = []
+        args = ["--calendar", calendar_name, "--uid", event_uid]
         updated_fields = []
 
-        # String fields: property name in AppleScript → (field_name, value)
-        string_fields = [
-            ("summary", "summary", summary),
-            ("location", "location", location),
-            ("description", "description", description),
-            ("url", "url", url),
-        ]
-        for as_prop, field_name, value in string_fields:
-            if value is not None:
-                escaped = self._escape_applescript_string(value)
-                set_lines.append(f'        set {as_prop} of evt to "{escaped}"')
-                updated_fields.append(field_name)
-
-        # Date fields: handle ordering to avoid start > end constraint
-        if start_date is not None and end_date is not None:
-            as_start = self._iso_to_applescript_date(start_date)
-            as_end = self._iso_to_applescript_date(end_date)
-            set_lines.append('        set end date of evt to date "December 31, 2099 11:59:59 PM"')
-            set_lines.append(f'        set start date of evt to date "{as_start}"')
-            set_lines.append(f'        set end date of evt to date "{as_end}"')
-            updated_fields.extend(["start_date", "end_date"])
-        elif start_date is not None:
-            as_date = self._iso_to_applescript_date(start_date)
-            set_lines.append(f'        set start date of evt to date "{as_date}"')
+        if summary is not None:
+            args += ["--summary", summary]
+            updated_fields.append("summary")
+        if start_date is not None:
+            self._validate_date(start_date)
+            args += ["--start", start_date]
             updated_fields.append("start_date")
-        elif end_date is not None:
-            as_date = self._iso_to_applescript_date(end_date)
-            set_lines.append(f'        set end date of evt to date "{as_date}"')
+        if end_date is not None:
+            self._validate_date(end_date)
+            args += ["--end", end_date]
             updated_fields.append("end_date")
-
+        if location is not None:
+            if location == "":
+                args += ["--clear-location"]
+            else:
+                args += ["--location", location]
+            updated_fields.append("location")
+        if description is not None:
+            if description == "":
+                args += ["--clear-description"]
+            else:
+                args += ["--description", description]
+            updated_fields.append("description")
+        if url is not None:
+            if url == "":
+                args += ["--clear-url"]
+            else:
+                args += ["--url", url]
+            updated_fields.append("url")
         if allday_event is not None:
-            allday_str = "true" if allday_event else "false"
-            set_lines.append(f"        set allday event of evt to {allday_str}")
+            args += ["--allday", "true" if allday_event else "false"]
             updated_fields.append("allday_event")
 
         if not updated_fields:
             raise ValueError("At least one field must be provided to update")
 
-        cal_escaped = self._escape_applescript_string(calendar_name)
-        uid_escaped = self._escape_applescript_string(event_uid)
-        set_block = "\n".join(set_lines)
+        result = run_swift_helper("update_event", args)
+        parsed = json.loads(result)
 
-        script = f'''tell application "Calendar"
-    tell calendar "{cal_escaped}"
-        set matchingEvents to (every event whose uid is "{uid_escaped}")
-        if (count of matchingEvents) is 0 then
-            error "Event not found: {uid_escaped}"
-        end if
-        set evt to item 1 of matchingEvents
-{set_block}
-        return uid of evt
-    end tell
-end tell'''
+        if isinstance(parsed, dict) and "error" in parsed:
+            if parsed["error"] == "calendar_access_denied":
+                raise PermissionError(parsed["message"])
+            elif parsed["error"] == "event_not_found":
+                raise ValueError(f"Event not found: {event_uid}")
+            else:
+                raise RuntimeError(parsed["message"])
 
-        run_applescript(script)
         return {"uid": event_uid, "updated_fields": updated_fields}
 
     def delete_events(

--- a/src/apple_calendar_mcp/swift/update_event.swift
+++ b/src/apple_calendar_mcp/swift/update_event.swift
@@ -1,0 +1,197 @@
+import EventKit
+import Foundation
+
+// MARK: - Argument Parsing
+
+struct UpdateEventArgs {
+    let calendar: String
+    let uid: String
+    var summary: String?
+    var start: String?
+    var end: String?
+    var location: String?
+    var clearLocation = false
+    var description: String?
+    var clearDescription = false
+    var url: String?
+    var clearUrl = false
+    var allday: Bool?
+    var updatedFields: [String] = []
+}
+
+func parseArgs() -> UpdateEventArgs? {
+    let args = CommandLine.arguments
+    var calendar: String?
+    var uid: String?
+    var result = UpdateEventArgs(calendar: "", uid: "")
+
+    var i = 1
+    while i < args.count {
+        switch args[i] {
+        case "--calendar":
+            i += 1; if i < args.count { calendar = args[i] }
+        case "--uid":
+            i += 1; if i < args.count { uid = args[i] }
+        case "--summary":
+            i += 1; if i < args.count { result.summary = args[i]; result.updatedFields.append("summary") }
+        case "--start":
+            i += 1; if i < args.count { result.start = args[i]; result.updatedFields.append("start_date") }
+        case "--end":
+            i += 1; if i < args.count { result.end = args[i]; result.updatedFields.append("end_date") }
+        case "--location":
+            i += 1; if i < args.count { result.location = args[i]; result.updatedFields.append("location") }
+        case "--clear-location":
+            result.clearLocation = true; result.updatedFields.append("location")
+        case "--description":
+            i += 1; if i < args.count { result.description = args[i]; result.updatedFields.append("description") }
+        case "--clear-description":
+            result.clearDescription = true; result.updatedFields.append("description")
+        case "--url":
+            i += 1; if i < args.count { result.url = args[i]; result.updatedFields.append("url") }
+        case "--clear-url":
+            result.clearUrl = true; result.updatedFields.append("url")
+        case "--allday":
+            i += 1; if i < args.count { result.allday = args[i] == "true"; result.updatedFields.append("allday_event") }
+        default:
+            break
+        }
+        i += 1
+    }
+
+    guard let cal = calendar, let u = uid else {
+        return nil
+    }
+    result = UpdateEventArgs(
+        calendar: cal, uid: u,
+        summary: result.summary, start: result.start, end: result.end,
+        location: result.location, clearLocation: result.clearLocation,
+        description: result.description, clearDescription: result.clearDescription,
+        url: result.url, clearUrl: result.clearUrl,
+        allday: result.allday, updatedFields: result.updatedFields
+    )
+    return result
+}
+
+// MARK: - Date Parsing
+
+func parseISO8601(_ str: String) -> Date? {
+    let isoFormatter = ISO8601DateFormatter()
+    isoFormatter.formatOptions = [.withInternetDateTime]
+    if let date = isoFormatter.date(from: str) { return date }
+
+    let df = DateFormatter()
+    df.locale = Locale(identifier: "en_US_POSIX")
+    for fmt in ["yyyy-MM-dd'T'HH:mm:ss", "yyyy-MM-dd"] {
+        df.dateFormat = fmt
+        if let date = df.date(from: str) { return date }
+    }
+    return nil
+}
+
+// MARK: - JSON Output
+
+func outputError(_ error: String, _ message: String) {
+    let obj: [String: String] = ["error": error, "message": message]
+    if let data = try? JSONSerialization.data(withJSONObject: obj),
+       let str = String(data: data, encoding: .utf8) {
+        print(str)
+    }
+}
+
+// MARK: - Main
+
+guard let parsed = parseArgs() else {
+    outputError("invalid_args", "Required: --calendar <name> --uid <uid> and at least one field to update")
+    exit(0)
+}
+
+if parsed.updatedFields.isEmpty {
+    outputError("no_fields", "At least one field must be provided to update")
+    exit(0)
+}
+
+let store = EKEventStore()
+let semaphore = DispatchSemaphore(value: 0)
+var accessGranted = false
+var accessError: Error?
+
+store.requestFullAccessToEvents { granted, error in
+    accessGranted = granted
+    accessError = error
+    semaphore.signal()
+}
+
+semaphore.wait()
+
+if !accessGranted {
+    let msg = accessError?.localizedDescription ?? "Calendar access denied."
+    outputError("calendar_access_denied", msg)
+    exit(0)
+}
+
+store.refreshSourcesIfNecessary()
+
+// Find event by UID
+let items = store.calendarItems(withExternalIdentifier: parsed.uid)
+let matches = items.compactMap { $0 as? EKEvent }.filter { $0.calendar.title == parsed.calendar }
+
+guard let event = matches.first else {
+    outputError("event_not_found", "Event not found: \(parsed.uid)")
+    exit(0)
+}
+
+// Apply updates
+if let summary = parsed.summary {
+    event.title = summary
+}
+if let startStr = parsed.start, let startDate = parseISO8601(startStr) {
+    event.startDate = startDate
+} else if parsed.start != nil {
+    outputError("invalid_date", "Cannot parse start date: \(parsed.start!)")
+    exit(0)
+}
+if let endStr = parsed.end, let endDate = parseISO8601(endStr) {
+    event.endDate = endDate
+} else if parsed.end != nil {
+    outputError("invalid_date", "Cannot parse end date: \(parsed.end!)")
+    exit(0)
+}
+if let location = parsed.location {
+    event.location = location
+} else if parsed.clearLocation {
+    event.location = nil
+}
+if let description = parsed.description {
+    event.notes = description
+} else if parsed.clearDescription {
+    event.notes = nil
+}
+if let urlStr = parsed.url, let url = URL(string: urlStr) {
+    event.url = url
+} else if parsed.clearUrl {
+    event.url = nil
+}
+if let allday = parsed.allday {
+    event.isAllDay = allday
+}
+
+// Save
+do {
+    try store.save(event, span: .thisEvent)
+} catch {
+    outputError("save_failed", "Failed to save event: \(error.localizedDescription)")
+    exit(0)
+}
+
+// Output result
+let result: [String: Any] = [
+    "uid": event.calendarItemIdentifier,
+    "updated_fields": parsed.updatedFields,
+]
+
+if let data = try? JSONSerialization.data(withJSONObject: result, options: [.sortedKeys]),
+   let str = String(data: data, encoding: .utf8) {
+    print(str)
+} else {
+    outputError("serialization_error", "Failed to serialize result to JSON")
+}

--- a/tests/unit/test_calendar_connector.py
+++ b/tests/unit/test_calendar_connector.py
@@ -723,89 +723,62 @@ class TestUpdateEvent:
     def setup_method(self):
         self.connector = CalendarConnector(enable_safety_checks=False)
 
-    @patch("apple_calendar_mcp.calendar_connector.run_applescript")
-    def test_updates_summary(self, mock_run):
-        mock_run.return_value = "ABC-123"
+    @patch("apple_calendar_mcp.calendar_connector.run_swift_helper")
+    def test_updates_summary(self, mock_swift):
+        mock_swift.return_value = json.dumps({"uid": "ABC-123", "updated_fields": ["summary"]})
         self.connector.update_event("MCP-Test-Calendar", "ABC-123", summary="New Title")
-        script = mock_run.call_args[0][0]
-        assert 'set summary of evt to "New Title"' in script
+        args = mock_swift.call_args[0][1]
+        assert "--summary" in args
+        assert "New Title" in args
 
-    @patch("apple_calendar_mcp.calendar_connector.run_applescript")
-    def test_updates_start_date(self, mock_run):
-        mock_run.return_value = "ABC-123"
-        self.connector.update_event("MCP-Test-Calendar", "ABC-123", start_date="2026-03-15T14:30:00")
-        script = mock_run.call_args[0][0]
-        assert 'set start date of evt to date "March 15, 2026 02:30:00 PM"' in script
+    @patch("apple_calendar_mcp.calendar_connector.run_swift_helper")
+    def test_updates_dates(self, mock_swift):
+        mock_swift.return_value = json.dumps({"uid": "ABC-123", "updated_fields": ["start_date", "end_date"]})
+        self.connector.update_event("MCP-Test-Calendar", "ABC-123",
+                                    start_date="2026-03-15T14:30:00", end_date="2026-03-15T15:30:00")
+        args = mock_swift.call_args[0][1]
+        assert "--start" in args
+        assert "2026-03-15T14:30:00" in args
+        assert "--end" in args
+        assert "2026-03-15T15:30:00" in args
 
-    @patch("apple_calendar_mcp.calendar_connector.run_applescript")
-    def test_updates_end_date(self, mock_run):
-        mock_run.return_value = "ABC-123"
-        self.connector.update_event("MCP-Test-Calendar", "ABC-123", end_date="2026-03-15T15:30:00")
-        script = mock_run.call_args[0][0]
-        assert 'set end date of evt to date "March 15, 2026 03:30:00 PM"' in script
-
-    @patch("apple_calendar_mcp.calendar_connector.run_applescript")
-    def test_updates_location(self, mock_run):
-        mock_run.return_value = "ABC-123"
-        self.connector.update_event("MCP-Test-Calendar", "ABC-123", location="Room B")
-        script = mock_run.call_args[0][0]
-        assert 'set location of evt to "Room B"' in script
-
-    @patch("apple_calendar_mcp.calendar_connector.run_applescript")
-    def test_updates_description(self, mock_run):
-        mock_run.return_value = "ABC-123"
-        self.connector.update_event("MCP-Test-Calendar", "ABC-123", description="New notes")
-        script = mock_run.call_args[0][0]
-        assert 'set description of evt to "New notes"' in script
-
-    @patch("apple_calendar_mcp.calendar_connector.run_applescript")
-    def test_updates_url(self, mock_run):
-        mock_run.return_value = "ABC-123"
-        self.connector.update_event("MCP-Test-Calendar", "ABC-123", url="https://example.com")
-        script = mock_run.call_args[0][0]
-        assert 'set url of evt to "https://example.com"' in script
-
-    @patch("apple_calendar_mcp.calendar_connector.run_applescript")
-    def test_updates_allday_true(self, mock_run):
-        mock_run.return_value = "ABC-123"
+    @patch("apple_calendar_mcp.calendar_connector.run_swift_helper")
+    def test_updates_allday(self, mock_swift):
+        mock_swift.return_value = json.dumps({"uid": "ABC-123", "updated_fields": ["allday_event"]})
         self.connector.update_event("MCP-Test-Calendar", "ABC-123", allday_event=True)
-        script = mock_run.call_args[0][0]
-        assert "set allday event of evt to true" in script
+        args = mock_swift.call_args[0][1]
+        assert "--allday" in args
+        assert "true" in args
 
-    @patch("apple_calendar_mcp.calendar_connector.run_applescript")
-    def test_updates_allday_false(self, mock_run):
-        mock_run.return_value = "ABC-123"
-        self.connector.update_event("MCP-Test-Calendar", "ABC-123", allday_event=False)
-        script = mock_run.call_args[0][0]
-        assert "set allday event of evt to false" in script
+    @patch("apple_calendar_mcp.calendar_connector.run_swift_helper")
+    def test_updates_multiple_fields(self, mock_swift):
+        mock_swift.return_value = json.dumps({"uid": "ABC-123", "updated_fields": ["summary", "location"]})
+        result = self.connector.update_event("MCP-Test-Calendar", "ABC-123", summary="New", location="Room C")
+        args = mock_swift.call_args[0][1]
+        assert "--summary" in args
+        assert "--location" in args
+        assert result == {"uid": "ABC-123", "updated_fields": ["summary", "location"]}
 
-    @patch("apple_calendar_mcp.calendar_connector.run_applescript")
-    def test_updates_multiple_fields(self, mock_run):
-        mock_run.return_value = "ABC-123"
-        self.connector.update_event("MCP-Test-Calendar", "ABC-123", summary="New", location="Room C")
-        script = mock_run.call_args[0][0]
-        assert 'set summary of evt to "New"' in script
-        assert 'set location of evt to "Room C"' in script
-
-    @patch("apple_calendar_mcp.calendar_connector.run_applescript")
-    def test_only_provided_fields_set(self, mock_run):
-        mock_run.return_value = "ABC-123"
+    @patch("apple_calendar_mcp.calendar_connector.run_swift_helper")
+    def test_only_provided_fields_passed(self, mock_swift):
+        mock_swift.return_value = json.dumps({"uid": "ABC-123", "updated_fields": ["summary"]})
         self.connector.update_event("MCP-Test-Calendar", "ABC-123", summary="New Title")
-        script = mock_run.call_args[0][0]
-        assert "set summary of evt" in script
-        assert "set location of evt" not in script
-        assert "set description of evt" not in script
-        assert "set url of evt" not in script
-        assert "set start date of evt" not in script
-        assert "set end date of evt" not in script
-        assert "set allday event of evt" not in script
+        args = mock_swift.call_args[0][1]
+        assert "--summary" in args
+        assert "--location" not in args
+        assert "--description" not in args
+        assert "--url" not in args
+        assert "--start" not in args
+        assert "--end" not in args
+        assert "--allday" not in args
 
-    @patch("apple_calendar_mcp.calendar_connector.run_applescript")
-    def test_escapes_special_characters(self, mock_run):
-        mock_run.return_value = "ABC-123"
-        self.connector.update_event("MCP-Test-Calendar", "ABC-123", summary='Say "hello"')
-        script = mock_run.call_args[0][0]
-        assert 'Say \\"hello\\"' in script
+    @patch("apple_calendar_mcp.calendar_connector.run_swift_helper")
+    def test_clear_field_with_empty_string(self, mock_swift):
+        mock_swift.return_value = json.dumps({"uid": "ABC-123", "updated_fields": ["location"]})
+        self.connector.update_event("MCP-Test-Calendar", "ABC-123", location="")
+        args = mock_swift.call_args[0][1]
+        assert "--clear-location" in args
+        assert "--location" not in args
 
     def test_invalid_date_raises(self):
         with pytest.raises(ValueError, match="Invalid date format"):
@@ -820,25 +793,11 @@ class TestUpdateEvent:
         with pytest.raises(ValueError, match="At least one field"):
             self.connector.update_event("MCP-Test-Calendar", "ABC-123")
 
-    @patch("apple_calendar_mcp.calendar_connector.run_applescript")
-    def test_returns_dict_with_uid_and_updated_fields(self, mock_run):
-        mock_run.return_value = "ABC-123"
-        result = self.connector.update_event("MCP-Test-Calendar", "ABC-123", summary="New", location="Room")
-        assert result == {"uid": "ABC-123", "updated_fields": ["summary", "location"]}
-
-    @patch("apple_calendar_mcp.calendar_connector.run_applescript")
-    def test_uses_whose_uid_clause(self, mock_run):
-        mock_run.return_value = "ABC-123"
-        self.connector.update_event("MCP-Test-Calendar", "ABC-123", summary="X")
-        script = mock_run.call_args[0][0]
-        assert 'whose uid is "ABC-123"' in script
-
-    @patch("apple_calendar_mcp.calendar_connector.run_applescript")
-    def test_clear_field_with_empty_string(self, mock_run):
-        mock_run.return_value = "ABC-123"
-        self.connector.update_event("MCP-Test-Calendar", "ABC-123", location="")
-        script = mock_run.call_args[0][0]
-        assert 'set location of evt to ""' in script
+    @patch("apple_calendar_mcp.calendar_connector.run_swift_helper")
+    def test_event_not_found_raises(self, mock_swift):
+        mock_swift.return_value = json.dumps({"error": "event_not_found", "message": "Event not found: BAD-UID"})
+        with pytest.raises(ValueError, match="Event not found"):
+            self.connector.update_event("MCP-Test-Calendar", "BAD-UID", summary="X")
 
 
 # ── delete_events ──────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Final PR completing the EventKit migration for all event operations.

- New `update_event.swift` helper using `EKEventStore.save()`
- Direct UID lookup via `calendarItems(withExternalIdentifier:)`
- Eliminates AppleScript date-ordering workaround
- `--clear-location/description/url` flags for clearing fields
- Updates CLAUDE.md architecture section

### Performance (full migration summary)

| Operation | Before (AppleScript) | After (EventKit) | Improvement |
|-----------|-----|-----|-----|
| get_calendars | ~6.4s | ~0.36s | **18x** |
| create_event | ~1.7s | ~0.6s | **3x** |
| update_event | ~2.6s | ~0.43s | **6x** |
| delete single | ~2.4s | ~0.4s | **6x** |
| delete batch 5 | ~14.5s | ~0.5s | **29x** |

Closes #41

## Test plan

- [x] `make test` — 125 unit tests pass
- [x] `make test-integration` — 38 integration tests pass
- [x] Benchmark: 2.6s → 0.43s

🤖 Generated with [Claude Code](https://claude.com/claude-code)