### PR TITLE
Support single-occurrence modify and series delete for recurring events (issue #44)

### DIFF
--- a/src/apple_calendar_mcp/calendar_connector.py
+++ b/src/apple_calendar_mcp/calendar_connector.py
@@ -262,6 +262,8 @@ class CalendarConnector:
         description: str | None = None,
         url: str | None = None,
         allday_event: bool | None = None,
+        occurrence_date: str | None = None,
+        span: str = "this_event",
     ) -> dict[str, Any]:
         """Update an existing event's properties by UID.
 
@@ -278,6 +280,8 @@ class CalendarConnector:
             description: New description (optional, "" to clear)
             url: New URL (optional, "" to clear)
             allday_event: New all-day status (optional)
+            occurrence_date: For recurring events, the date of the specific occurrence to update (optional)
+            span: "this_event" to update one occurrence, "future_events" to update this and all future (default: "this_event")
 
         Returns:
             Dict with 'uid' and 'updated_fields' keys
@@ -285,7 +289,6 @@ class CalendarConnector:
         Raises:
             CalendarSafetyError: If safety checks block the target calendar
             ValueError: If no fields provided or date format is invalid
-            subprocess.CalledProcessError: If AppleScript execution fails
         """
         self._verify_calendar_safety(calendar_name)
 
@@ -328,6 +331,11 @@ class CalendarConnector:
         if not updated_fields:
             raise ValueError("At least one field must be provided to update")
 
+        if occurrence_date:
+            args += ["--occurrence-date", occurrence_date]
+        if span != "this_event":
+            args += ["--span", span]
+
         result = run_swift_helper("update_event", args)
         parsed = json.loads(result)
 
@@ -345,12 +353,14 @@ class CalendarConnector:
         self,
         calendar_name: str,
         event_uids: str | list[str],
+        span: str = "this_event",
     ) -> dict[str, Any]:
         """Delete one or more events by UID.
 
         Args:
             calendar_name: Name of the calendar containing the events
             event_uids: Single UID string or list of UIDs to delete
+            span: "this_event" to delete one occurrence, "future_events" to delete series from this point (default: "this_event")
 
         Returns:
             Dict with 'deleted_uids' and 'not_found_uids' keys
@@ -368,6 +378,8 @@ class CalendarConnector:
         args = ["--calendar", calendar_name]
         for uid in uids:
             args += ["--uid", uid]
+        if span != "this_event":
+            args += ["--span", span]
 
         result = run_swift_helper("delete_events", args)
         parsed = json.loads(result)

--- a/src/apple_calendar_mcp/server_fastmcp.py
+++ b/src/apple_calendar_mcp/server_fastmcp.py
@@ -16,7 +16,7 @@ CALENDAR IDENTIFICATION: Calendars are identified by name (not UID — UIDs are 
 
 EVENTS: Events have summary (title), start/end dates, location, description (notes), URL, status, and recurrence. Events are identified by their UID (UUID format).
 
-RECURRING EVENTS: Recurring events share the same UID across all occurrences. Each occurrence has a unique occurrence_date. The is_recurring field indicates if an event is part of a series. The recurrence_rule field contains the iCalendar RRULE (e.g., "FREQ=WEEKLY;INTERVAL=1;BYDAY=MO,WE,FR"). Note: update_event by UID modifies the entire series — single-occurrence modification is not yet supported.
+RECURRING EVENTS: Recurring events share the same UID across all occurrences. Each occurrence has a unique occurrence_date. The is_recurring field indicates if an event is part of a series. The recurrence_rule field contains the iCalendar RRULE (e.g., "FREQ=WEEKLY;INTERVAL=1;BYDAY=MO,WE,FR"). To modify or delete a specific occurrence, pass occurrence_date and span="this_event". To modify or delete the series from a point onward, use span="future_events".
 
 DATES: All dates use ISO 8601 format in local time, without timezone suffix (e.g., "2026-03-15" or "2026-03-15T14:30:00"). Returned event timestamps are also in local time. Do NOT append "Z" to dates — they are not UTC.
 """)
@@ -274,6 +274,8 @@ def update_event(
     description: str | None = None,
     url: str | None = None,
     allday_event: bool | None = None,
+    occurrence_date: str = "",
+    span: str = "this_event",
 ) -> str:
     """Update an existing event's properties by UID.
 
@@ -281,6 +283,9 @@ def update_event(
     To clear a text field (location, description, url), pass an empty string "".
 
     Use get_events first to find the event's UID and calendar_name.
+
+    For recurring events: use occurrence_date to target a specific occurrence,
+    and span to control whether the change affects just this occurrence or the series.
 
     Args:
         calendar_name: Exact name of the calendar containing the event
@@ -292,6 +297,8 @@ def update_event(
         description: New description/notes, or "" to clear (optional)
         url: New URL, or "" to clear (optional)
         allday_event: New all-day status (optional)
+        occurrence_date: For recurring events, the occurrence_date from get_events to target a specific occurrence (optional)
+        span: "this_event" to update one occurrence, "future_events" to update this and all future occurrences (default: "this_event")
     """
     client = get_client()
     try:
@@ -305,6 +312,8 @@ def update_event(
             description=description,
             url=url,
             allday_event=allday_event,
+            occurrence_date=occurrence_date or None,
+            span=span,
         )
     except Exception as e:
         return f"Error updating event: {e}"
@@ -317,6 +326,7 @@ def update_event(
 def delete_events(
     calendar_name: str,
     event_uid: str | list[str],
+    span: str = "this_event",
 ) -> str:
     """Delete one or more events from a calendar by UID.
 
@@ -325,15 +335,19 @@ def delete_events(
 
     Use get_events first to find the event UID(s) and calendar_name.
 
+    For recurring events: use span to control deletion scope.
+
     Args:
         calendar_name: Exact name of the calendar containing the event(s)
         event_uid: UID of a single event (str) or list of UIDs to delete
+        span: "this_event" to delete one occurrence, "future_events" to delete the series from this point onward (default: "this_event")
     """
     client = get_client()
     try:
         result = client.delete_events(
             calendar_name=calendar_name,
             event_uids=event_uid,
+            span=span,
         )
     except Exception as e:
         return f"Error deleting event(s): {e}"

--- a/src/apple_calendar_mcp/swift/delete_events.swift
+++ b/src/apple_calendar_mcp/swift/delete_events.swift
@@ -3,10 +3,11 @@ import Foundation
 
 // MARK: - Argument Parsing
 
-func parseArgs() -> (calendar: String, uids: [String])? {
+func parseArgs() -> (calendar: String, uids: [String], span: EKSpan)? {
     let args = CommandLine.arguments
     var calendar: String?
     var uids: [String] = []
+    var span: EKSpan = .thisEvent
 
     var i = 1
     while i < args.count {
@@ -15,6 +16,8 @@ func parseArgs() -> (calendar: String, uids: [String])? {
             i += 1; if i < args.count { calendar = args[i] }
         case "--uid":
             i += 1; if i < args.count { uids.append(args[i]) }
+        case "--span":
+            i += 1; if i < args.count { span = args[i] == "future_events" ? .futureEvents : .thisEvent }
         default:
             break
         }
@@ -24,7 +27,7 @@ func parseArgs() -> (calendar: String, uids: [String])? {
     guard let cal = calendar, !uids.isEmpty else {
         return nil
     }
-    return (cal, uids)
+    return (cal, uids, span)
 }
 
 // MARK: - JSON Output
@@ -84,8 +87,15 @@ for uid in parsed.uids {
         notFoundUids.append(uid)
     } else {
         do {
-            for event in matches {
-                try store.remove(event, span: .thisEvent, commit: false)
+            if parsed.span == .futureEvents {
+                // For futureEvents, remove the first match with futureEvents span
+                // (this deletes the series from this occurrence onward)
+                try store.remove(matches.first!, span: .futureEvents, commit: false)
+            } else {
+                // For thisEvent, remove all matching occurrences individually
+                for event in matches {
+                    try store.remove(event, span: .thisEvent, commit: false)
+                }
             }
             deletedUids.append(uid)
         } catch {

--- a/src/apple_calendar_mcp/swift/update_event.swift
+++ b/src/apple_calendar_mcp/swift/update_event.swift
@@ -16,6 +16,8 @@ struct UpdateEventArgs {
     var url: String?
     var clearUrl = false
     var allday: Bool?
+    var occurrenceDate: String?
+    var span: EKSpan = .thisEvent
     var updatedFields: [String] = []
 }
 
@@ -52,6 +54,10 @@ func parseArgs() -> UpdateEventArgs? {
             result.clearUrl = true; result.updatedFields.append("url")
         case "--allday":
             i += 1; if i < args.count { result.allday = args[i] == "true"; result.updatedFields.append("allday_event") }
+        case "--occurrence-date":
+            i += 1; if i < args.count { result.occurrenceDate = args[i] }
+        case "--span":
+            i += 1; if i < args.count { result.span = args[i] == "future_events" ? .futureEvents : .thisEvent }
         default:
             break
         }
@@ -67,7 +73,8 @@ func parseArgs() -> UpdateEventArgs? {
         location: result.location, clearLocation: result.clearLocation,
         description: result.description, clearDescription: result.clearDescription,
         url: result.url, clearUrl: result.clearUrl,
-        allday: result.allday, updatedFields: result.updatedFields
+        allday: result.allday, occurrenceDate: result.occurrenceDate,
+        span: result.span, updatedFields: result.updatedFields
     )
     return result
 }
@@ -131,9 +138,15 @@ if !accessGranted {
 
 store.refreshSourcesIfNecessary()
 
-// Find event by UID
+// Find event by UID (and optionally by occurrence date)
 let items = store.calendarItems(withExternalIdentifier: parsed.uid)
-let matches = items.compactMap { $0 as? EKEvent }.filter { $0.calendar.title == parsed.calendar }
+var matches = items.compactMap { $0 as? EKEvent }.filter { $0.calendar.title == parsed.calendar }
+
+// If occurrence date specified, find the specific occurrence
+if let occDateStr = parsed.occurrenceDate, let occDate = parseISO8601(occDateStr) {
+    let tolerance: TimeInterval = 60 // 1 minute tolerance
+    matches = matches.filter { abs($0.occurrenceDate.timeIntervalSince(occDate)) < tolerance }
+}
 
 guard let event = matches.first else {
     outputError("event_not_found", "Event not found: \(parsed.uid)")
@@ -177,7 +190,7 @@ if let allday = parsed.allday {
 
 // Save
 do {
-    try store.save(event, span: .thisEvent)
+    try store.save(event, span: parsed.span)
 } catch {
     outputError("save_failed", "Failed to save event: \(error.localizedDescription)")
     exit(0)

--- a/tests/unit/test_calendar_connector.py
+++ b/tests/unit/test_calendar_connector.py
@@ -799,6 +799,32 @@ class TestUpdateEvent:
         with pytest.raises(ValueError, match="Event not found"):
             self.connector.update_event("MCP-Test-Calendar", "BAD-UID", summary="X")
 
+    @patch("apple_calendar_mcp.calendar_connector.run_swift_helper")
+    def test_passes_occurrence_date(self, mock_swift):
+        mock_swift.return_value = json.dumps({"uid": "REC-123", "updated_fields": ["summary"]})
+        self.connector.update_event("MCP-Test-Calendar", "REC-123",
+                                    summary="Modified", occurrence_date="2027-01-05T10:00:00")
+        args = mock_swift.call_args[0][1]
+        assert "--occurrence-date" in args
+        assert "2027-01-05T10:00:00" in args
+
+    @patch("apple_calendar_mcp.calendar_connector.run_swift_helper")
+    def test_passes_span_future_events(self, mock_swift):
+        mock_swift.return_value = json.dumps({"uid": "REC-123", "updated_fields": ["summary"]})
+        self.connector.update_event("MCP-Test-Calendar", "REC-123",
+                                    summary="Series Update", span="future_events")
+        args = mock_swift.call_args[0][1]
+        assert "--span" in args
+        assert "future_events" in args
+
+    @patch("apple_calendar_mcp.calendar_connector.run_swift_helper")
+    def test_default_span_not_passed(self, mock_swift):
+        mock_swift.return_value = json.dumps({"uid": "ABC-123", "updated_fields": ["summary"]})
+        self.connector.update_event("MCP-Test-Calendar", "ABC-123", summary="X")
+        args = mock_swift.call_args[0][1]
+        assert "--span" not in args
+        assert "--occurrence-date" not in args
+
 
 # ── delete_events ──────────────────────────────────────────────────────────
 
@@ -857,3 +883,18 @@ class TestDeleteEvents:
         result = self.connector.delete_events("MCP-Test-Calendar", ["UID-1", "UID-2", "UID-3"])
         assert result["deleted_uids"] == ["UID-1", "UID-3"]
         assert result["not_found_uids"] == ["UID-2"]
+
+    @patch("apple_calendar_mcp.calendar_connector.run_swift_helper")
+    def test_passes_span_future_events(self, mock_swift):
+        mock_swift.return_value = json.dumps({"deleted_uids": ["REC-123"], "not_found_uids": []})
+        self.connector.delete_events("MCP-Test-Calendar", "REC-123", span="future_events")
+        args = mock_swift.call_args[0][1]
+        assert "--span" in args
+        assert "future_events" in args
+
+    @patch("apple_calendar_mcp.calendar_connector.run_swift_helper")
+    def test_default_span_not_passed(self, mock_swift):
+        mock_swift.return_value = json.dumps({"deleted_uids": ["ABC-123"], "not_found_uids": []})
+        self.connector.delete_events("MCP-Test-Calendar", "ABC-123")
+        args = mock_swift.call_args[0][1]
+        assert "--span" not in args

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -502,6 +502,7 @@ class TestDeleteEventsTool:
         mock_client.delete_events.assert_called_once_with(
             calendar_name="Work",
             event_uids=["UID-1", "UID-2"],
+            span="this_event",
         )
 
 


### PR DESCRIPTION
## Summary

Adds span-based operations for recurring events, previously blocked by #41 (EventKit migration).

- `update_event`: new `occurrence_date` param to target a specific occurrence, `span` param (`this_event` or `future_events`)
- `delete_events`: new `span` param for controlling deletion scope
- Swift helpers updated with `--occurrence-date`, `--span` CLI flags
- Occurrence matching uses 1-minute tolerance for date comparison
- Server instructions updated with recurring event targeting guidance

### Usage examples
```python
# Modify one occurrence of a recurring event
update_event("Work", uid, summary="Special", occurrence_date="2027-01-12T10:00:00", span="this_event")

# Modify this and all future occurrences
update_event("Work", uid, summary="New Series Name", span="future_events")

# Delete the series from a point onward
delete_events("Work", uid, span="future_events")
```

Closes #44

## Test plan

- [x] `make test` — 130 unit tests pass (5 new span/occurrence tests)
- [x] `make test-integration` — 38 integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)