### PR TITLE
Expose attendee information in get_events (read-only) (issue #49)

### DIFF
--- a/src/apple_calendar_mcp/server_fastmcp.py
+++ b/src/apple_calendar_mcp/server_fastmcp.py
@@ -14,7 +14,7 @@ CALENDARS: Each calendar has a name, writable status, description, and color. Ca
 
 CALENDAR IDENTIFICATION: Calendars are identified by name (not UID — UIDs are not accessible via AppleScript). When specifying a calendar, use the exact name as returned by get_calendars.
 
-EVENTS: Events have summary (title), start/end dates, location, description (notes), URL, status, and recurrence. Events are identified by their UID (UUID format).
+EVENTS: Events have summary (title), start/end dates, location, description (notes), URL, status, recurrence, and attendees. Events are identified by their UID (UUID format). Attendees are read-only — they cannot be added via this server (use Calendar.app or email invitations).
 
 RECURRING EVENTS: Recurring events share the same UID across all occurrences. Each occurrence has a unique occurrence_date. The is_recurring field indicates if an event is part of a series. The recurrence_rule field contains the iCalendar RRULE (e.g., "FREQ=WEEKLY;INTERVAL=1;BYDAY=MO,WE,FR"). To modify or delete a specific occurrence, pass occurrence_date and span="this_event". To modify or delete the series from a point onward, use span="future_events".
 
@@ -173,6 +173,10 @@ def _format_event(event: dict) -> str:
         result += f"Recurring: {event.get('recurrence_rule', 'yes')}\n"
         if event.get("is_detached"):
             result += "Modified occurrence (detached from series)\n"
+    attendees = event.get("attendees", [])
+    if attendees:
+        names = [a.get("name") or a.get("email", "unknown") for a in attendees]
+        result += f"Attendees ({len(attendees)}): {', '.join(names)}\n"
     result += f"Status: {event.get('status', 'none')}\n"
     result += f"UID: {event['uid']}\n"
     return result

--- a/src/apple_calendar_mcp/swift/get_events.swift
+++ b/src/apple_calendar_mcp/swift/get_events.swift
@@ -116,7 +116,42 @@ func eventToDict(_ event: EKEvent) -> [String: Any] {
         dict["recurrence_rule"] = NSNull()
     }
 
+    // Attendees (read-only — EventKit cannot add attendees programmatically)
+    dict["attendees"] = (event.attendees ?? []).map { att in
+        [
+            "name": att.name ?? "",
+            "email": att.url.absoluteString.replacingOccurrences(of: "mailto:", with: ""),
+            "role": participantRoleString(att.participantRole),
+            "status": participantStatusString(att.participantStatus),
+        ] as [String: String]
+    }
+
     return dict
+}
+
+func participantRoleString(_ role: EKParticipantRole) -> String {
+    switch role {
+    case .unknown: return "unknown"
+    case .required: return "required"
+    case .optional: return "optional"
+    case .chair: return "chair"
+    case .nonParticipant: return "non_participant"
+    @unknown default: return "unknown"
+    }
+}
+
+func participantStatusString(_ status: EKParticipantStatus) -> String {
+    switch status {
+    case .unknown: return "unknown"
+    case .pending: return "pending"
+    case .accepted: return "accepted"
+    case .declined: return "declined"
+    case .tentative: return "tentative"
+    case .delegated: return "delegated"
+    case .completed: return "completed"
+    case .inProcess: return "in_process"
+    @unknown default: return "unknown"
+    }
 }
 
 // MARK: - Main

--- a/tests/unit/test_calendar_connector.py
+++ b/tests/unit/test_calendar_connector.py
@@ -564,6 +564,38 @@ class TestGetEvents:
         assert event["is_detached"] is False
         assert event["occurrence_date"] == "2026-07-01T09:00:00"
 
+    @patch("apple_calendar_mcp.calendar_connector.run_swift_helper")
+    def test_attendees_returned(self, mock_swift):
+        mock_swift.return_value = json.dumps([
+            {"uid": "ATT-123", "summary": "Team Meeting", "start_date": "2026-07-01T14:00:00",
+             "end_date": "2026-07-01T15:00:00", "allday_event": False, "location": "",
+             "description": "", "url": "", "status": "confirmed", "calendar_name": "Work",
+             "is_recurring": False, "recurrence_rule": None, "is_detached": False,
+             "occurrence_date": "2026-07-01T14:00:00",
+             "attendees": [
+                 {"name": "Alice", "email": "alice@example.com", "role": "required", "status": "accepted"},
+                 {"name": "", "email": "bob@example.com", "role": "optional", "status": "pending"},
+             ]},
+        ])
+        result = self.connector.get_events("Work", "2026-07-01", "2026-07-02")
+        event = result[0]
+        assert len(event["attendees"]) == 2
+        assert event["attendees"][0]["name"] == "Alice"
+        assert event["attendees"][0]["email"] == "alice@example.com"
+        assert event["attendees"][1]["role"] == "optional"
+
+    @patch("apple_calendar_mcp.calendar_connector.run_swift_helper")
+    def test_empty_attendees_returned(self, mock_swift):
+        mock_swift.return_value = json.dumps([
+            {"uid": "NO-ATT", "summary": "Solo Event", "start_date": "2026-07-01T10:00:00",
+             "end_date": "2026-07-01T11:00:00", "allday_event": False, "location": "",
+             "description": "", "url": "", "status": "confirmed", "calendar_name": "Work",
+             "is_recurring": False, "recurrence_rule": None, "is_detached": False,
+             "occurrence_date": "2026-07-01T10:00:00", "attendees": []},
+        ])
+        result = self.connector.get_events("Work", "2026-07-01", "2026-07-02")
+        assert result[0]["attendees"] == []
+
 
 # ── get_availability ────────────────────────────────────────────────────────
 

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -283,6 +283,26 @@ class TestGetEventsTool:
         assert "FREQ=WEEKLY" in result
 
     @patch("apple_calendar_mcp.server_fastmcp.get_client")
+    def test_formats_attendees(self, mock_get_client):
+        mock_client = MagicMock()
+        mock_client.get_events.return_value = [
+            {"uid": "ATT-123", "summary": "Team Meeting", "start_date": "2026-07-01T14:00:00",
+             "end_date": "2026-07-01T15:00:00", "allday_event": False, "location": "",
+             "description": "", "url": "", "status": "confirmed", "calendar_name": "Work",
+             "attendees": [
+                 {"name": "Alice", "email": "alice@example.com", "role": "required", "status": "accepted"},
+                 {"name": "", "email": "bob@example.com", "role": "optional", "status": "pending"},
+             ]},
+        ]
+        mock_get_client.return_value = mock_client
+
+        from apple_calendar_mcp.server_fastmcp import get_events
+        result = get_events(calendar_name="Work", start_date="2026-07-01", end_date="2026-07-02")
+        assert "Attendees (2)" in result
+        assert "Alice" in result
+        assert "bob@example.com" in result
+
+    @patch("apple_calendar_mcp.server_fastmcp.get_client")
     def test_returns_no_events_message(self, mock_get_client):
         mock_client = MagicMock()
         mock_client.get_events.return_value = []


### PR DESCRIPTION
## Summary

- Adds `attendees` array to `get_events` output: `[{name, email, role, status}]`
- Roles: unknown, required, optional, chair, non_participant
- Statuses: unknown, pending, accepted, declined, tentative, delegated, completed, in_process
- Attendee display in formatted output: "Attendees (N): name1, name2, ..."
- Server instructions updated: attendees are read-only (EventKit limitation)
- Filed #67 for research into AppleScript-based attendee creation

Closes #49

## Test plan

- [x] `make test` — 133 unit tests pass (3 new)
- [x] `make test-integration` — 38 integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)