### PR TITLE
Expose alerts in get_events, create_event, and update_event (issue #50)

### DIFF
--- a/src/apple_calendar_mcp/calendar_connector.py
+++ b/src/apple_calendar_mcp/calendar_connector.py
@@ -155,6 +155,7 @@ class CalendarConnector:
         url: Optional[str] = None,
         allday_event: bool = False,
         recurrence_rule: Optional[str] = None,
+        alert_minutes: Optional[list[int]] = None,
     ) -> str:
         """Create a new event in a specified calendar.
 
@@ -168,6 +169,7 @@ class CalendarConnector:
             url: URL associated with the event (optional)
             allday_event: Whether this is an all-day event
             recurrence_rule: iCalendar RRULE string (optional, e.g. "FREQ=WEEKLY;BYDAY=MO,WE,FR")
+            alert_minutes: List of alert times in minutes before event (optional, e.g. [15, 60])
 
         Returns:
             The UID of the created event
@@ -193,6 +195,9 @@ class CalendarConnector:
             args += ["--allday"]
         if recurrence_rule:
             args += ["--recurrence", recurrence_rule]
+        if alert_minutes:
+            for mins in alert_minutes:
+                args += ["--alert", str(mins)]
 
         parsed = self._run_swift_helper_json("create_event", args)
         return parsed["uid"]
@@ -256,6 +261,7 @@ class CalendarConnector:
         description: str | None = None,
         url: str | None = None,
         allday_event: bool | None = None,
+        alert_minutes: list[int] | None = None,
         occurrence_date: str | None = None,
         span: str = "this_event",
     ) -> dict[str, Any]:
@@ -298,6 +304,14 @@ class CalendarConnector:
         args, updated_fields = self._build_update_args(
             calendar_name, event_uid, fields, occurrence_date, span
         )
+
+        if alert_minutes is not None:
+            if len(alert_minutes) == 0:
+                args += ["--clear-alerts"]
+            else:
+                for mins in alert_minutes:
+                    args += ["--alert", str(mins)]
+            updated_fields.append("alerts")
 
         if not updated_fields:
             raise ValueError("At least one field must be provided to update")

--- a/src/apple_calendar_mcp/server_fastmcp.py
+++ b/src/apple_calendar_mcp/server_fastmcp.py
@@ -116,6 +116,7 @@ def create_event(
     url: str = "",
     allday_event: bool = False,
     recurrence_rule: str = "",
+    alert_minutes: str = "",
 ) -> str:
     """Create a new event in a specified calendar.
 
@@ -129,7 +130,9 @@ def create_event(
         url: URL associated with the event (optional)
         allday_event: Whether this is an all-day event (default: false). When true, use date-only format for start_date/end_date.
         recurrence_rule: iCalendar RRULE string for recurring events (optional, e.g., "FREQ=WEEKLY;BYDAY=MO,WE,FR" or "FREQ=DAILY;COUNT=10")
+        alert_minutes: Comma-separated minutes before event to alert (optional, e.g., "15" or "15,60")
     """
+    parsed_alerts = [int(m.strip()) for m in alert_minutes.split(",") if m.strip()] if alert_minutes else None
     client = get_client()
     try:
         event_uid = client.create_event(
@@ -142,6 +145,7 @@ def create_event(
             url=url or None,
             allday_event=allday_event,
             recurrence_rule=recurrence_rule or None,
+            alert_minutes=parsed_alerts,
         )
     except Exception as e:
         return f"Error creating event: {e}"
@@ -173,6 +177,10 @@ def _format_event(event: dict) -> str:
         result += f"Recurring: {event.get('recurrence_rule', 'yes')}\n"
         if event.get("is_detached"):
             result += "Modified occurrence (detached from series)\n"
+    alerts = event.get("alerts", [])
+    if alerts:
+        alert_strs = [f"{a['minutes_before']}m before" for a in alerts]
+        result += f"Alerts: {', '.join(alert_strs)}\n"
     attendees = event.get("attendees", [])
     if attendees:
         names = [a.get("name") or a.get("email", "unknown") for a in attendees]
@@ -278,6 +286,7 @@ def update_event(
     description: str | None = None,
     url: str | None = None,
     allday_event: bool | None = None,
+    alert_minutes: str = "",
     occurrence_date: str = "",
     span: str = "this_event",
 ) -> str:
@@ -301,9 +310,15 @@ def update_event(
         description: New description/notes, or "" to clear (optional)
         url: New URL, or "" to clear (optional)
         allday_event: New all-day status (optional)
+        alert_minutes: Comma-separated minutes before event to alert (e.g., "15,60"), or "none" to clear all alerts (optional)
         occurrence_date: For recurring events, the occurrence_date from get_events to target a specific occurrence (optional)
         span: "this_event" to update one occurrence, "future_events" to update this and all future occurrences (default: "this_event")
     """
+    parsed_alerts = None
+    if alert_minutes == "none":
+        parsed_alerts = []
+    elif alert_minutes:
+        parsed_alerts = [int(m.strip()) for m in alert_minutes.split(",") if m.strip()]
     client = get_client()
     try:
         result = client.update_event(
@@ -316,6 +331,7 @@ def update_event(
             description=description,
             url=url,
             allday_event=allday_event,
+            alert_minutes=parsed_alerts,
             occurrence_date=occurrence_date or None,
             span=span,
         )

--- a/src/apple_calendar_mcp/swift/create_event.swift
+++ b/src/apple_calendar_mcp/swift/create_event.swift
@@ -13,6 +13,7 @@ struct CreateEventArgs {
     var url: String?
     var allday: Bool = false
     var recurrence: String?
+    var alertMinutes: [Int] = []
 }
 
 func parseArgs() -> CreateEventArgs? {
@@ -26,6 +27,7 @@ func parseArgs() -> CreateEventArgs? {
     var url: String?
     var allday = false
     var recurrence: String?
+    var alertMinutes: [Int] = []
 
     var i = 1
     while i < args.count {
@@ -48,6 +50,8 @@ func parseArgs() -> CreateEventArgs? {
             allday = true
         case "--recurrence":
             i += 1; if i < args.count { recurrence = args[i] }
+        case "--alert":
+            i += 1; if i < args.count, let mins = Int(args[i]) { alertMinutes.append(mins) }
         default:
             break
         }
@@ -63,6 +67,7 @@ func parseArgs() -> CreateEventArgs? {
     result.url = url
     result.allday = allday
     result.recurrence = recurrence
+    result.alertMinutes = alertMinutes
     return result
 }
 
@@ -224,6 +229,9 @@ if let urlStr = parsed.url, let url = URL(string: urlStr) {
 }
 if let rrule = parsed.recurrence, let rule = parseRecurrenceRule(rrule) {
     event.addRecurrenceRule(rule)
+}
+for mins in parsed.alertMinutes {
+    event.addAlarm(EKAlarm(relativeOffset: TimeInterval(-mins * 60)))
 }
 
 do {

--- a/src/apple_calendar_mcp/swift/get_events.swift
+++ b/src/apple_calendar_mcp/swift/get_events.swift
@@ -116,6 +116,11 @@ func eventToDict(_ event: EKEvent) -> [String: Any] {
         dict["recurrence_rule"] = NSNull()
     }
 
+    // Alerts
+    dict["alerts"] = (event.alarms ?? []).map { alarm in
+        ["minutes_before": Int(alarm.relativeOffset / -60)] as [String: Int]
+    }
+
     // Attendees (read-only — EventKit cannot add attendees programmatically)
     dict["attendees"] = (event.attendees ?? []).map { att in
         [

--- a/src/apple_calendar_mcp/swift/update_event.swift
+++ b/src/apple_calendar_mcp/swift/update_event.swift
@@ -16,6 +16,8 @@ struct UpdateEventArgs {
     var url: String?
     var clearUrl = false
     var allday: Bool?
+    var alertMinutes: [Int] = []
+    var clearAlerts = false
     var occurrenceDate: String?
     var span: EKSpan = .thisEvent
     var updatedFields: [String] = []
@@ -54,6 +56,12 @@ func parseArgs() -> UpdateEventArgs? {
             result.clearUrl = true; result.updatedFields.append("url")
         case "--allday":
             i += 1; if i < args.count { result.allday = args[i] == "true"; result.updatedFields.append("allday_event") }
+        case "--alert":
+            i += 1; if i < args.count, let mins = Int(args[i]) { result.alertMinutes.append(mins) }
+            if !result.updatedFields.contains("alerts") { result.updatedFields.append("alerts") }
+        case "--clear-alerts":
+            result.clearAlerts = true
+            if !result.updatedFields.contains("alerts") { result.updatedFields.append("alerts") }
         case "--occurrence-date":
             i += 1; if i < args.count { result.occurrenceDate = args[i] }
         case "--span":
@@ -73,7 +81,8 @@ func parseArgs() -> UpdateEventArgs? {
         location: result.location, clearLocation: result.clearLocation,
         description: result.description, clearDescription: result.clearDescription,
         url: result.url, clearUrl: result.clearUrl,
-        allday: result.allday, occurrenceDate: result.occurrenceDate,
+        allday: result.allday, alertMinutes: result.alertMinutes,
+        clearAlerts: result.clearAlerts, occurrenceDate: result.occurrenceDate,
         span: result.span, updatedFields: result.updatedFields
     )
     return result
@@ -186,6 +195,12 @@ if let urlStr = parsed.url, let url = URL(string: urlStr) {
 }
 if let allday = parsed.allday {
     event.isAllDay = allday
+}
+if parsed.clearAlerts || !parsed.alertMinutes.isEmpty {
+    event.alarms = nil
+    for mins in parsed.alertMinutes {
+        event.addAlarm(EKAlarm(relativeOffset: TimeInterval(-mins * 60)))
+    }
 }
 
 // Save

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -208,6 +208,7 @@ class TestCreateEventTool:
             url="https://example.com",
             allday_event=True,
             recurrence_rule=None,
+            alert_minutes=None,
         )
 
     @patch("apple_calendar_mcp.server_fastmcp.get_client")


### PR DESCRIPTION
## Summary

Full read/write support for event alerts via EventKit.

- **Read:** `get_events` returns `alerts: [{minutes_before: N}]` for each event
- **Create:** `create_event` accepts `alert_minutes` (e.g., "15,60")
- **Update:** `update_event` accepts `alert_minutes` (replace alerts) or "none" to clear
- **Display:** formatted output shows "Alerts: 15m before, 60m before"
- EventKit seconds normalized to minutes in API

Closes #50

## Test plan

- [x] `make test` — 133 unit tests pass
- [x] `make test-integration` — 38 integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)