### PR TITLE
Add search_events tool with text search across calendars (issue #51)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -19,10 +19,10 @@ make test-verbose          # Tests with verbose output
 
 **Running the server:** `uv run python -m apple_calendar_mcp.server_fastmcp` or via Claude Desktop config.
 
-## API Surface (8 functions)
+## API Surface (9 functions)
 
 - **Calendars:** `get_calendars`, `create_calendar`, `delete_calendar`
-- **Events:** `get_events`, `create_event`, `update_event`, `delete_events`
+- **Events:** `get_events`, `search_events`, `create_event`, `update_event`, `delete_events`
 - **Availability:** `get_availability`
 
 Planned (filed as issues): `update_events`

--- a/src/apple_calendar_mcp/calendar_connector.py
+++ b/src/apple_calendar_mcp/calendar_connector.py
@@ -245,10 +245,55 @@ class CalendarConnector:
         self._validate_date(start_date)
         self._validate_date(end_date)
 
-        return self._run_swift_helper_json(
-            "get_events",
-            ["--calendar", calendar_name, "--start", start_date, "--end", end_date],
-        )
+        args = ["--calendar", calendar_name, "--start", start_date, "--end", end_date]
+        return self._run_swift_helper_json("get_events", args)
+
+    def search_events(
+        self,
+        query: str,
+        calendar_name: Optional[str] = None,
+        start_date: Optional[str] = None,
+        end_date: Optional[str] = None,
+    ) -> list[dict[str, Any]]:
+        """Search events by text across one or all calendars.
+
+        Searches event summaries, descriptions, and locations with
+        case-insensitive matching.
+
+        Args:
+            query: Text to search for
+            calendar_name: Calendar to search (optional — searches all if omitted)
+            start_date: Start of date range (optional — defaults to 1 month ago)
+            end_date: End of date range (optional — defaults to 6 months from now)
+
+        Returns:
+            List of matching event dicts.
+        """
+        if not start_date:
+            start_date = (datetime.now() - timedelta(days=30)).strftime("%Y-%m-%dT00:00:00")
+        if not end_date:
+            end_date = (datetime.now() + timedelta(days=180)).strftime("%Y-%m-%dT00:00:00")
+
+        self._validate_date(start_date)
+        self._validate_date(end_date)
+
+        if calendar_name:
+            calendars = [calendar_name]
+        else:
+            cal_list = self.get_calendars()
+            calendars = [c["name"] for c in cal_list]
+
+        all_results = []
+        for cal in calendars:
+            args = ["--calendar", cal, "--start", start_date, "--end", end_date, "--query", query]
+            try:
+                events = self._run_swift_helper_json("get_events", args)
+                if isinstance(events, list):
+                    all_results.extend(events)
+            except ValueError:
+                continue  # skip calendars that error (e.g., not found)
+
+        return all_results
 
     def update_event(
         self,

--- a/src/apple_calendar_mcp/server_fastmcp.py
+++ b/src/apple_calendar_mcp/server_fastmcp.py
@@ -226,6 +226,45 @@ def get_events(
     return f"Found {len(events)} event(s) in '{calendar_name}':\n\n" + "\n".join(lines)
 
 
+@mcp.tool()
+def search_events(
+    query: str,
+    calendar_name: str = "",
+    start_date: str = "",
+    end_date: str = "",
+) -> str:
+    """Search events by text across one or all calendars.
+
+    Searches event summaries, descriptions, and locations with case-insensitive
+    matching. If no calendar is specified, searches all calendars. If no date
+    range is specified, searches from 1 month ago to 6 months from now.
+
+    Args:
+        query: Text to search for in event titles, descriptions, and locations
+        calendar_name: Calendar to search (optional — searches all calendars if empty)
+        start_date: Start of date range in ISO 8601 format (optional)
+        end_date: End of date range in ISO 8601 format (optional)
+    """
+    client = get_client()
+    try:
+        events = client.search_events(
+            query=query,
+            calendar_name=calendar_name or None,
+            start_date=start_date or None,
+            end_date=end_date or None,
+        )
+    except Exception as e:
+        return f"Error searching events: {e}"
+
+    if not events:
+        scope = f"in '{calendar_name}'" if calendar_name else "across all calendars"
+        return f"No events matching '{query}' found {scope}."
+
+    lines = [_format_event(event) for event in events]
+    scope = f"in '{calendar_name}'" if calendar_name else "across all calendars"
+    return f"Found {len(events)} event(s) matching '{query}' {scope}:\n\n" + "\n".join(lines)
+
+
 def _format_free_slot(slot: dict) -> str:
     """Format a free time slot as human-readable text."""
     hours = slot["duration_minutes"] // 60

--- a/src/apple_calendar_mcp/swift/get_events.swift
+++ b/src/apple_calendar_mcp/swift/get_events.swift
@@ -13,11 +13,12 @@ func printUsage() {
     FileHandle.standardError.write(Data(msg.utf8))
 }
 
-func parseArgs() -> (calendar: String, start: String, end: String)? {
+func parseArgs() -> (calendar: String, start: String, end: String, query: String?)? {
     let args = CommandLine.arguments
     var calendar: String?
     var start: String?
     var end: String?
+    var query: String?
 
     var i = 1
     while i < args.count {
@@ -28,6 +29,8 @@ func parseArgs() -> (calendar: String, start: String, end: String)? {
             i += 1; if i < args.count { start = args[i] }
         case "--end":
             i += 1; if i < args.count { end = args[i] }
+        case "--query":
+            i += 1; if i < args.count { query = args[i] }
         default:
             break
         }
@@ -37,7 +40,7 @@ func parseArgs() -> (calendar: String, start: String, end: String)? {
     guard let cal = calendar, let s = start, let e = end else {
         return nil
     }
-    return (cal, s, e)
+    return (cal, s, e, query)
 }
 
 // MARK: - Date Parsing
@@ -208,7 +211,17 @@ guard let calendar = allCalendars.first(where: { $0.title == parsed.calendar }) 
 
 // Query events
 let predicate = store.predicateForEvents(withStart: startDate, end: endDate, calendars: [calendar])
-let events = store.events(matching: predicate)
+var events = store.events(matching: predicate)
+
+// Filter by query text (case-insensitive match on title, notes, location)
+if let query = parsed.query {
+    let q = query.lowercased()
+    events = events.filter { event in
+        (event.title ?? "").lowercased().contains(q) ||
+        (event.notes ?? "").lowercased().contains(q) ||
+        (event.location ?? "").lowercased().contains(q)
+    }
+}
 
 // Build JSON output
 let eventDicts = events.map { eventToDict($0) }


### PR DESCRIPTION
## Summary

New `search_events` tool for text search across one or all calendars.

- Adds `--query` flag to `get_events.swift` for client-side case-insensitive filtering on title, notes, and location
- New `search_events` connector method with optional calendar and date range (defaults to -1 month to +6 months)
- When no calendar specified, searches all calendars
- Updates CLAUDE.md: 8 → 9 functions

### Performance
EventKit client-side filtering: <1s for 163 matches over 6 months (from gap analysis research).

Closes #51

## Test plan

- [x] `make test` — 133 unit tests pass
- [x] `make test-integration` — 38 integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)