### PR TITLE
Add GitHub Release creation to release workflow (issue #70)

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -153,6 +153,12 @@ After the user approves the PR:
    git describe --tags --abbrev=0  # Should return vX.Y.Z
    ```
 
+6. **Create the GitHub Release** using the CHANGELOG entry as release notes:
+   ```bash
+   gh release create vX.Y.Z --title "Release vX.Y.Z" --latest --notes "..."
+   ```
+   Extract the relevant section from CHANGELOG.md for the release notes body.
+
 ## Phase 9: Close Milestone
 
 After the tag is pushed, close the milestone:


### PR DESCRIPTION
## Summary

- Created GitHub Releases for all 6 existing tags (v0.1.0 through v0.4.0)
- Updated release skill to include `gh release create` step after tagging

Closes #70

## Test plan

- [x] All 6 releases visible on GitHub repo page
- [x] v0.4.0 shows "Latest" badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)