### PR TITLE
Fix RRULE parser: nth weekday and UNTIL support (#79, #81)

### DIFF
--- a/evals/agent_tool_usability/create_event_eval.md
+++ b/evals/agent_tool_usability/create_event_eval.md
@@ -28,10 +28,35 @@ Give an agent access to the apple-calendar-mcp tools with NO additional instruct
 **Expected:** Agent calls `get_calendars()` first. If multiple "Family" calendars exist, agent asks for clarification or uses description to disambiguate.
 **Pass criteria:** Agent doesn't blindly pick one of the duplicate calendars — it either asks or explains the ambiguity.
 
+### Scenario 5: Weekly recurring with simple BYDAY
+**Prompt:** "Set up a recurring meeting called 'Sprint Planning' every Monday and Wednesday at 2pm for an hour on my Work calendar."
+**Expected:** Agent calls `create_event` with `recurrence_rule="FREQ=WEEKLY;BYDAY=MO,WE"`.
+**Pass criteria:** Agent produces a valid RRULE with FREQ=WEEKLY and BYDAY containing MO and WE. Start/end dates set correctly for the first occurrence.
+
+### Scenario 6: Monthly nth weekday recurrence
+**Prompt:** "Create a recurring event called 'Board Meeting' on the 4th Tuesday of every month at 3pm for 2 hours on my Work calendar."
+**Expected:** Agent calls `create_event` with `recurrence_rule="FREQ=MONTHLY;BYDAY=4TU"` or equivalent.
+**Pass criteria:** Agent produces an RRULE with `BYDAY=4TU` (or `4TU` somewhere in a valid RRULE). Start date should be the next 4th Tuesday.
+
+### Scenario 7: Complex recurrence with UNTIL
+**Prompt:** "I need a weekly team lunch every Friday starting this week until Christmas on my Work calendar. 12pm to 1pm."
+**Expected:** Agent calls `create_event` with `recurrence_rule="FREQ=WEEKLY;BYDAY=FR;UNTIL=YYYYMMDD"` where UNTIL is Dec 25 of the current year.
+**Pass criteria:** Agent produces a valid RRULE with FREQ=WEEKLY, BYDAY=FR, and an UNTIL date near Dec 25. UNTIL format should be YYYYMMDD or YYYYMMDDTHHMMSS.
+
+### Scenario 8: Last weekday of month
+**Prompt:** "Schedule 'Month-End Review' on the last Friday of every month at 4pm for 1 hour on Work, for the next 6 months."
+**Expected:** Agent calls `create_event` with `recurrence_rule="FREQ=MONTHLY;BYDAY=-1FR;COUNT=6"` or uses UNTIL.
+**Pass criteria:** Agent produces an RRULE with `BYDAY=-1FR` and either COUNT=6 or an appropriate UNTIL date.
+
+### Scenario 9: Every N months
+**Prompt:** "Set up a quarterly planning session — every 3 months on the 2nd Wednesday, starting next month, for 3 hours. Put it on Work."
+**Expected:** Agent calls `create_event` with `recurrence_rule="FREQ=MONTHLY;INTERVAL=3;BYDAY=2WE"`.
+**Pass criteria:** Agent produces an RRULE with FREQ=MONTHLY, INTERVAL=3, and BYDAY=2WE. Start date should be the 2nd Wednesday of next month.
+
 ## Scoring
-- 4/4 pass: Tool descriptions are clear
-- 3/4 pass: Minor description improvements needed
-- 2/4 or fewer: Rewrite descriptions before release
+- 8/9 or 9/9 pass: Tool descriptions are clear
+- 6-7/9 pass: Minor description improvements needed
+- 5/9 or fewer: Rewrite descriptions before release
 
 ## Results
 _Run these scenarios before each release that changes tool descriptions._

--- a/src/apple_calendar_mcp/swift/create_event.swift
+++ b/src/apple_calendar_mcp/swift/create_event.swift
@@ -91,11 +91,31 @@ func parseISO8601(_ str: String) -> Date? {
 
 // MARK: - Recurrence Rule Parsing
 
+func parseDayOfWeek(_ day: String) -> EKRecurrenceDayOfWeek? {
+    let dayMap: [String: EKWeekday] = [
+        "SU": .sunday, "MO": .monday, "TU": .tuesday,
+        "WE": .wednesday, "TH": .thursday, "FR": .friday, "SA": .saturday
+    ]
+    // Parse optional numeric prefix: "4MO" → weekNumber=4, day="MO"
+    // "-1FR" → weekNumber=-1, day="FR"
+    let dayStr = String(day)
+    let letters = dayStr.suffix(2)
+    let prefix = dayStr.dropLast(2)
+
+    guard let weekday = dayMap[String(letters)] else { return nil }
+
+    if prefix.isEmpty {
+        return EKRecurrenceDayOfWeek(weekday)
+    } else if let weekNumber = Int(prefix) {
+        return EKRecurrenceDayOfWeek(weekday, weekNumber: weekNumber)
+    }
+    return nil
+}
+
 func parseRecurrenceRule(_ rrule: String) -> EKRecurrenceRule? {
-    // Parse common RRULE components
     var frequency: EKRecurrenceFrequency = .daily
     var interval = 1
-    var count: Int?
+    var end: EKRecurrenceEnd?
     var daysOfWeek: [EKRecurrenceDayOfWeek]?
 
     let parts = rrule.split(separator: ";")
@@ -117,21 +137,15 @@ func parseRecurrenceRule(_ rrule: String) -> EKRecurrenceRule? {
         case "INTERVAL":
             interval = Int(value) ?? 1
         case "COUNT":
-            count = Int(value)
+            if let n = Int(value) { end = EKRecurrenceEnd(occurrenceCount: n) }
+        case "UNTIL":
+            if let date = parseUntilDate(value) { end = EKRecurrenceEnd(end: date) }
         case "BYDAY":
-            let dayMap: [String: EKWeekday] = [
-                "SU": .sunday, "MO": .monday, "TU": .tuesday,
-                "WE": .wednesday, "TH": .thursday, "FR": .friday, "SA": .saturday
-            ]
-            daysOfWeek = value.split(separator: ",").compactMap { day in
-                dayMap[String(day)].map { EKRecurrenceDayOfWeek($0) }
-            }
+            daysOfWeek = value.split(separator: ",").compactMap { parseDayOfWeek(String($0)) }
         default:
             break
         }
     }
-
-    let end: EKRecurrenceEnd? = count.map { EKRecurrenceEnd(occurrenceCount: $0) }
 
     return EKRecurrenceRule(
         recurrenceWith: frequency,
@@ -144,6 +158,18 @@ func parseRecurrenceRule(_ rrule: String) -> EKRecurrenceRule? {
         setPositions: nil,
         end: end
     )
+}
+
+func parseUntilDate(_ value: String) -> Date? {
+    // Try formats: "20280322T000000Z", "20280322T000000", "20280322"
+    let df = DateFormatter()
+    df.locale = Locale(identifier: "en_US_POSIX")
+    for fmt in ["yyyyMMdd'T'HHmmss'Z'", "yyyyMMdd'T'HHmmss", "yyyyMMdd"] {
+        df.dateFormat = fmt
+        if let date = df.date(from: value) { return date }
+    }
+    // Also try ISO 8601 format
+    return parseISO8601(value)
 }
 
 // MARK: - JSON Output

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -535,6 +535,93 @@ class TestRecurringEventsIntegration:
             delete_test_calendar(TEST_CALENDAR)
             create_test_calendar(TEST_CALENDAR)
 
+    def test_monthly_nth_weekday_recurrence(self, connector):
+        """Create monthly event on 4th Monday — verify correct dates (#79)."""
+        # Jan 26 2028 is a 4th Monday
+        uid = connector.create_event(
+            calendar_name=TEST_CALENDAR,
+            summary="4th Monday Test",
+            start_date="2028-01-26T10:00:00",
+            end_date="2028-01-26T11:00:00",
+            recurrence_rule="FREQ=MONTHLY;BYDAY=4MO;COUNT=3",
+        )
+        try:
+            events = connector.get_events(
+                calendar_name=TEST_CALENDAR,
+                start_date="2028-01-01",
+                end_date="2028-04-30",
+            )
+            recurring = [e for e in events if e["uid"] == uid]
+            assert len(recurring) == 3, f"Expected 3 occurrences, got {len(recurring)}"
+
+            # Verify dates are all 4th Mondays
+            dates = sorted([e["start_date"][:10] for e in recurring])
+            assert dates[0] == "2028-01-26"  # 4th Monday of Jan
+            assert dates[1] == "2028-02-28"  # 4th Monday of Feb
+            assert dates[2] == "2028-03-27"  # 4th Monday of Mar
+        finally:
+            from tests.helpers.calendar_setup import delete_test_calendar, create_test_calendar
+            delete_test_calendar(TEST_CALENDAR)
+            create_test_calendar(TEST_CALENDAR)
+
+    def test_recurrence_with_until_end_date(self, connector):
+        """Create weekly event with UNTIL — verify recurrence stops (#81)."""
+        uid = connector.create_event(
+            calendar_name=TEST_CALENDAR,
+            summary="Until Test",
+            start_date="2028-03-01T10:00:00",
+            end_date="2028-03-01T11:00:00",
+            recurrence_rule="FREQ=WEEKLY;UNTIL=20280322T000000",
+        )
+        try:
+            events = connector.get_events(
+                calendar_name=TEST_CALENDAR,
+                start_date="2028-03-01",
+                end_date="2028-04-30",
+            )
+            recurring = [e for e in events if e["uid"] == uid]
+            # Should have ~3 occurrences (Mar 1, 8, 15) — Mar 22 is the UNTIL date
+            assert len(recurring) <= 4, f"Should stop by March 22, got {len(recurring)} occurrences"
+            assert len(recurring) >= 3, f"Should have at least 3 occurrences, got {len(recurring)}"
+
+            # No occurrence should be on or after March 22
+            for e in recurring:
+                assert e["start_date"][:10] < "2028-03-22", (
+                    f"Occurrence {e['start_date']} should be before UNTIL date 2028-03-22"
+                )
+        finally:
+            from tests.helpers.calendar_setup import delete_test_calendar, create_test_calendar
+            delete_test_calendar(TEST_CALENDAR)
+            create_test_calendar(TEST_CALENDAR)
+
+    def test_last_friday_recurrence(self, connector):
+        """Create monthly event on last Friday (BYDAY=-1FR) — verify correct dates (#79)."""
+        # Jan 27 2028 is the last Friday of January
+        uid = connector.create_event(
+            calendar_name=TEST_CALENDAR,
+            summary="Last Friday Test",
+            start_date="2028-01-28T10:00:00",
+            end_date="2028-01-28T11:00:00",
+            recurrence_rule="FREQ=MONTHLY;BYDAY=-1FR;COUNT=3",
+        )
+        try:
+            events = connector.get_events(
+                calendar_name=TEST_CALENDAR,
+                start_date="2028-01-01",
+                end_date="2028-04-30",
+            )
+            recurring = [e for e in events if e["uid"] == uid]
+            assert len(recurring) == 3, f"Expected 3 occurrences, got {len(recurring)}"
+
+            dates = sorted([e["start_date"][:10] for e in recurring])
+            assert dates[0] == "2028-01-28"  # Last Friday of Jan
+            assert dates[1] == "2028-02-25"  # Last Friday of Feb
+            assert dates[2] == "2028-03-31"  # Last Friday of Mar
+        finally:
+            from tests.helpers.calendar_setup import delete_test_calendar, create_test_calendar
+            delete_test_calendar(TEST_CALENDAR)
+            create_test_calendar(TEST_CALENDAR)
+
 
 class TestRoundTripIntegration:
     """Round-trip tests: create → read → use returned data to query again."""


### PR DESCRIPTION
## Summary

Fixes two RRULE parsing gaps that silently produced wrong recurrence patterns.

**#79 — BYDAY=NXX (nth weekday):** Parses numeric prefix from BYDAY values. `4MO` → 4th Monday, `-1FR` → last Friday. Uses `EKRecurrenceDayOfWeek(weekday, weekNumber:)`.

**#81 — UNTIL:** Parses UNTIL date in multiple formats (`20280322T000000Z`, `20280322T000000`, `20280322`). Uses `EKRecurrenceEnd(end: date)`.

### TDD approach
1. Wrote 3 failing integration tests (nth weekday, UNTIL, last Friday)
2. Fixed parser to make them pass

Closes #79, closes #81

## Test plan

- [x] `make test` — 133 unit tests pass
- [x] `make test-integration` — 41 integration tests pass (3 new)
- [x] New tests verify correct 4th Monday, last Friday, and UNTIL dates

🤖 Generated with [Claude Code](https://claude.com/claude-code)