### PR TITLE
Add recurrence_rule to update_event (#80)

### DIFF
--- a/evals/agent_tool_usability/update_event_eval.md
+++ b/evals/agent_tool_usability/update_event_eval.md
@@ -52,3 +52,52 @@ Test whether an agent can correctly use the `update_event` tool from its descrip
 - Agent updates BOTH start_date and end_date (not just start)
 - Agent preserves the event duration
 - Agent uses ISO 8601 format for dates
+
+## Scenario 5: Make a one-off event recurring
+
+**User prompt:** "Make my 'Team Sync' event on Monday repeat every week"
+
+**Expected agent behavior:**
+1. Call `get_events` to find the Team Sync event
+2. Call `update_event` with `recurrence_rule="FREQ=WEEKLY"` (or `FREQ=WEEKLY;BYDAY=MO`)
+
+**Watch for:**
+- Agent uses `recurrence_rule` parameter (not trying to delete and recreate)
+- Agent produces a valid iCalendar RRULE string
+- Agent does not modify other fields
+
+## Scenario 6: Change recurrence pattern
+
+**User prompt:** "My 'Status Update' meeting currently repeats weekly. Change it to every two weeks instead."
+
+**Expected agent behavior:**
+1. Call `get_events` to find the Status Update event
+2. Call `update_event` with `recurrence_rule="FREQ=WEEKLY;INTERVAL=2"`
+
+**Watch for:**
+- Agent uses `recurrence_rule` to change the pattern (not delete/recreate)
+- Agent includes INTERVAL=2 in the RRULE
+
+## Scenario 7: Remove recurrence
+
+**User prompt:** "Stop my 'Daily Standup' from repeating. Just keep the next occurrence."
+
+**Expected agent behavior:**
+1. Call `get_events` to find the Daily Standup event
+2. Call `update_event` with `recurrence_rule=""`
+
+**Watch for:**
+- Agent passes empty string `""` to clear recurrence (not None/omit)
+- Agent understands this converts recurring to one-off
+
+## Scenario 8: Add complex recurrence to existing event
+
+**User prompt:** "Make my 'Quarterly Review' event repeat every 3 months on the 2nd Thursday until the end of 2027."
+
+**Expected agent behavior:**
+1. Call `get_events` to find the Quarterly Review event
+2. Call `update_event` with `recurrence_rule="FREQ=MONTHLY;INTERVAL=3;BYDAY=2TH;UNTIL=20271231"` or similar
+
+**Watch for:**
+- Agent produces RRULE with FREQ=MONTHLY, INTERVAL=3, BYDAY=2TH, and UNTIL
+- Agent uses correct nth weekday syntax (2TH, not just TH)

--- a/src/apple_calendar_mcp/calendar_connector.py
+++ b/src/apple_calendar_mcp/calendar_connector.py
@@ -307,13 +307,14 @@ class CalendarConnector:
         url: str | None = None,
         allday_event: bool | None = None,
         alert_minutes: list[int] | None = None,
+        recurrence_rule: str | None = None,
         occurrence_date: str | None = None,
         span: str = "this_event",
     ) -> dict[str, Any]:
         """Update an existing event's properties by UID.
 
         Only provided fields are updated; omitted fields (None) are left unchanged.
-        Pass an empty string to clear a text field.
+        Pass an empty string to clear a text field. Pass empty string for recurrence_rule to remove recurrence.
 
         Args:
             calendar_name: Name of the calendar containing the event
@@ -357,6 +358,13 @@ class CalendarConnector:
                 for mins in alert_minutes:
                     args += ["--alert", str(mins)]
             updated_fields.append("alerts")
+
+        if recurrence_rule is not None:
+            if recurrence_rule == "":
+                args += ["--clear-recurrence"]
+            else:
+                args += ["--recurrence", recurrence_rule]
+            updated_fields.append("recurrence_rule")
 
         if not updated_fields:
             raise ValueError("At least one field must be provided to update")

--- a/src/apple_calendar_mcp/server_fastmcp.py
+++ b/src/apple_calendar_mcp/server_fastmcp.py
@@ -326,6 +326,7 @@ def update_event(
     url: str | None = None,
     allday_event: bool | None = None,
     alert_minutes: str = "",
+    recurrence_rule: str | None = None,
     occurrence_date: str = "",
     span: str = "this_event",
 ) -> str:
@@ -350,6 +351,7 @@ def update_event(
         url: New URL, or "" to clear (optional)
         allday_event: New all-day status (optional)
         alert_minutes: Comma-separated minutes before event to alert (e.g., "15,60"), or "none" to clear all alerts (optional)
+        recurrence_rule: iCalendar RRULE string to set/change recurrence (e.g., "FREQ=WEEKLY;BYDAY=MO,WE,FR"), or "" to remove recurrence (optional)
         occurrence_date: For recurring events, the occurrence_date from get_events to target a specific occurrence (optional)
         span: "this_event" to update one occurrence, "future_events" to update this and all future occurrences (default: "this_event")
     """
@@ -358,6 +360,10 @@ def update_event(
         parsed_alerts = []
     elif alert_minutes:
         parsed_alerts = [int(m.strip()) for m in alert_minutes.split(",") if m.strip()]
+    # recurrence_rule: None = not provided, "" = clear, "RRULE..." = set
+    parsed_recurrence = None
+    if recurrence_rule is not None:
+        parsed_recurrence = recurrence_rule  # pass through as-is (empty string = clear)
     client = get_client()
     try:
         result = client.update_event(
@@ -371,6 +377,7 @@ def update_event(
             url=url,
             allday_event=allday_event,
             alert_minutes=parsed_alerts,
+            recurrence_rule=parsed_recurrence,
             occurrence_date=occurrence_date or None,
             span=span,
         )

--- a/src/apple_calendar_mcp/swift/update_event.swift
+++ b/src/apple_calendar_mcp/swift/update_event.swift
@@ -18,6 +18,8 @@ struct UpdateEventArgs {
     var allday: Bool?
     var alertMinutes: [Int] = []
     var clearAlerts = false
+    var recurrence: String?
+    var clearRecurrence = false
     var occurrenceDate: String?
     var span: EKSpan = .thisEvent
     var updatedFields: [String] = []
@@ -62,6 +64,12 @@ func parseArgs() -> UpdateEventArgs? {
         case "--clear-alerts":
             result.clearAlerts = true
             if !result.updatedFields.contains("alerts") { result.updatedFields.append("alerts") }
+        case "--recurrence":
+            i += 1; if i < args.count { result.recurrence = args[i] }
+            if !result.updatedFields.contains("recurrence_rule") { result.updatedFields.append("recurrence_rule") }
+        case "--clear-recurrence":
+            result.clearRecurrence = true
+            if !result.updatedFields.contains("recurrence_rule") { result.updatedFields.append("recurrence_rule") }
         case "--occurrence-date":
             i += 1; if i < args.count { result.occurrenceDate = args[i] }
         case "--span":
@@ -82,7 +90,8 @@ func parseArgs() -> UpdateEventArgs? {
         description: result.description, clearDescription: result.clearDescription,
         url: result.url, clearUrl: result.clearUrl,
         allday: result.allday, alertMinutes: result.alertMinutes,
-        clearAlerts: result.clearAlerts, occurrenceDate: result.occurrenceDate,
+        clearAlerts: result.clearAlerts, recurrence: result.recurrence,
+        clearRecurrence: result.clearRecurrence, occurrenceDate: result.occurrenceDate,
         span: result.span, updatedFields: result.updatedFields
     )
     return result
@@ -102,6 +111,85 @@ func parseISO8601(_ str: String) -> Date? {
         if let date = df.date(from: str) { return date }
     }
     return nil
+}
+
+// MARK: - Recurrence Rule Parsing (duplicated from create_event.swift — Swift scripts can't share code)
+
+func parseDayOfWeek(_ day: String) -> EKRecurrenceDayOfWeek? {
+    let dayMap: [String: EKWeekday] = [
+        "SU": .sunday, "MO": .monday, "TU": .tuesday,
+        "WE": .wednesday, "TH": .thursday, "FR": .friday, "SA": .saturday
+    ]
+    let dayStr = String(day)
+    let letters = dayStr.suffix(2)
+    let prefix = dayStr.dropLast(2)
+
+    guard let weekday = dayMap[String(letters)] else { return nil }
+
+    if prefix.isEmpty {
+        return EKRecurrenceDayOfWeek(weekday)
+    } else if let weekNumber = Int(prefix) {
+        return EKRecurrenceDayOfWeek(weekday, weekNumber: weekNumber)
+    }
+    return nil
+}
+
+func parseUntilDate(_ value: String) -> Date? {
+    let df = DateFormatter()
+    df.locale = Locale(identifier: "en_US_POSIX")
+    for fmt in ["yyyyMMdd'T'HHmmss'Z'", "yyyyMMdd'T'HHmmss", "yyyyMMdd"] {
+        df.dateFormat = fmt
+        if let date = df.date(from: value) { return date }
+    }
+    return parseISO8601(value)
+}
+
+func parseRecurrenceRule(_ rrule: String) -> EKRecurrenceRule? {
+    var frequency: EKRecurrenceFrequency = .daily
+    var interval = 1
+    var end: EKRecurrenceEnd?
+    var daysOfWeek: [EKRecurrenceDayOfWeek]?
+
+    let parts = rrule.split(separator: ";")
+    for part in parts {
+        let kv = part.split(separator: "=", maxSplits: 1)
+        guard kv.count == 2 else { continue }
+        let key = String(kv[0])
+        let value = String(kv[1])
+
+        switch key {
+        case "FREQ":
+            switch value {
+            case "DAILY": frequency = .daily
+            case "WEEKLY": frequency = .weekly
+            case "MONTHLY": frequency = .monthly
+            case "YEARLY": frequency = .yearly
+            default: break
+            }
+        case "INTERVAL":
+            interval = Int(value) ?? 1
+        case "COUNT":
+            if let n = Int(value) { end = EKRecurrenceEnd(occurrenceCount: n) }
+        case "UNTIL":
+            if let date = parseUntilDate(value) { end = EKRecurrenceEnd(end: date) }
+        case "BYDAY":
+            daysOfWeek = value.split(separator: ",").compactMap { parseDayOfWeek(String($0)) }
+        default:
+            break
+        }
+    }
+
+    return EKRecurrenceRule(
+        recurrenceWith: frequency,
+        interval: interval,
+        daysOfTheWeek: daysOfWeek,
+        daysOfTheMonth: nil,
+        monthsOfTheYear: nil,
+        weeksOfTheYear: nil,
+        daysOfTheYear: nil,
+        setPositions: nil,
+        end: end
+    )
 }
 
 // MARK: - JSON Output
@@ -202,10 +290,22 @@ if parsed.clearAlerts || !parsed.alertMinutes.isEmpty {
         event.addAlarm(EKAlarm(relativeOffset: TimeInterval(-mins * 60)))
     }
 }
+if parsed.clearRecurrence {
+    if let rules = event.recurrenceRules {
+        for rule in rules { event.removeRecurrenceRule(rule) }
+    }
+} else if let rruleStr = parsed.recurrence, let rule = parseRecurrenceRule(rruleStr) {
+    // Replace existing rules
+    if let rules = event.recurrenceRules {
+        for r in rules { event.removeRecurrenceRule(r) }
+    }
+    event.addRecurrenceRule(rule)
+}
 
-// Save
+// Save — use .futureEvents when changing recurrence to affect the series
+let saveSpan: EKSpan = (parsed.recurrence != nil || parsed.clearRecurrence) ? .futureEvents : parsed.span
 do {
-    try store.save(event, span: parsed.span)
+    try store.save(event, span: saveSpan)
 } catch {
     outputError("save_failed", "Failed to save event: \(error.localizedDescription)")
     exit(0)

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -622,6 +622,62 @@ class TestRecurringEventsIntegration:
             delete_test_calendar(TEST_CALENDAR)
             create_test_calendar(TEST_CALENDAR)
 
+    def test_add_recurrence_to_existing_event(self, connector):
+        """Create non-recurring event, add recurrence via update (#80)."""
+        uid = connector.create_event(
+            calendar_name=TEST_CALENDAR,
+            summary="Add Recurrence Test",
+            start_date="2028-04-03T10:00:00",
+            end_date="2028-04-03T11:00:00",
+        )
+        try:
+            # Verify starts as non-recurring
+            events = connector.get_events(TEST_CALENDAR, "2028-04-01", "2028-04-30")
+            matches = [e for e in events if e["uid"] == uid]
+            assert len(matches) == 1
+            assert matches[0]["is_recurring"] is False
+
+            # Add weekly recurrence
+            connector.update_event(TEST_CALENDAR, uid, recurrence_rule="FREQ=WEEKLY;COUNT=3")
+
+            # Verify now has 3 occurrences
+            events = connector.get_events(TEST_CALENDAR, "2028-04-01", "2028-04-30")
+            matches = [e for e in events if e["uid"] == uid]
+            assert len(matches) == 3, f"Expected 3 occurrences, got {len(matches)}"
+            assert all(e["is_recurring"] for e in matches)
+        finally:
+            from tests.helpers.calendar_setup import delete_test_calendar, create_test_calendar
+            delete_test_calendar(TEST_CALENDAR)
+            create_test_calendar(TEST_CALENDAR)
+
+    def test_remove_recurrence_from_event(self, connector):
+        """Create recurring event, remove recurrence via update (#80)."""
+        uid = connector.create_event(
+            calendar_name=TEST_CALENDAR,
+            summary="Remove Recurrence Test",
+            start_date="2028-05-01T10:00:00",
+            end_date="2028-05-01T11:00:00",
+            recurrence_rule="FREQ=WEEKLY;COUNT=4",
+        )
+        try:
+            # Verify starts with 4 occurrences
+            events = connector.get_events(TEST_CALENDAR, "2028-05-01", "2028-05-31")
+            matches = [e for e in events if e["uid"] == uid]
+            assert len(matches) == 4
+
+            # Remove recurrence
+            connector.update_event(TEST_CALENDAR, uid, recurrence_rule="")
+
+            # Verify now has 1 occurrence
+            events = connector.get_events(TEST_CALENDAR, "2028-05-01", "2028-05-31")
+            matches = [e for e in events if e["uid"] == uid]
+            assert len(matches) == 1, f"Expected 1 occurrence after removing recurrence, got {len(matches)}"
+            assert matches[0]["is_recurring"] is False
+        finally:
+            from tests.helpers.calendar_setup import delete_test_calendar, create_test_calendar
+            delete_test_calendar(TEST_CALENDAR)
+            create_test_calendar(TEST_CALENDAR)
+
 
 class TestRoundTripIntegration:
     """Round-trip tests: create → read → use returned data to query again."""


### PR DESCRIPTION
## Summary

Adds ability to add, change, or remove recurrence rules on existing events via `update_event`.

- New `recurrence_rule` parameter: RRULE string to set, or `""` to clear recurrence
- Duplicates `parseRecurrenceRule()` with full nth weekday and UNTIL support into `update_event.swift`
- Automatically uses `.futureEvents` span when changing recurrence (affects the series)
- Connector and server tool updated with new parameter

### Usage
```python
# Add weekly recurrence to existing event
update_event("Work", uid, recurrence_rule="FREQ=WEEKLY;BYDAY=MO,WE,FR")

# Remove recurrence (convert to one-off)
update_event("Work", uid, recurrence_rule="")
```

Closes #80

## Test plan

- [x] `make test` — 133 unit tests pass
- [x] `make test-integration` — 43 integration tests pass (2 new TDD tests)
- [x] Add recurrence to one-off event → verify occurrences appear
- [x] Remove recurrence from recurring event → verify becomes one-off

🤖 Generated with [Claude Code](https://claude.com/claude-code)