### PR TITLE
Fix date changes on recurring events: reschedule instead of delete (#82)

### DIFF
--- a/src/apple_calendar_mcp/swift/update_event.swift
+++ b/src/apple_calendar_mcp/swift/update_event.swift
@@ -236,16 +236,27 @@ if !accessGranted {
 store.refreshSourcesIfNecessary()
 
 // Find event by UID (and optionally by occurrence date)
-let items = store.calendarItems(withExternalIdentifier: parsed.uid)
-var matches = items.compactMap { $0 as? EKEvent }.filter { $0.calendar.title == parsed.calendar }
+var event: EKEvent?
 
-// If occurrence date specified, find the specific occurrence
 if let occDateStr = parsed.occurrenceDate, let occDate = parseISO8601(occDateStr) {
-    let tolerance: TimeInterval = 60 // 1 minute tolerance
-    matches = matches.filter { abs($0.occurrenceDate.timeIntervalSince(occDate)) < tolerance }
+    // For specific occurrences: use date predicate (calendarItems only returns base event)
+    let cal = store.calendars(for: .event).first { $0.title == parsed.calendar }
+    if let cal = cal {
+        let dayBefore = occDate.addingTimeInterval(-86400)
+        let dayAfter = occDate.addingTimeInterval(86400)
+        let pred = store.predicateForEvents(withStart: dayBefore, end: dayAfter, calendars: [cal])
+        let tolerance: TimeInterval = 60
+        event = store.events(matching: pred)
+            .filter { $0.calendarItemIdentifier == parsed.uid }
+            .first { abs($0.occurrenceDate.timeIntervalSince(occDate)) < tolerance }
+    }
+} else {
+    // No occurrence date: use calendarItems lookup (works for non-recurring)
+    let items = store.calendarItems(withExternalIdentifier: parsed.uid)
+    event = items.compactMap { $0 as? EKEvent }.first { $0.calendar.title == parsed.calendar }
 }
 
-guard let event = matches.first else {
+guard let event = event else {
     outputError("event_not_found", "Event not found: \(parsed.uid)")
     exit(0)
 }
@@ -302,7 +313,63 @@ if parsed.clearRecurrence {
     event.addRecurrenceRule(rule)
 }
 
-// Save — use .futureEvents when changing recurrence to affect the series
+// Determine if this is a date change on a recurring event with .thisEvent
+let isDateChange = parsed.start != nil || parsed.end != nil
+let isRecurringThisEvent = event.hasRecurrenceRules && parsed.span == .thisEvent && parsed.occurrenceDate != nil
+
+if isDateChange && isRecurringThisEvent {
+    // Emulate Calendar.app: remove occurrence from series, create standalone event at new time
+    let newTitle = parsed.summary ?? event.title ?? ""
+    let newStart = (parsed.start != nil ? parseISO8601(parsed.start!) : nil) ?? event.startDate!
+    let newEnd = (parsed.end != nil ? parseISO8601(parsed.end!) : nil) ?? event.endDate!
+    let newLocation = parsed.clearLocation ? nil : (parsed.location ?? event.location)
+    let newNotes = parsed.clearDescription ? nil : (parsed.description ?? event.notes)
+    let newUrl = parsed.clearUrl ? nil : (parsed.url.flatMap { URL(string: $0) } ?? event.url)
+    let newAllDay = parsed.allday ?? event.isAllDay
+    let newAlarms = event.alarms
+
+    // Remove the occurrence from the series
+    do {
+        try store.remove(event, span: .thisEvent)
+    } catch {
+        outputError("remove_failed", "Failed to remove occurrence: \(error.localizedDescription)")
+        exit(0)
+    }
+
+    // Create standalone event with same properties at new time
+    let newEvent = EKEvent(eventStore: store)
+    newEvent.calendar = event.calendar
+    newEvent.title = newTitle
+    newEvent.startDate = newStart
+    newEvent.endDate = newEnd
+    newEvent.isAllDay = newAllDay
+    newEvent.location = newLocation
+    newEvent.notes = newNotes
+    newEvent.url = newUrl
+    if let alarms = newAlarms {
+        for alarm in alarms { newEvent.addAlarm(EKAlarm(relativeOffset: alarm.relativeOffset)) }
+    }
+
+    do {
+        try store.save(newEvent, span: .thisEvent)
+    } catch {
+        outputError("save_failed", "Failed to create rescheduled event: \(error.localizedDescription)")
+        exit(0)
+    }
+
+    let result: [String: Any] = [
+        "uid": newEvent.calendarItemIdentifier,
+        "updated_fields": parsed.updatedFields,
+        "rescheduled": true,
+    ]
+    if let data = try? JSONSerialization.data(withJSONObject: result, options: [.sortedKeys]),
+       let str = String(data: data, encoding: .utf8) {
+        print(str)
+    }
+    exit(0)
+}
+
+// Normal save path
 let saveSpan: EKSpan = (parsed.recurrence != nil || parsed.clearRecurrence) ? .futureEvents : parsed.span
 do {
     try store.save(event, span: saveSpan)

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -678,6 +678,52 @@ class TestRecurringEventsIntegration:
             delete_test_calendar(TEST_CALENDAR)
             create_test_calendar(TEST_CALENDAR)
 
+    def test_reschedule_single_occurrence(self, connector):
+        """Reschedule one occurrence of a recurring event — should create standalone event (#82)."""
+        uid = connector.create_event(
+            calendar_name=TEST_CALENDAR,
+            summary="Reschedule Test",
+            start_date="2028-06-05T10:00:00",
+            end_date="2028-06-05T11:00:00",
+            recurrence_rule="FREQ=WEEKLY;COUNT=3",
+            location="Room A",
+        )
+        try:
+            # Verify 3 occurrences: Jun 5, 12, 19
+            events = connector.get_events(TEST_CALENDAR, "2028-06-01", "2028-06-30")
+            series = [e for e in events if e["uid"] == uid]
+            assert len(series) == 3
+
+            # Reschedule the Jun 12 occurrence to 2pm
+            result = connector.update_event(
+                TEST_CALENDAR, uid,
+                start_date="2028-06-12T14:00:00",
+                end_date="2028-06-12T15:00:00",
+                occurrence_date="2028-06-12T10:00:00",
+                span="this_event",
+            )
+
+            # Check results
+            events = connector.get_events(TEST_CALENDAR, "2028-06-01", "2028-06-30")
+
+            # Series should still have occurrences (Jun 5 and Jun 19 at 10am)
+            remaining_series = [e for e in events if e["uid"] == uid]
+            assert len(remaining_series) >= 2, (
+                f"Series should still have at least 2 occurrences, got {len(remaining_series)}"
+            )
+
+            # A standalone event should exist at 2pm on Jun 12 with same summary and location
+            jun12_events = [e for e in events if "2028-06-12" in e["start_date"]]
+            assert len(jun12_events) >= 1, "Should have an event on Jun 12 at the new time"
+            rescheduled = [e for e in jun12_events if "14:00" in e["start_date"]]
+            assert len(rescheduled) == 1, f"Should have one event at 2pm on Jun 12, got {len(rescheduled)}"
+            assert rescheduled[0]["summary"] == "Reschedule Test"
+            assert rescheduled[0]["location"] == "Room A"
+        finally:
+            from tests.helpers.calendar_setup import delete_test_calendar, create_test_calendar
+            delete_test_calendar(TEST_CALENDAR)
+            create_test_calendar(TEST_CALENDAR)
+
 
 class TestRoundTripIntegration:
     """Round-trip tests: create → read → use returned data to query again."""


### PR DESCRIPTION
## Summary

**CRITICAL FIX:** Previously, changing the time of a single occurrence of a recurring event silently deleted that occurrence. Now it emulates Calendar.app behavior:

1. Removes the occurrence from the series
2. Creates a new standalone event at the new time with all the same properties (summary, location, description, url, alerts, allday)
3. Returns the new event's UID

Also fixes occurrence lookup — `calendarItems(withExternalIdentifier:)` only returns the base event for recurring series, not individual occurrences. Now uses `predicateForEvents` with a date range when `occurrence_date` is specified.

### Behavior matrix

| Change | span=this_event | span=future_events |
|--------|----------------|-------------------|
| Non-date fields (title, location, etc.) | Detaches occurrence, modifies it | Modifies series from that point |
| Date/time change | **Removes occurrence + creates standalone** | Shifts series from that point |
| Recurrence rule | N/A | Replaces series recurrence |

Closes #82

## Test plan

- [x] `make test` — 133 unit tests pass
- [x] `make test-integration` — 44 integration tests pass (1 new TDD test)
- [x] New test: create weekly recurring → reschedule one occurrence → verify series preserved AND standalone event at new time with same properties

🤖 Generated with [Claude Code](https://claude.com/claude-code)