### PR TITLE
Fix delete_events for recurring events: add occurrence_date support (#84)

### DIFF
--- a/src/apple_calendar_mcp/calendar_connector.py
+++ b/src/apple_calendar_mcp/calendar_connector.py
@@ -420,6 +420,7 @@ class CalendarConnector:
         calendar_name: str,
         event_uids: str | list[str],
         span: str = "this_event",
+        occurrence_date: Optional[str] = None,
     ) -> dict[str, Any]:
         """Delete one or more events by UID.
 
@@ -427,6 +428,7 @@ class CalendarConnector:
             calendar_name: Name of the calendar containing the events
             event_uids: Single UID string or list of UIDs to delete
             span: "this_event" to delete one occurrence, "future_events" to delete series from this point (default: "this_event")
+            occurrence_date: For recurring events, the date of the specific occurrence to delete (optional)
 
         Returns:
             Dict with 'deleted_uids' and 'not_found_uids' keys
@@ -446,6 +448,8 @@ class CalendarConnector:
             args += ["--uid", uid]
         if span != "this_event":
             args += ["--span", span]
+        if occurrence_date:
+            args += ["--occurrence-date", occurrence_date]
 
         parsed = self._run_swift_helper_json("delete_events", args)
         return {"deleted_uids": parsed["deleted_uids"], "not_found_uids": parsed["not_found_uids"]}

--- a/src/apple_calendar_mcp/server_fastmcp.py
+++ b/src/apple_calendar_mcp/server_fastmcp.py
@@ -393,6 +393,7 @@ def delete_events(
     calendar_name: str,
     event_uid: str | list[str],
     span: str = "this_event",
+    occurrence_date: str = "",
 ) -> str:
     """Delete one or more events from a calendar by UID.
 
@@ -401,12 +402,15 @@ def delete_events(
 
     Use get_events first to find the event UID(s) and calendar_name.
 
-    For recurring events: use span to control deletion scope.
+    For recurring events: use occurrence_date to target a specific occurrence,
+    and span to control deletion scope. Without occurrence_date, deletes the
+    base event (which may affect the entire series).
 
     Args:
         calendar_name: Exact name of the calendar containing the event(s)
         event_uid: UID of a single event (str) or list of UIDs to delete
         span: "this_event" to delete one occurrence, "future_events" to delete the series from this point onward (default: "this_event")
+        occurrence_date: For recurring events, the occurrence_date from get_events to target a specific occurrence (optional)
     """
     client = get_client()
     try:
@@ -414,6 +418,7 @@ def delete_events(
             calendar_name=calendar_name,
             event_uids=event_uid,
             span=span,
+            occurrence_date=occurrence_date or None,
         )
     except Exception as e:
         return f"Error deleting event(s): {e}"

--- a/src/apple_calendar_mcp/swift/delete_events.swift
+++ b/src/apple_calendar_mcp/swift/delete_events.swift
@@ -3,11 +3,12 @@ import Foundation
 
 // MARK: - Argument Parsing
 
-func parseArgs() -> (calendar: String, uids: [String], span: EKSpan)? {
+func parseArgs() -> (calendar: String, uids: [String], span: EKSpan, occurrenceDate: String?)? {
     let args = CommandLine.arguments
     var calendar: String?
     var uids: [String] = []
     var span: EKSpan = .thisEvent
+    var occurrenceDate: String?
 
     var i = 1
     while i < args.count {
@@ -18,6 +19,8 @@ func parseArgs() -> (calendar: String, uids: [String], span: EKSpan)? {
             i += 1; if i < args.count { uids.append(args[i]) }
         case "--span":
             i += 1; if i < args.count { span = args[i] == "future_events" ? .futureEvents : .thisEvent }
+        case "--occurrence-date":
+            i += 1; if i < args.count { occurrenceDate = args[i] }
         default:
             break
         }
@@ -27,7 +30,23 @@ func parseArgs() -> (calendar: String, uids: [String], span: EKSpan)? {
     guard let cal = calendar, !uids.isEmpty else {
         return nil
     }
-    return (cal, uids, span)
+    return (cal, uids, span, occurrenceDate)
+}
+
+// MARK: - Date Parsing
+
+func parseISO8601(_ str: String) -> Date? {
+    let isoFormatter = ISO8601DateFormatter()
+    isoFormatter.formatOptions = [.withInternetDateTime]
+    if let date = isoFormatter.date(from: str) { return date }
+
+    let df = DateFormatter()
+    df.locale = Locale(identifier: "en_US_POSIX")
+    for fmt in ["yyyy-MM-dd'T'HH:mm:ss", "yyyy-MM-dd"] {
+        df.dateFormat = fmt
+        if let date = df.date(from: str) { return date }
+    }
+    return nil
 }
 
 // MARK: - JSON Output
@@ -76,23 +95,34 @@ guard let calendar = allCalendars.first(where: { $0.title == parsed.calendar }) 
     exit(0)
 }
 
-// Delete events by UID using direct calendarItem lookup
+// Delete events by UID
 var deletedUids: [String] = []
 var notFoundUids: [String] = []
 
 for uid in parsed.uids {
-    let items = store.calendarItems(withExternalIdentifier: uid)
-    let matches = items.compactMap { $0 as? EKEvent }.filter { $0.calendar.title == parsed.calendar }
+    var matches: [EKEvent] = []
+
+    // If occurrence_date provided, use predicate-based lookup (for recurring events)
+    if let occDateStr = parsed.occurrenceDate, let occDate = parseISO8601(occDateStr) {
+        let dayBefore = occDate.addingTimeInterval(-86400)
+        let dayAfter = occDate.addingTimeInterval(86400)
+        let pred = store.predicateForEvents(withStart: dayBefore, end: dayAfter, calendars: [calendar])
+        let tolerance: TimeInterval = 60
+        matches = store.events(matching: pred)
+            .filter { $0.calendarItemIdentifier == uid && abs($0.occurrenceDate.timeIntervalSince(occDate)) < tolerance }
+    } else {
+        // No occurrence date: use calendarItems lookup
+        let items = store.calendarItems(withExternalIdentifier: uid)
+        matches = items.compactMap { $0 as? EKEvent }.filter { $0.calendar.title == parsed.calendar }
+    }
+
     if matches.isEmpty {
         notFoundUids.append(uid)
     } else {
         do {
             if parsed.span == .futureEvents {
-                // For futureEvents, remove the first match with futureEvents span
-                // (this deletes the series from this occurrence onward)
                 try store.remove(matches.first!, span: .futureEvents, commit: false)
             } else {
-                // For thisEvent, remove all matching occurrences individually
                 for event in matches {
                     try store.remove(event, span: .thisEvent, commit: false)
                 }

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -460,6 +460,67 @@ class TestDeleteEventsIntegration:
         finally:
             _delete_event_by_uid(uid)
 
+    def test_delete_single_occurrence_of_recurring(self, connector):
+        """Delete one occurrence of a recurring event, verify others preserved (#84)."""
+        uid = connector.create_event(
+            calendar_name=TEST_CALENDAR,
+            summary="Delete Occurrence Test",
+            start_date="2028-08-07T10:00:00",
+            end_date="2028-08-07T11:00:00",
+            recurrence_rule="FREQ=WEEKLY;COUNT=3",
+        )
+        try:
+            # Verify 3 occurrences: Aug 7, 14, 21
+            events = connector.get_events(TEST_CALENDAR, "2028-08-01", "2028-08-31")
+            series = [e for e in events if e["uid"] == uid]
+            assert len(series) == 3
+
+            # Delete the middle occurrence (Aug 14)
+            result = connector.delete_events(
+                TEST_CALENDAR, uid,
+                span="this_event",
+                occurrence_date="2028-08-14T10:00:00",
+            )
+            assert uid in result["deleted_uids"]
+
+            # Verify 2 remaining occurrences (Aug 7 and 21)
+            events = connector.get_events(TEST_CALENDAR, "2028-08-01", "2028-08-31")
+            remaining = [e for e in events if e["uid"] == uid]
+            assert len(remaining) == 2, f"Expected 2 occurrences after deleting one, got {len(remaining)}"
+            dates = sorted([e["start_date"][:10] for e in remaining])
+            assert "2028-08-14" not in dates, "Deleted occurrence should be gone"
+        finally:
+            from tests.helpers.calendar_setup import delete_test_calendar, create_test_calendar
+            delete_test_calendar(TEST_CALENDAR)
+            create_test_calendar(TEST_CALENDAR)
+
+    def test_delete_recurring_series_with_future_events(self, connector):
+        """Delete a recurring series using span=future_events (#84)."""
+        uid = connector.create_event(
+            calendar_name=TEST_CALENDAR,
+            summary="Delete Series Test",
+            start_date="2028-09-02T10:00:00",
+            end_date="2028-09-02T11:00:00",
+            recurrence_rule="FREQ=WEEKLY;COUNT=4",
+        )
+        try:
+            events = connector.get_events(TEST_CALENDAR, "2028-09-01", "2028-09-30")
+            series = [e for e in events if e["uid"] == uid]
+            assert len(series) == 4
+
+            # Delete entire series
+            result = connector.delete_events(TEST_CALENDAR, uid, span="future_events")
+            assert uid in result["deleted_uids"]
+
+            # Verify all gone
+            events = connector.get_events(TEST_CALENDAR, "2028-09-01", "2028-09-30")
+            remaining = [e for e in events if e["uid"] == uid]
+            assert len(remaining) == 0, f"Expected 0 occurrences after deleting series, got {len(remaining)}"
+        finally:
+            from tests.helpers.calendar_setup import delete_test_calendar, create_test_calendar
+            delete_test_calendar(TEST_CALENDAR)
+            create_test_calendar(TEST_CALENDAR)
+
 
 class TestGetAvailabilityIntegration:
     """Integration tests for get_availability against real Calendar.app."""

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -524,6 +524,7 @@ class TestDeleteEventsTool:
             calendar_name="Work",
             event_uids=["UID-1", "UID-2"],
             span="this_event",
+            occurrence_date=None,
         )
 
 


### PR DESCRIPTION
## Summary

- Adds `occurrence_date` parameter to `delete_events` for targeting specific occurrences of recurring events
- Uses predicate-based lookup (same fix as #82 for update_event) since `calendarItems(withExternalIdentifier:)` only returns the base event
- Updates tool docstring documenting recurring event delete behavior

Closes #84

## Test plan

- [x] `make test` — 133 unit tests pass
- [x] `make test-integration` — 46 integration tests pass (2 new)
- [x] Delete single occurrence → other occurrences preserved
- [x] Delete series with span=future_events → all gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)