### PR TITLE
Add calendar type and event editability fields (#76)

### DIFF
--- a/src/apple_calendar_mcp/server_fastmcp.py
+++ b/src/apple_calendar_mcp/server_fastmcp.py
@@ -10,11 +10,11 @@ from .calendar_connector import CalendarConnector
 # Create FastMCP server
 mcp = FastMCP("apple-calendar-mcp", instructions="""Apple Calendar is the built-in macOS calendar application. This MCP server provides tools to interact with it.
 
-CALENDARS: Each calendar has a name, writable status, description, and color. Calendar names are NOT guaranteed unique — the same name can appear across different accounts (e.g., two "Family" calendars from iCloud and Google). Use description to disambiguate when needed.
+CALENDARS: Each calendar has a name, writable status, type (caldav, subscription, birthday, local), description, and color. Calendar names are NOT guaranteed unique — the same name can appear across different accounts (e.g., two "Family" calendars from iCloud and Google). Use description to disambiguate when needed.
 
 CALENDAR IDENTIFICATION: Calendars are identified by name (not UID — UIDs are not accessible via AppleScript). When specifying a calendar, use the exact name as returned by get_calendars.
 
-EVENTS: Events have summary (title), start/end dates, location, description (notes), URL, status, recurrence, and attendees. Events are identified by their UID (UUID format). Attendees are read-only — they cannot be added via this server (use Calendar.app or email invitations).
+EVENTS: Events have summary (title), start/end dates, location, description (notes), URL, status, recurrence, attendees, and editability info. Events are identified by their UID (UUID format). The is_editable field indicates whether the event can be modified — events on read-only calendars or events where you are not the organizer (invited events) are not editable. Attendees are read-only — they cannot be added via this server (use Calendar.app or email invitations).
 
 RECURRING EVENTS: Recurring events share the same UID across all occurrences. Each occurrence has a unique occurrence_date. The is_recurring field indicates if an event is part of a series. The recurrence_rule field contains the iCalendar RRULE (e.g., "FREQ=WEEKLY;INTERVAL=1;BYDAY=MO,WE,FR"). To modify or delete a specific occurrence, pass occurrence_date and span="this_event". To modify or delete the series from a point onward, use span="future_events".
 

--- a/src/apple_calendar_mcp/swift/get_calendars.swift
+++ b/src/apple_calendar_mcp/swift/get_calendars.swift
@@ -48,12 +48,24 @@ store.refreshSourcesIfNecessary()
 
 let calendars = store.calendars(for: .event)
 
+func calendarTypeString(_ type: EKCalendarType) -> String {
+    switch type {
+    case .local: return "local"
+    case .calDAV: return "caldav"
+    case .exchange: return "exchange"
+    case .subscription: return "subscription"
+    case .birthday: return "birthday"
+    @unknown default: return "unknown"
+    }
+}
+
 let calendarDicts: [[String: Any]] = calendars.map { cal in
     [
         "name": cal.title,
         "writable": cal.allowsContentModifications,
         "description": (cal as EKCalendar).value(forKey: "notes") as? String ?? "",
         "color": cgColorToHex(cal.cgColor),
+        "type": calendarTypeString(cal.type),
     ]
 }
 

--- a/src/apple_calendar_mcp/swift/get_events.swift
+++ b/src/apple_calendar_mcp/swift/get_events.swift
@@ -134,6 +134,11 @@ func eventToDict(_ event: EKEvent) -> [String: Any] {
         ] as [String: String]
     }
 
+    // Editability
+    let isOrganizer = event.organizer?.isCurrentUser ?? true
+    dict["is_organizer"] = isOrganizer
+    dict["is_editable"] = event.calendar.allowsContentModifications && isOrganizer
+
     return dict
 }
 


### PR DESCRIPTION
## Summary

- `get_calendars` now includes `type` field: caldav, subscription, birthday, local, exchange
- `get_events` now includes `is_organizer` (raw) and `is_editable` (computed: calendar writable AND is organizer)
- Server instructions updated to document editability

Agents can now check `is_editable` before attempting updates, preventing failed operations on invited events or subscription calendars.

Closes #76

## Test plan

- [x] `make test` — 133 unit tests pass
- [x] `make test-integration` — 46 integration tests pass
- [x] Verified: calendar types correct (caldav, birthday, subscription)
- [x] Verified: is_editable/is_organizer correct for Work calendar events

🤖 Generated with [Claude Code](https://claude.com/claude-code)