### PR TITLE
Support event availability status (free/busy/tentative) (#90)

### DIFF
--- a/src/apple_calendar_mcp/calendar_connector.py
+++ b/src/apple_calendar_mcp/calendar_connector.py
@@ -156,6 +156,7 @@ class CalendarConnector:
         allday_event: bool = False,
         recurrence_rule: Optional[str] = None,
         alert_minutes: Optional[list[int]] = None,
+        availability: Optional[str] = None,
     ) -> str:
         """Create a new event in a specified calendar.
 
@@ -198,6 +199,8 @@ class CalendarConnector:
         if alert_minutes:
             for mins in alert_minutes:
                 args += ["--alert", str(mins)]
+        if availability:
+            args += ["--availability", availability]
 
         parsed = self._run_swift_helper_json("create_event", args)
         return parsed["uid"]
@@ -307,6 +310,7 @@ class CalendarConnector:
         url: str | None = None,
         allday_event: bool | None = None,
         alert_minutes: list[int] | None = None,
+        availability: str | None = None,
         recurrence_rule: str | None = None,
         occurrence_date: str | None = None,
         span: str = "this_event",
@@ -365,6 +369,10 @@ class CalendarConnector:
             else:
                 args += ["--recurrence", recurrence_rule]
             updated_fields.append("recurrence_rule")
+
+        if availability is not None:
+            args += ["--availability", availability]
+            updated_fields.append("availability")
 
         if not updated_fields:
             raise ValueError("At least one field must be provided to update")

--- a/src/apple_calendar_mcp/server_fastmcp.py
+++ b/src/apple_calendar_mcp/server_fastmcp.py
@@ -117,6 +117,7 @@ def create_event(
     allday_event: bool = False,
     recurrence_rule: str = "",
     alert_minutes: str = "",
+    availability: str = "",
 ) -> str:
     """Create a new event in a specified calendar.
 
@@ -131,6 +132,7 @@ def create_event(
         allday_event: Whether this is an all-day event (default: false). When true, use date-only format for start_date/end_date.
         recurrence_rule: iCalendar RRULE string for recurring events (optional, e.g., "FREQ=WEEKLY;BYDAY=MO,WE,FR" or "FREQ=DAILY;COUNT=10")
         alert_minutes: Comma-separated minutes before event to alert (optional, e.g., "15" or "15,60")
+        availability: Event availability status: "free", "busy", or "tentative" (optional, default: busy)
     """
     parsed_alerts = [int(m.strip()) for m in alert_minutes.split(",") if m.strip()] if alert_minutes else None
     client = get_client()
@@ -146,6 +148,7 @@ def create_event(
             allday_event=allday_event,
             recurrence_rule=recurrence_rule or None,
             alert_minutes=parsed_alerts,
+            availability=availability or None,
         )
     except Exception as e:
         return f"Error creating event: {e}"
@@ -185,6 +188,9 @@ def _format_event(event: dict) -> str:
     if attendees:
         names = [a.get("name") or a.get("email", "unknown") for a in attendees]
         result += f"Attendees ({len(attendees)}): {', '.join(names)}\n"
+    avail = event.get("availability", "busy")
+    if avail and avail != "busy":
+        result += f"Availability: {avail}\n"
     result += f"Status: {event.get('status', 'none')}\n"
     result += f"UID: {event['uid']}\n"
     return result
@@ -326,6 +332,7 @@ def update_event(
     url: str | None = None,
     allday_event: bool | None = None,
     alert_minutes: str = "",
+    availability: str | None = None,
     recurrence_rule: str | None = None,
     occurrence_date: str = "",
     span: str = "this_event",
@@ -351,6 +358,7 @@ def update_event(
         url: New URL, or "" to clear (optional)
         allday_event: New all-day status (optional)
         alert_minutes: Comma-separated minutes before event to alert (e.g., "15,60"), or "none" to clear all alerts (optional)
+        availability: Event availability: "free", "busy", or "tentative" (optional)
         recurrence_rule: iCalendar RRULE string to set/change recurrence (e.g., "FREQ=WEEKLY;BYDAY=MO,WE,FR"), or "" to remove recurrence (optional)
         occurrence_date: For recurring events, the occurrence_date from get_events to target a specific occurrence (optional)
         span: "this_event" to update one occurrence, "future_events" to update this and all future occurrences (default: "this_event")
@@ -377,6 +385,7 @@ def update_event(
             url=url,
             allday_event=allday_event,
             alert_minutes=parsed_alerts,
+            availability=availability,
             recurrence_rule=parsed_recurrence,
             occurrence_date=occurrence_date or None,
             span=span,

--- a/src/apple_calendar_mcp/swift/create_event.swift
+++ b/src/apple_calendar_mcp/swift/create_event.swift
@@ -14,6 +14,7 @@ struct CreateEventArgs {
     var allday: Bool = false
     var recurrence: String?
     var alertMinutes: [Int] = []
+    var availability: String?
 }
 
 func parseArgs() -> CreateEventArgs? {
@@ -28,6 +29,7 @@ func parseArgs() -> CreateEventArgs? {
     var allday = false
     var recurrence: String?
     var alertMinutes: [Int] = []
+    var availability: String?
 
     var i = 1
     while i < args.count {
@@ -52,6 +54,8 @@ func parseArgs() -> CreateEventArgs? {
             i += 1; if i < args.count { recurrence = args[i] }
         case "--alert":
             i += 1; if i < args.count, let mins = Int(args[i]) { alertMinutes.append(mins) }
+        case "--availability":
+            i += 1; if i < args.count { availability = args[i] }
         default:
             break
         }
@@ -68,6 +72,7 @@ func parseArgs() -> CreateEventArgs? {
     result.allday = allday
     result.recurrence = recurrence
     result.alertMinutes = alertMinutes
+    result.availability = availability
     return result
 }
 
@@ -172,6 +177,16 @@ func parseUntilDate(_ value: String) -> Date? {
     return parseISO8601(value)
 }
 
+func parseAvailability(_ str: String) -> EKEventAvailability {
+    switch str.lowercased() {
+    case "free": return .free
+    case "busy": return .busy
+    case "tentative": return .tentative
+    case "unavailable": return .unavailable
+    default: return .busy
+    }
+}
+
 // MARK: - JSON Output
 
 func outputError(_ error: String, _ message: String) {
@@ -258,6 +273,9 @@ if let rrule = parsed.recurrence, let rule = parseRecurrenceRule(rrule) {
 }
 for mins in parsed.alertMinutes {
     event.addAlarm(EKAlarm(relativeOffset: TimeInterval(-mins * 60)))
+}
+if let avail = parsed.availability {
+    event.availability = parseAvailability(avail)
 }
 
 do {

--- a/src/apple_calendar_mcp/swift/get_events.swift
+++ b/src/apple_calendar_mcp/swift/get_events.swift
@@ -139,7 +139,21 @@ func eventToDict(_ event: EKEvent) -> [String: Any] {
     dict["is_organizer"] = isOrganizer
     dict["is_editable"] = event.calendar.allowsContentModifications && isOrganizer
 
+    // Availability
+    dict["availability"] = availabilityString(event.availability)
+
     return dict
+}
+
+func availabilityString(_ availability: EKEventAvailability) -> String {
+    switch availability {
+    case .notSupported: return "not_supported"
+    case .busy: return "busy"
+    case .free: return "free"
+    case .tentative: return "tentative"
+    case .unavailable: return "unavailable"
+    @unknown default: return "busy"
+    }
 }
 
 func participantRoleString(_ role: EKParticipantRole) -> String {

--- a/src/apple_calendar_mcp/swift/update_event.swift
+++ b/src/apple_calendar_mcp/swift/update_event.swift
@@ -20,6 +20,7 @@ struct UpdateEventArgs {
     var clearAlerts = false
     var recurrence: String?
     var clearRecurrence = false
+    var availability: String?
     var occurrenceDate: String?
     var span: EKSpan = .thisEvent
     var updatedFields: [String] = []
@@ -70,6 +71,8 @@ func parseArgs() -> UpdateEventArgs? {
         case "--clear-recurrence":
             result.clearRecurrence = true
             if !result.updatedFields.contains("recurrence_rule") { result.updatedFields.append("recurrence_rule") }
+        case "--availability":
+            i += 1; if i < args.count { result.availability = args[i]; result.updatedFields.append("availability") }
         case "--occurrence-date":
             i += 1; if i < args.count { result.occurrenceDate = args[i] }
         case "--span":
@@ -91,7 +94,8 @@ func parseArgs() -> UpdateEventArgs? {
         url: result.url, clearUrl: result.clearUrl,
         allday: result.allday, alertMinutes: result.alertMinutes,
         clearAlerts: result.clearAlerts, recurrence: result.recurrence,
-        clearRecurrence: result.clearRecurrence, occurrenceDate: result.occurrenceDate,
+        clearRecurrence: result.clearRecurrence, availability: result.availability,
+        occurrenceDate: result.occurrenceDate,
         span: result.span, updatedFields: result.updatedFields
     )
     return result
@@ -190,6 +194,16 @@ func parseRecurrenceRule(_ rrule: String) -> EKRecurrenceRule? {
         setPositions: nil,
         end: end
     )
+}
+
+func parseAvailability(_ str: String) -> EKEventAvailability {
+    switch str.lowercased() {
+    case "free": return .free
+    case "busy": return .busy
+    case "tentative": return .tentative
+    case "unavailable": return .unavailable
+    default: return .busy
+    }
 }
 
 // MARK: - JSON Output
@@ -311,6 +325,9 @@ if parsed.clearRecurrence {
         for r in rules { event.removeRecurrenceRule(r) }
     }
     event.addRecurrenceRule(rule)
+}
+if let avail = parsed.availability {
+    event.availability = parseAvailability(avail)
 }
 
 // Determine if this is a date change on a recurring event with .thisEvent

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -209,6 +209,7 @@ class TestCreateEventTool:
             allday_event=True,
             recurrence_rule=None,
             alert_minutes=None,
+            availability=None,
         )
 
     @patch("apple_calendar_mcp.server_fastmcp.get_client")


### PR DESCRIPTION
## Summary

Full read/write support for event availability status.

- **Read:** `get_events` returns `availability` field (free, busy, tentative, unavailable, not_supported)
- **Write:** `create_event` and `update_event` accept `availability` parameter
- **Display:** formatted output shows availability when not "busy" (the default)

Enables micro-events marked as "free" (transition reminders that don't block time slots).

Closes #90

## Test plan

- [x] `make test` — 133 unit tests pass
- [x] `make test-integration` — 46 integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)