### PR TITLE
Support timezone parameter on event creation and update (#91)

### DIFF
--- a/src/apple_calendar_mcp/calendar_connector.py
+++ b/src/apple_calendar_mcp/calendar_connector.py
@@ -157,6 +157,7 @@ class CalendarConnector:
         recurrence_rule: Optional[str] = None,
         alert_minutes: Optional[list[int]] = None,
         availability: Optional[str] = None,
+        timezone: Optional[str] = None,
     ) -> str:
         """Create a new event in a specified calendar.
 
@@ -201,6 +202,8 @@ class CalendarConnector:
                 args += ["--alert", str(mins)]
         if availability:
             args += ["--availability", availability]
+        if timezone:
+            args += ["--timezone", timezone]
 
         parsed = self._run_swift_helper_json("create_event", args)
         return parsed["uid"]
@@ -311,6 +314,7 @@ class CalendarConnector:
         allday_event: bool | None = None,
         alert_minutes: list[int] | None = None,
         availability: str | None = None,
+        timezone: str | None = None,
         recurrence_rule: str | None = None,
         occurrence_date: str | None = None,
         span: str = "this_event",
@@ -373,6 +377,9 @@ class CalendarConnector:
         if availability is not None:
             args += ["--availability", availability]
             updated_fields.append("availability")
+
+        if timezone:
+            args += ["--timezone", timezone]
 
         if not updated_fields:
             raise ValueError("At least one field must be provided to update")

--- a/src/apple_calendar_mcp/server_fastmcp.py
+++ b/src/apple_calendar_mcp/server_fastmcp.py
@@ -118,6 +118,7 @@ def create_event(
     recurrence_rule: str = "",
     alert_minutes: str = "",
     availability: str = "",
+    timezone: str = "",
 ) -> str:
     """Create a new event in a specified calendar.
 
@@ -133,6 +134,7 @@ def create_event(
         recurrence_rule: iCalendar RRULE string for recurring events (optional, e.g., "FREQ=WEEKLY;BYDAY=MO,WE,FR" or "FREQ=DAILY;COUNT=10")
         alert_minutes: Comma-separated minutes before event to alert (optional, e.g., "15" or "15,60")
         availability: Event availability status: "free", "busy", or "tentative" (optional, default: busy)
+        timezone: IANA timezone for interpreting start/end times (optional, e.g., "America/Los_Angeles", "US/Eastern"). When provided, times are interpreted in that timezone instead of the system's local timezone.
     """
     parsed_alerts = [int(m.strip()) for m in alert_minutes.split(",") if m.strip()] if alert_minutes else None
     client = get_client()
@@ -149,6 +151,7 @@ def create_event(
             recurrence_rule=recurrence_rule or None,
             alert_minutes=parsed_alerts,
             availability=availability or None,
+            timezone=timezone or None,
         )
     except Exception as e:
         return f"Error creating event: {e}"
@@ -333,6 +336,7 @@ def update_event(
     allday_event: bool | None = None,
     alert_minutes: str = "",
     availability: str | None = None,
+    timezone: str = "",
     recurrence_rule: str | None = None,
     occurrence_date: str = "",
     span: str = "this_event",
@@ -386,6 +390,7 @@ def update_event(
             allday_event=allday_event,
             alert_minutes=parsed_alerts,
             availability=availability,
+            timezone=timezone or None,
             recurrence_rule=parsed_recurrence,
             occurrence_date=occurrence_date or None,
             span=span,

--- a/src/apple_calendar_mcp/swift/create_event.swift
+++ b/src/apple_calendar_mcp/swift/create_event.swift
@@ -15,6 +15,7 @@ struct CreateEventArgs {
     var recurrence: String?
     var alertMinutes: [Int] = []
     var availability: String?
+    var timezone: String?
 }
 
 func parseArgs() -> CreateEventArgs? {
@@ -30,6 +31,7 @@ func parseArgs() -> CreateEventArgs? {
     var recurrence: String?
     var alertMinutes: [Int] = []
     var availability: String?
+    var timezone: String?
 
     var i = 1
     while i < args.count {
@@ -56,6 +58,8 @@ func parseArgs() -> CreateEventArgs? {
             i += 1; if i < args.count, let mins = Int(args[i]) { alertMinutes.append(mins) }
         case "--availability":
             i += 1; if i < args.count { availability = args[i] }
+        case "--timezone":
+            i += 1; if i < args.count { timezone = args[i] }
         default:
             break
         }
@@ -73,20 +77,22 @@ func parseArgs() -> CreateEventArgs? {
     result.recurrence = recurrence
     result.alertMinutes = alertMinutes
     result.availability = availability
+    result.timezone = timezone
     return result
 }
 
 // MARK: - Date Parsing
 
-func parseISO8601(_ str: String) -> Date? {
-    // Try with timezone (e.g., "2026-03-15T14:00:00Z")
+func parseISO8601(_ str: String, timeZone: TimeZone? = nil) -> Date? {
+    // Try with explicit timezone suffix (e.g., "2026-03-15T14:00:00Z")
     let isoFormatter = ISO8601DateFormatter()
     isoFormatter.formatOptions = [.withInternetDateTime]
     if let date = isoFormatter.date(from: str) { return date }
 
-    // Try without timezone — interpret as local time
+    // Try without timezone suffix — interpret in specified timezone or local
     let df = DateFormatter()
     df.locale = Locale(identifier: "en_US_POSIX")
+    if let tz = timeZone { df.timeZone = tz }
     for fmt in ["yyyy-MM-dd'T'HH:mm:ss", "yyyy-MM-dd"] {
         df.dateFormat = fmt
         if let date = df.date(from: str) { return date }
@@ -212,12 +218,15 @@ guard let parsed = parseArgs() else {
     exit(0)
 }
 
-guard let startDate = parseISO8601(parsed.start) else {
+// Resolve timezone for date parsing
+let eventTimeZone: TimeZone? = parsed.timezone.flatMap { TimeZone(identifier: $0) }
+
+guard let startDate = parseISO8601(parsed.start, timeZone: eventTimeZone) else {
     outputError("invalid_date", "Cannot parse start date: \(parsed.start)")
     exit(0)
 }
 
-guard let endDate = parseISO8601(parsed.end) else {
+guard let endDate = parseISO8601(parsed.end, timeZone: eventTimeZone) else {
     outputError("invalid_date", "Cannot parse end date: \(parsed.end)")
     exit(0)
 }

--- a/src/apple_calendar_mcp/swift/update_event.swift
+++ b/src/apple_calendar_mcp/swift/update_event.swift
@@ -21,6 +21,7 @@ struct UpdateEventArgs {
     var recurrence: String?
     var clearRecurrence = false
     var availability: String?
+    var timezone: String?
     var occurrenceDate: String?
     var span: EKSpan = .thisEvent
     var updatedFields: [String] = []
@@ -73,6 +74,8 @@ func parseArgs() -> UpdateEventArgs? {
             if !result.updatedFields.contains("recurrence_rule") { result.updatedFields.append("recurrence_rule") }
         case "--availability":
             i += 1; if i < args.count { result.availability = args[i]; result.updatedFields.append("availability") }
+        case "--timezone":
+            i += 1; if i < args.count { result.timezone = args[i] }
         case "--occurrence-date":
             i += 1; if i < args.count { result.occurrenceDate = args[i] }
         case "--span":
@@ -95,6 +98,7 @@ func parseArgs() -> UpdateEventArgs? {
         allday: result.allday, alertMinutes: result.alertMinutes,
         clearAlerts: result.clearAlerts, recurrence: result.recurrence,
         clearRecurrence: result.clearRecurrence, availability: result.availability,
+        timezone: result.timezone,
         occurrenceDate: result.occurrenceDate,
         span: result.span, updatedFields: result.updatedFields
     )
@@ -103,13 +107,14 @@ func parseArgs() -> UpdateEventArgs? {
 
 // MARK: - Date Parsing
 
-func parseISO8601(_ str: String) -> Date? {
+func parseISO8601(_ str: String, timeZone: TimeZone? = nil) -> Date? {
     let isoFormatter = ISO8601DateFormatter()
     isoFormatter.formatOptions = [.withInternetDateTime]
     if let date = isoFormatter.date(from: str) { return date }
 
     let df = DateFormatter()
     df.locale = Locale(identifier: "en_US_POSIX")
+    if let tz = timeZone { df.timeZone = tz }
     for fmt in ["yyyy-MM-dd'T'HH:mm:ss", "yyyy-MM-dd"] {
         df.dateFormat = fmt
         if let date = df.date(from: str) { return date }
@@ -275,17 +280,20 @@ guard let event = event else {
     exit(0)
 }
 
+// Resolve timezone for date parsing
+let eventTimeZone: TimeZone? = parsed.timezone.flatMap { TimeZone(identifier: $0) }
+
 // Apply updates
 if let summary = parsed.summary {
     event.title = summary
 }
-if let startStr = parsed.start, let startDate = parseISO8601(startStr) {
+if let startStr = parsed.start, let startDate = parseISO8601(startStr, timeZone: eventTimeZone) {
     event.startDate = startDate
 } else if parsed.start != nil {
     outputError("invalid_date", "Cannot parse start date: \(parsed.start!)")
     exit(0)
 }
-if let endStr = parsed.end, let endDate = parseISO8601(endStr) {
+if let endStr = parsed.end, let endDate = parseISO8601(endStr, timeZone: eventTimeZone) {
     event.endDate = endDate
 } else if parsed.end != nil {
     outputError("invalid_date", "Cannot parse end date: \(parsed.end!)")
@@ -337,8 +345,8 @@ let isRecurringThisEvent = event.hasRecurrenceRules && parsed.span == .thisEvent
 if isDateChange && isRecurringThisEvent {
     // Emulate Calendar.app: remove occurrence from series, create standalone event at new time
     let newTitle = parsed.summary ?? event.title ?? ""
-    let newStart = (parsed.start != nil ? parseISO8601(parsed.start!) : nil) ?? event.startDate!
-    let newEnd = (parsed.end != nil ? parseISO8601(parsed.end!) : nil) ?? event.endDate!
+    let newStart = (parsed.start != nil ? parseISO8601(parsed.start!, timeZone: eventTimeZone) : nil) ?? event.startDate!
+    let newEnd = (parsed.end != nil ? parseISO8601(parsed.end!, timeZone: eventTimeZone) : nil) ?? event.endDate!
     let newLocation = parsed.clearLocation ? nil : (parsed.location ?? event.location)
     let newNotes = parsed.clearDescription ? nil : (parsed.description ?? event.notes)
     let newUrl = parsed.clearUrl ? nil : (parsed.url.flatMap { URL(string: $0) } ?? event.url)

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -210,6 +210,7 @@ class TestCreateEventTool:
             recurrence_rule=None,
             alert_minutes=None,
             availability=None,
+            timezone=None,
         )
 
     @patch("apple_calendar_mcp.server_fastmcp.get_client")


### PR DESCRIPTION
## Summary

Adds optional `timezone` parameter to `create_event` and `update_event`. When provided, naive datetime inputs are interpreted in the specified timezone instead of system local time.

**Use case:** "Add all conference events. All times are Pacific, convert to Eastern."

**Example:** `create_event(..., start_date="2026-06-15T15:00:00", timezone="America/Los_Angeles")` creates an event at 3 PM Pacific (= 6 PM Eastern).

Accepts IANA timezone identifiers (e.g., `America/Los_Angeles`, `US/Eastern`, `Europe/London`).

Closes #91

## Test plan

- [x] `make test` — 133 unit tests pass
- [x] `make test-integration` — 46 integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)