### PR TITLE
Add batch create_events tool for bulk event creation (#92)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -19,10 +19,10 @@ make test-verbose          # Tests with verbose output
 
 **Running the server:** `uv run python -m apple_calendar_mcp.server_fastmcp` or via Claude Desktop config.
 
-## API Surface (9 functions)
+## API Surface (10 functions)
 
 - **Calendars:** `get_calendars`, `create_calendar`, `delete_calendar`
-- **Events:** `get_events`, `search_events`, `create_event`, `update_event`, `delete_events`
+- **Events:** `get_events`, `search_events`, `create_event`, `create_events`, `update_event`, `delete_events`
 - **Availability:** `get_availability`
 
 Planned (filed as issues): `update_events`

--- a/evals/agent_tool_usability/create_events_eval.md
+++ b/evals/agent_tool_usability/create_events_eval.md
@@ -1,0 +1,42 @@
+# Blind Agent Eval: create_events (batch)
+
+## Purpose
+Verify that an agent knows when to use `create_events` (batch) vs `create_event` (single), and can format the JSON events array correctly.
+
+## Setup
+Give an agent access to the apple-calendar-mcp tools with NO additional instructions beyond the MCP server's `instructions` block and tool docstrings.
+
+## Scenarios
+
+### Scenario 1: Multiple events in one request
+**Prompt:** "Add three meetings to my Work calendar: Team Standup Mon 9-9:30am, Design Review Mon 2-3pm, and Sprint Planning Tue 10-11am."
+**Expected:** Agent calls `create_events` (not three separate `create_event` calls) with a JSON array of 3 event objects.
+**Pass criteria:** Agent uses batch tool, JSON is valid, all 3 events have correct summary/start/end.
+
+### Scenario 2: Single event — should NOT use batch
+**Prompt:** "Add a dentist appointment to my Personal calendar on Friday at 2pm for an hour."
+**Expected:** Agent calls `create_event` (singular), not `create_events`.
+**Pass criteria:** Agent uses the single-event tool for a single event.
+
+### Scenario 3: Conference schedule import
+**Prompt:** "Here's a conference schedule for Thursday. Add all of these to Work: Opening Keynote 9-10am, Workshop A 10:15-11:45am at Room 101, Lunch 12-1pm (mark as free), Workshop B 1:15-2:45pm at Room 203, Closing Panel 3-4pm."
+**Expected:** Agent calls `create_events` with 5 events, including locations and availability=free for lunch.
+**Pass criteria:** JSON array has 5 objects with correct fields. Lunch event has availability "free". Workshop events have locations.
+
+### Scenario 4: Events with mixed features
+**Prompt:** "Add to my Work calendar: Weekly Team Sync every Monday 10-11am recurring weekly, a one-time Project Kickoff on Wednesday 2-4pm with a 30-minute alert, and an All-Day Planning Day on Friday."
+**Expected:** Agent calls `create_events` with 3 events: one with recurrence, one with alerts, one all-day.
+**Pass criteria:** JSON includes recurrence RRULE for first event, alerts=[30] for second, allday=true for third.
+
+### Scenario 5: Timezone-specific batch
+**Prompt:** "I'm scheduling meetings with our West Coast team. Add these to Work — all times are Pacific: Sync Call Mon 9am-10am, Follow-Up Tue 2pm-3pm."
+**Expected:** Agent calls `create_events` with timezone "America/Los_Angeles" on each event (or asks if all events share the timezone).
+**Pass criteria:** Events include timezone field with a valid Pacific timezone identifier.
+
+## Scoring
+- 4/5 or 5/5 pass: Tool descriptions are clear
+- 3/5 pass: Minor description improvements needed
+- 2/5 or fewer: Rewrite descriptions before release
+
+## Results
+_Run these scenarios before each release that changes tool descriptions._

--- a/src/apple_calendar_mcp/calendar_connector.py
+++ b/src/apple_calendar_mcp/calendar_connector.py
@@ -34,13 +34,19 @@ def run_applescript(script: str, timeout: int = 60) -> str:
     return result.stdout.strip()
 
 
-def run_swift_helper(script_name: str, args: list[str], timeout: int = 30) -> str:
+def run_swift_helper(
+    script_name: str,
+    args: list[str],
+    timeout: int = 30,
+    stdin_data: Optional[str] = None,
+) -> str:
     """Execute a Swift helper script and return the result.
 
     Args:
         script_name: Name of the Swift script (without .swift extension)
         args: Command-line arguments to pass to the script
         timeout: Maximum seconds to wait (default: 30)
+        stdin_data: Optional data to pipe to the script's stdin
 
     Returns:
         The stdout output from the Swift script
@@ -56,6 +62,7 @@ def run_swift_helper(script_name: str, args: list[str], timeout: int = 30) -> st
         text=True,
         check=True,
         timeout=timeout,
+        input=stdin_data,
     )
     return result.stdout.strip()
 
@@ -130,9 +137,11 @@ class CalendarConnector:
         # Format for AppleScript: "March 15, 2026 02:30:00 PM"
         return dt.strftime("%B %d, %Y %I:%M:%S %p")
 
-    def _run_swift_helper_json(self, script_name: str, args: list[str]) -> dict:
+    def _run_swift_helper_json(
+        self, script_name: str, args: list[str], stdin_data: Optional[str] = None
+    ) -> dict:
         """Run a Swift helper and parse JSON response, raising on errors."""
-        result = run_swift_helper(script_name, args)
+        result = run_swift_helper(script_name, args, stdin_data=stdin_data)
         parsed = json.loads(result)
         if isinstance(parsed, dict) and "error" in parsed:
             error_map = {
@@ -207,6 +216,32 @@ class CalendarConnector:
 
         parsed = self._run_swift_helper_json("create_event", args)
         return parsed["uid"]
+
+    def create_events(
+        self,
+        calendar_name: str,
+        events: list[dict[str, Any]],
+    ) -> dict[str, Any]:
+        """Create multiple events in a single batch operation.
+
+        Args:
+            calendar_name: Name of the target calendar (all events go to same calendar)
+            events: List of event dicts, each with keys: summary, start, end,
+                    and optional: location, description, url, allday, recurrence,
+                    alerts (list of int), availability, timezone
+
+        Returns:
+            Dict with 'created' (list of {uid, summary}) and 'errors' (list of {index, summary, error})
+        """
+        self._verify_calendar_safety(calendar_name)
+
+        if not events:
+            raise ValueError("At least one event must be provided")
+
+        stdin_data = json.dumps(events)
+        return self._run_swift_helper_json(
+            "create_events", ["--calendar", calendar_name], stdin_data=stdin_data
+        )
 
     def _validate_date(self, date_str: str) -> None:
         """Validate that a string is a valid ISO 8601 date.

--- a/src/apple_calendar_mcp/server_fastmcp.py
+++ b/src/apple_calendar_mcp/server_fastmcp.py
@@ -166,6 +166,54 @@ def create_event(
     return result
 
 
+@mcp.tool()
+def create_events(
+    calendar_name: str,
+    events: str,
+) -> str:
+    """Create multiple events in a single batch operation.
+
+    More efficient than calling create_event multiple times — all events are
+    created in one operation. All events go to the same calendar.
+
+    Args:
+        calendar_name: Exact name of the target calendar
+        events: JSON array of event objects. Each object has keys: summary (required),
+                start (required, ISO 8601), end (required, ISO 8601), and optional:
+                location, description, url, allday (bool), recurrence (RRULE string),
+                alerts (list of minutes, e.g. [15, 60]), availability ("free"/"busy"/"tentative"),
+                timezone (IANA identifier, e.g. "America/Los_Angeles")
+    """
+    try:
+        event_list = json.loads(events)
+    except json.JSONDecodeError as e:
+        return f"Error: invalid JSON for events parameter: {e}"
+
+    if not isinstance(event_list, list):
+        return "Error: events must be a JSON array"
+
+    client = get_client()
+    try:
+        result = client.create_events(
+            calendar_name=calendar_name,
+            events=event_list,
+        )
+    except Exception as e:
+        return f"Error creating events: {e}"
+
+    created = result.get("created", [])
+    errors = result.get("errors", [])
+
+    parts = [f"Created {len(created)} event(s) in calendar '{calendar_name}'"]
+    for c in created:
+        parts.append(f"  {c['summary']} (UID: {c['uid']})")
+    if errors:
+        parts.append(f"\n{len(errors)} error(s):")
+        for e in errors:
+            parts.append(f"  [{e.get('index', '?')}] {e.get('summary', '?')}: {e.get('error', '?')}")
+    return "\n".join(parts)
+
+
 def _format_event(event: dict) -> str:
     """Format an event dict as human-readable text."""
     result = f"Title: {event['summary']}\n"

--- a/src/apple_calendar_mcp/swift/create_events.swift
+++ b/src/apple_calendar_mcp/swift/create_events.swift
@@ -1,0 +1,218 @@
+import EventKit
+import Foundation
+
+// MARK: - Argument Parsing
+
+func parseArgs() -> String? {
+    let args = CommandLine.arguments
+    var calendar: String?
+
+    var i = 1
+    while i < args.count {
+        if args[i] == "--calendar" {
+            i += 1; if i < args.count { calendar = args[i] }
+        }
+        i += 1
+    }
+    return calendar
+}
+
+// MARK: - Date Parsing
+
+func parseISO8601(_ str: String, timeZone: TimeZone? = nil) -> Date? {
+    let isoFormatter = ISO8601DateFormatter()
+    isoFormatter.formatOptions = [.withInternetDateTime]
+    if let date = isoFormatter.date(from: str) { return date }
+
+    let df = DateFormatter()
+    df.locale = Locale(identifier: "en_US_POSIX")
+    if let tz = timeZone { df.timeZone = tz }
+    for fmt in ["yyyy-MM-dd'T'HH:mm:ss", "yyyy-MM-dd"] {
+        df.dateFormat = fmt
+        if let date = df.date(from: str) { return date }
+    }
+    return nil
+}
+
+// MARK: - Recurrence Rule Parsing
+
+func parseDayOfWeek(_ day: String) -> EKRecurrenceDayOfWeek? {
+    let dayMap: [String: EKWeekday] = [
+        "SU": .sunday, "MO": .monday, "TU": .tuesday,
+        "WE": .wednesday, "TH": .thursday, "FR": .friday, "SA": .saturday
+    ]
+    let letters = day.suffix(2)
+    let prefix = day.dropLast(2)
+    guard let weekday = dayMap[String(letters)] else { return nil }
+    if prefix.isEmpty { return EKRecurrenceDayOfWeek(weekday) }
+    if let n = Int(prefix) { return EKRecurrenceDayOfWeek(weekday, weekNumber: n) }
+    return nil
+}
+
+func parseUntilDate(_ value: String) -> Date? {
+    let df = DateFormatter()
+    df.locale = Locale(identifier: "en_US_POSIX")
+    for fmt in ["yyyyMMdd'T'HHmmss'Z'", "yyyyMMdd'T'HHmmss", "yyyyMMdd"] {
+        df.dateFormat = fmt
+        if let date = df.date(from: value) { return date }
+    }
+    return parseISO8601(value)
+}
+
+func parseRecurrenceRule(_ rrule: String) -> EKRecurrenceRule? {
+    var frequency: EKRecurrenceFrequency = .daily
+    var interval = 1
+    var end: EKRecurrenceEnd?
+    var daysOfWeek: [EKRecurrenceDayOfWeek]?
+
+    for part in rrule.split(separator: ";") {
+        let kv = part.split(separator: "=", maxSplits: 1)
+        guard kv.count == 2 else { continue }
+        let key = String(kv[0]), value = String(kv[1])
+        switch key {
+        case "FREQ":
+            switch value {
+            case "DAILY": frequency = .daily
+            case "WEEKLY": frequency = .weekly
+            case "MONTHLY": frequency = .monthly
+            case "YEARLY": frequency = .yearly
+            default: break
+            }
+        case "INTERVAL": interval = Int(value) ?? 1
+        case "COUNT": if let n = Int(value) { end = EKRecurrenceEnd(occurrenceCount: n) }
+        case "UNTIL": if let d = parseUntilDate(value) { end = EKRecurrenceEnd(end: d) }
+        case "BYDAY": daysOfWeek = value.split(separator: ",").compactMap { parseDayOfWeek(String($0)) }
+        default: break
+        }
+    }
+    return EKRecurrenceRule(recurrenceWith: frequency, interval: interval,
+        daysOfTheWeek: daysOfWeek, daysOfTheMonth: nil, monthsOfTheYear: nil,
+        weeksOfTheYear: nil, daysOfTheYear: nil, setPositions: nil, end: end)
+}
+
+func parseAvailability(_ str: String) -> EKEventAvailability {
+    switch str.lowercased() {
+    case "free": return .free
+    case "busy": return .busy
+    case "tentative": return .tentative
+    case "unavailable": return .unavailable
+    default: return .busy
+    }
+}
+
+// MARK: - JSON Output
+
+func outputError(_ error: String, _ message: String) {
+    let obj: [String: String] = ["error": error, "message": message]
+    if let data = try? JSONSerialization.data(withJSONObject: obj),
+       let str = String(data: data, encoding: .utf8) { print(str) }
+}
+
+// MARK: - Main
+
+guard let calendarName = parseArgs() else {
+    outputError("invalid_args", "Required: --calendar <name>. Event data is read from stdin as JSON array.")
+    exit(0)
+}
+
+// Read JSON from stdin
+let stdinData = FileHandle.standardInput.readDataToEndOfFile()
+guard let eventsJson = try? JSONSerialization.jsonObject(with: stdinData) as? [[String: Any]] else {
+    outputError("invalid_input", "Expected JSON array of event objects on stdin")
+    exit(0)
+}
+
+let store = EKEventStore()
+let semaphore = DispatchSemaphore(value: 0)
+var accessGranted = false
+store.requestFullAccessToEvents { granted, _ in
+    accessGranted = granted
+    semaphore.signal()
+}
+semaphore.wait()
+
+if !accessGranted {
+    outputError("calendar_access_denied", "Calendar access denied.")
+    exit(0)
+}
+
+store.refreshSourcesIfNecessary()
+
+guard let calendar = store.calendars(for: .event).first(where: { $0.title == calendarName }) else {
+    let available = store.calendars(for: .event).map { $0.title }.joined(separator: ", ")
+    outputError("calendar_not_found", "Calendar '\(calendarName)' not found. Available: \(available)")
+    exit(0)
+}
+
+// Create events
+var created: [[String: String]] = []
+var errors: [[String: Any]] = []
+
+for (index, eventData) in eventsJson.enumerated() {
+    guard let summary = eventData["summary"] as? String,
+          let startStr = eventData["start"] as? String,
+          let endStr = eventData["end"] as? String else {
+        errors.append(["index": index, "summary": eventData["summary"] as? String ?? "unknown", "error": "Missing required fields: summary, start, end"])
+        continue
+    }
+
+    let tzName = eventData["timezone"] as? String
+    let tz: TimeZone? = tzName.flatMap { TimeZone(identifier: $0) }
+
+    guard let startDate = parseISO8601(startStr, timeZone: tz) else {
+        errors.append(["index": index, "summary": summary, "error": "Invalid start date: \(startStr)"])
+        continue
+    }
+    guard let endDate = parseISO8601(endStr, timeZone: tz) else {
+        errors.append(["index": index, "summary": summary, "error": "Invalid end date: \(endStr)"])
+        continue
+    }
+
+    let event = EKEvent(eventStore: store)
+    event.calendar = calendar
+    event.title = summary
+    event.startDate = startDate
+    event.endDate = endDate
+    event.isAllDay = eventData["allday"] as? Bool ?? false
+
+    if let location = eventData["location"] as? String { event.location = location }
+    if let description = eventData["description"] as? String { event.notes = description }
+    if let urlStr = eventData["url"] as? String, let url = URL(string: urlStr) { event.url = url }
+    if let rrule = eventData["recurrence"] as? String, let rule = parseRecurrenceRule(rrule) {
+        event.addRecurrenceRule(rule)
+    }
+    if let alerts = eventData["alerts"] as? [Int] {
+        for mins in alerts {
+            event.addAlarm(EKAlarm(relativeOffset: TimeInterval(-mins * 60)))
+        }
+    }
+    if let avail = eventData["availability"] as? String {
+        event.availability = parseAvailability(avail)
+    }
+
+    do {
+        try store.save(event, span: .thisEvent, commit: false)
+        created.append(["uid": event.calendarItemIdentifier, "summary": summary])
+    } catch {
+        errors.append(["index": index, "summary": summary, "error": error.localizedDescription])
+    }
+}
+
+// Batch commit
+if !created.isEmpty {
+    do {
+        try store.commit()
+    } catch {
+        outputError("commit_failed", "Failed to commit batch: \(error.localizedDescription)")
+        exit(0)
+    }
+}
+
+// Output result
+let result: [String: Any] = ["created": created, "errors": errors]
+if let data = try? JSONSerialization.data(withJSONObject: result, options: [.sortedKeys]),
+   let str = String(data: data, encoding: .utf8) {
+    print(str)
+} else {
+    outputError("serialization_error", "Failed to serialize result")
+}

--- a/tests/unit/test_calendar_connector.py
+++ b/tests/unit/test_calendar_connector.py
@@ -289,7 +289,7 @@ class TestGetCalendars:
         """Verify get_calendars uses the Swift helper."""
         mock_swift.return_value = json.dumps([])
         self.connector.get_calendars()
-        mock_swift.assert_called_once_with("get_calendars", [])
+        mock_swift.assert_called_once_with("get_calendars", [], stdin_data=None)
 
     @patch("apple_calendar_mcp.calendar_connector.run_swift_helper")
     def test_handles_access_denied(self, mock_swift):
@@ -379,7 +379,7 @@ class TestCreateEvent:
         mock_swift.assert_called_once_with("create_event", [
             "--calendar", "MCP-Test-Calendar", "--summary", "Team Meeting",
             "--start", "2026-03-15T14:00:00", "--end", "2026-03-15T15:00:00",
-        ])
+        ], stdin_data=None)
 
     @patch("apple_calendar_mcp.calendar_connector.run_swift_helper")
     def test_creates_event_with_all_optional_fields(self, mock_swift):
@@ -497,6 +497,7 @@ class TestGetEvents:
         mock_swift.assert_called_once_with(
             "get_events",
             ["--calendar", "Work", "--start", "2026-03-15T00:00:00", "--end", "2026-03-16T00:00:00"],
+            stdin_data=None,
         )
 
     @patch("apple_calendar_mcp.calendar_connector.run_swift_helper")
@@ -659,7 +660,7 @@ class TestGetAvailability:
     @patch("apple_calendar_mcp.calendar_connector.run_swift_helper")
     def test_overlapping_events_merged(self, mock_swift):
         """Two overlapping events across calendars should merge into one busy block."""
-        def swift_side_effect(script_name, args):
+        def swift_side_effect(script_name, args, stdin_data=None):
             cal = args[args.index("--calendar") + 1]
             if cal == "Work":
                 return json.dumps([
@@ -725,7 +726,7 @@ class TestGetAvailability:
     @patch("apple_calendar_mcp.calendar_connector.run_swift_helper")
     def test_multiple_calendars_combined(self, mock_swift):
         """Events from multiple calendars should be merged for availability."""
-        def swift_side_effect(script_name, args):
+        def swift_side_effect(script_name, args, stdin_data=None):
             cal = args[args.index("--calendar") + 1]
             if cal == "Work":
                 return json.dumps([


### PR DESCRIPTION
## Summary

New `create_events` tool for creating multiple events in one operation.

- Events passed as JSON array to the tool
- Swift helper reads from stdin, creates all events, commits in one batch
- Supports all event fields: location, alerts, recurrence, availability, timezone
- Partial success: reports created UIDs and errors separately
- Also adds `stdin_data` support to `run_swift_helper()` for piping structured data

### Usage
```python
create_events("Work", '[
  {"summary": "Meeting 1", "start": "2026-04-01T09:00:00", "end": "2026-04-01T10:00:00"},
  {"summary": "Meeting 2", "start": "2026-04-01T11:00:00", "end": "2026-04-01T12:00:00", "location": "Room B", "alerts": [15]}
]')
```

Closes #92

## Test plan

- [x] `make test` — 133 unit tests pass
- [x] `make test-integration` — 46 integration tests pass
- [x] Manual test: batch create 3 events with mixed fields → all created and verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)