### PR TITLE
release: v0.6.0

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -3,7 +3,7 @@
 An MCP server bridging Claude and Apple Calendar via AppleScript and EventKit on macOS.
 
 **Stack:** Python 3.10+, FastMCP, AppleScript (via `osascript`), Swift/EventKit (via `swift`)
-**Version:** v0.5.1 | **Tests:** 133 unit, 46 integration | **Coverage:** TBD
+**Version:** v0.6.0 | **Tests:** 133 unit, 46 integration | **Coverage:** TBD
 
 ## Commands
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.0] - 2026-03-18
+
+### Added
+
+- `create_events` batch tool for creating multiple events in one operation via `store.commit()` (#98)
+- Event availability status (free/busy/tentative) on `get_events`, `create_event`, `update_event` (#96)
+- Timezone parameter on `create_event` and `update_event` for cross-timezone scheduling (#97)
+- Calendar `type` field in `get_calendars` output (caldav, subscription, birthday, local, exchange) (#95)
+- Event `is_editable` and `is_organizer` fields in `get_events` for permission awareness (#95)
+- `stdin_data` support in `run_swift_helper()` for piping structured data to Swift subprocesses (#98)
+- Blind eval scenarios for batch create operations (#98)
+
 ## [0.5.1] - 2026-03-18
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "apple-calendar-mcp"
-version = "0.5.1"
+version = "0.6.0"
 description = "MCP server for Apple Calendar integration"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -39,7 +39,7 @@ wheels = [
 
 [[package]]
 name = "apple-calendar-mcp"
-version = "0.5.1"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## Summary

- Version bump to 0.6.0
- CHANGELOG entry for v0.6.0

### Changes in this release
- Batch `create_events` tool for bulk event creation (#98)
- Event availability status (free/busy/tentative) (#96)
- Timezone parameter for cross-timezone scheduling (#97)
- Calendar type and event editability fields (#95)

## Validation

- [x] Version sync check
- [x] Complexity check
- [x] Unit tests (133 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)