### PR TITLE
Add batch update_events tool (#100)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -19,10 +19,10 @@ make test-verbose          # Tests with verbose output
 
 **Running the server:** `uv run python -m apple_calendar_mcp.server_fastmcp` or via Claude Desktop config.
 
-## API Surface (10 functions)
+## API Surface (11 functions)
 
 - **Calendars:** `get_calendars`, `create_calendar`, `delete_calendar`
-- **Events:** `get_events`, `search_events`, `create_event`, `create_events`, `update_event`, `delete_events`
+- **Events:** `get_events`, `search_events`, `create_event`, `create_events`, `update_event`, `update_events`, `delete_events`
 - **Availability:** `get_availability`
 
 Planned (filed as issues): `update_events`

--- a/src/apple_calendar_mcp/calendar_connector.py
+++ b/src/apple_calendar_mcp/calendar_connector.py
@@ -243,6 +243,33 @@ class CalendarConnector:
             "create_events", ["--calendar", calendar_name], stdin_data=stdin_data
         )
 
+    def update_events(
+        self,
+        calendar_name: str,
+        updates: list[dict[str, Any]],
+    ) -> dict[str, Any]:
+        """Update multiple events in a single batch operation.
+
+        Args:
+            calendar_name: Name of the calendar containing the events
+            updates: List of update dicts, each with 'uid' (required) and optional fields
+                     to update: summary, start, end, location, description, url, allday,
+                     alerts, availability, timezone, recurrence, clear_location,
+                     clear_description, clear_url, clear_alerts, clear_recurrence
+
+        Returns:
+            Dict with 'updated' (list of {uid, summary, updated_fields}) and 'errors'
+        """
+        self._verify_calendar_safety(calendar_name)
+
+        if not updates:
+            raise ValueError("At least one update must be provided")
+
+        stdin_data = json.dumps(updates)
+        return self._run_swift_helper_json(
+            "update_events", ["--calendar", calendar_name], stdin_data=stdin_data
+        )
+
     def _validate_date(self, date_str: str) -> None:
         """Validate that a string is a valid ISO 8601 date.
 

--- a/src/apple_calendar_mcp/server_fastmcp.py
+++ b/src/apple_calendar_mcp/server_fastmcp.py
@@ -214,6 +214,56 @@ def create_events(
     return "\n".join(parts)
 
 
+@mcp.tool()
+def update_events(
+    calendar_name: str,
+    updates: str,
+) -> str:
+    """Update multiple events in a single batch operation.
+
+    More efficient than calling update_event multiple times. All events must be
+    on the same calendar.
+
+    Args:
+        calendar_name: Exact name of the calendar containing the events
+        updates: JSON array of update objects. Each object must have "uid" (required)
+                 and at least one field to update: summary, start (ISO 8601), end (ISO 8601),
+                 location, description, url, allday (bool), alerts (list of minutes),
+                 availability ("free"/"busy"/"tentative"), timezone (IANA identifier),
+                 recurrence (RRULE string), clear_location (bool), clear_description (bool),
+                 clear_url (bool), clear_alerts (bool), clear_recurrence (bool)
+    """
+    try:
+        update_list = json.loads(updates)
+    except json.JSONDecodeError as e:
+        return f"Error: invalid JSON for updates parameter: {e}"
+
+    if not isinstance(update_list, list):
+        return "Error: updates must be a JSON array"
+
+    client = get_client()
+    try:
+        result = client.update_events(
+            calendar_name=calendar_name,
+            updates=update_list,
+        )
+    except Exception as e:
+        return f"Error updating events: {e}"
+
+    updated = result.get("updated", [])
+    errors = result.get("errors", [])
+
+    parts = [f"Updated {len(updated)} event(s) in calendar '{calendar_name}'"]
+    for u in updated:
+        fields = ", ".join(u.get("updated_fields", []))
+        parts.append(f"  {u.get('summary', '?')} — {fields}")
+    if errors:
+        parts.append(f"\n{len(errors)} error(s):")
+        for e in errors:
+            parts.append(f"  [{e.get('index', '?')}] {e.get('uid', '?')}: {e.get('error', '?')}")
+    return "\n".join(parts)
+
+
 def _format_event(event: dict) -> str:
     """Format an event dict as human-readable text."""
     result = f"Title: {event['summary']}\n"

--- a/src/apple_calendar_mcp/swift/update_events.swift
+++ b/src/apple_calendar_mcp/swift/update_events.swift
@@ -1,0 +1,240 @@
+import EventKit
+import Foundation
+
+// MARK: - Argument Parsing
+
+func parseArgs() -> String? {
+    let args = CommandLine.arguments
+    var calendar: String?
+    var i = 1
+    while i < args.count {
+        if args[i] == "--calendar" { i += 1; if i < args.count { calendar = args[i] } }
+        i += 1
+    }
+    return calendar
+}
+
+// MARK: - Date Parsing
+
+func parseISO8601(_ str: String, timeZone: TimeZone? = nil) -> Date? {
+    let isoFormatter = ISO8601DateFormatter()
+    isoFormatter.formatOptions = [.withInternetDateTime]
+    if let date = isoFormatter.date(from: str) { return date }
+
+    let df = DateFormatter()
+    df.locale = Locale(identifier: "en_US_POSIX")
+    if let tz = timeZone { df.timeZone = tz }
+    for fmt in ["yyyy-MM-dd'T'HH:mm:ss", "yyyy-MM-dd"] {
+        df.dateFormat = fmt
+        if let date = df.date(from: str) { return date }
+    }
+    return nil
+}
+
+// MARK: - Recurrence Rule Parsing
+
+func parseDayOfWeek(_ day: String) -> EKRecurrenceDayOfWeek? {
+    let dayMap: [String: EKWeekday] = [
+        "SU": .sunday, "MO": .monday, "TU": .tuesday,
+        "WE": .wednesday, "TH": .thursday, "FR": .friday, "SA": .saturday
+    ]
+    let letters = day.suffix(2)
+    let prefix = day.dropLast(2)
+    guard let weekday = dayMap[String(letters)] else { return nil }
+    if prefix.isEmpty { return EKRecurrenceDayOfWeek(weekday) }
+    if let n = Int(prefix) { return EKRecurrenceDayOfWeek(weekday, weekNumber: n) }
+    return nil
+}
+
+func parseUntilDate(_ value: String) -> Date? {
+    let df = DateFormatter()
+    df.locale = Locale(identifier: "en_US_POSIX")
+    for fmt in ["yyyyMMdd'T'HHmmss'Z'", "yyyyMMdd'T'HHmmss", "yyyyMMdd"] {
+        df.dateFormat = fmt
+        if let date = df.date(from: value) { return date }
+    }
+    return parseISO8601(value)
+}
+
+func parseRecurrenceRule(_ rrule: String) -> EKRecurrenceRule? {
+    var frequency: EKRecurrenceFrequency = .daily
+    var interval = 1
+    var end: EKRecurrenceEnd?
+    var daysOfWeek: [EKRecurrenceDayOfWeek]?
+
+    for part in rrule.split(separator: ";") {
+        let kv = part.split(separator: "=", maxSplits: 1)
+        guard kv.count == 2 else { continue }
+        let key = String(kv[0]), value = String(kv[1])
+        switch key {
+        case "FREQ":
+            switch value {
+            case "DAILY": frequency = .daily
+            case "WEEKLY": frequency = .weekly
+            case "MONTHLY": frequency = .monthly
+            case "YEARLY": frequency = .yearly
+            default: break
+            }
+        case "INTERVAL": interval = Int(value) ?? 1
+        case "COUNT": if let n = Int(value) { end = EKRecurrenceEnd(occurrenceCount: n) }
+        case "UNTIL": if let d = parseUntilDate(value) { end = EKRecurrenceEnd(end: d) }
+        case "BYDAY": daysOfWeek = value.split(separator: ",").compactMap { parseDayOfWeek(String($0)) }
+        default: break
+        }
+    }
+    return EKRecurrenceRule(recurrenceWith: frequency, interval: interval,
+        daysOfTheWeek: daysOfWeek, daysOfTheMonth: nil, monthsOfTheYear: nil,
+        weeksOfTheYear: nil, daysOfTheYear: nil, setPositions: nil, end: end)
+}
+
+func parseAvailability(_ str: String) -> EKEventAvailability {
+    switch str.lowercased() {
+    case "free": return .free
+    case "busy": return .busy
+    case "tentative": return .tentative
+    case "unavailable": return .unavailable
+    default: return .busy
+    }
+}
+
+// MARK: - JSON Output
+
+func outputError(_ error: String, _ message: String) {
+    let obj: [String: String] = ["error": error, "message": message]
+    if let data = try? JSONSerialization.data(withJSONObject: obj),
+       let str = String(data: data, encoding: .utf8) { print(str) }
+}
+
+// MARK: - Main
+
+guard let calendarName = parseArgs() else {
+    outputError("invalid_args", "Required: --calendar <name>. Update data is read from stdin as JSON array.")
+    exit(0)
+}
+
+let stdinData = FileHandle.standardInput.readDataToEndOfFile()
+guard let updatesJson = try? JSONSerialization.jsonObject(with: stdinData) as? [[String: Any]] else {
+    outputError("invalid_input", "Expected JSON array of update objects on stdin")
+    exit(0)
+}
+
+let store = EKEventStore()
+let semaphore = DispatchSemaphore(value: 0)
+var accessGranted = false
+store.requestFullAccessToEvents { granted, _ in
+    accessGranted = granted
+    semaphore.signal()
+}
+semaphore.wait()
+
+if !accessGranted {
+    outputError("calendar_access_denied", "Calendar access denied.")
+    exit(0)
+}
+
+store.refreshSourcesIfNecessary()
+
+guard let calendar = store.calendars(for: .event).first(where: { $0.title == calendarName }) else {
+    let available = store.calendars(for: .event).map { $0.title }.joined(separator: ", ")
+    outputError("calendar_not_found", "Calendar '\(calendarName)' not found. Available: \(available)")
+    exit(0)
+}
+
+var updated: [[String: Any]] = []
+var errors: [[String: Any]] = []
+
+for (index, updateData) in updatesJson.enumerated() {
+    guard let uid = updateData["uid"] as? String else {
+        errors.append(["index": index, "uid": "unknown", "error": "Missing required 'uid' field"])
+        continue
+    }
+
+    let items = store.calendarItems(withExternalIdentifier: uid)
+    guard let event = items.compactMap({ $0 as? EKEvent }).first(where: { $0.calendar.title == calendarName }) else {
+        errors.append(["index": index, "uid": uid, "error": "Event not found"])
+        continue
+    }
+
+    let tzName = updateData["timezone"] as? String
+    let tz: TimeZone? = tzName.flatMap { TimeZone(identifier: $0) }
+    var updatedFields: [String] = []
+
+    if let summary = updateData["summary"] as? String {
+        event.title = summary; updatedFields.append("summary")
+    }
+    if let startStr = updateData["start"] as? String, let startDate = parseISO8601(startStr, timeZone: tz) {
+        event.startDate = startDate; updatedFields.append("start_date")
+    }
+    if let endStr = updateData["end"] as? String, let endDate = parseISO8601(endStr, timeZone: tz) {
+        event.endDate = endDate; updatedFields.append("end_date")
+    }
+    if let location = updateData["location"] as? String {
+        event.location = location; updatedFields.append("location")
+    } else if updateData["clear_location"] as? Bool == true {
+        event.location = nil; updatedFields.append("location")
+    }
+    if let description = updateData["description"] as? String {
+        event.notes = description; updatedFields.append("description")
+    } else if updateData["clear_description"] as? Bool == true {
+        event.notes = nil; updatedFields.append("description")
+    }
+    if let urlStr = updateData["url"] as? String, let url = URL(string: urlStr) {
+        event.url = url; updatedFields.append("url")
+    } else if updateData["clear_url"] as? Bool == true {
+        event.url = nil; updatedFields.append("url")
+    }
+    if let allday = updateData["allday"] as? Bool {
+        event.isAllDay = allday; updatedFields.append("allday_event")
+    }
+    if let avail = updateData["availability"] as? String {
+        event.availability = parseAvailability(avail); updatedFields.append("availability")
+    }
+    if updateData["clear_alerts"] as? Bool == true || updateData["alerts"] != nil {
+        event.alarms = nil
+        if let alerts = updateData["alerts"] as? [Int] {
+            for mins in alerts { event.addAlarm(EKAlarm(relativeOffset: TimeInterval(-mins * 60))) }
+        }
+        updatedFields.append("alerts")
+    }
+    if updateData["clear_recurrence"] as? Bool == true {
+        if let rules = event.recurrenceRules {
+            for rule in rules { event.removeRecurrenceRule(rule) }
+        }
+        updatedFields.append("recurrence_rule")
+    } else if let rruleStr = updateData["recurrence"] as? String, let rule = parseRecurrenceRule(rruleStr) {
+        if let rules = event.recurrenceRules {
+            for r in rules { event.removeRecurrenceRule(r) }
+        }
+        event.addRecurrenceRule(rule)
+        updatedFields.append("recurrence_rule")
+    }
+
+    if updatedFields.isEmpty {
+        errors.append(["index": index, "uid": uid, "error": "No fields to update"])
+        continue
+    }
+
+    do {
+        try store.save(event, span: .thisEvent, commit: false)
+        updated.append(["uid": uid, "summary": event.title ?? "", "updated_fields": updatedFields])
+    } catch {
+        errors.append(["index": index, "uid": uid, "error": error.localizedDescription])
+    }
+}
+
+if !updated.isEmpty {
+    do {
+        try store.commit()
+    } catch {
+        outputError("commit_failed", "Failed to commit batch: \(error.localizedDescription)")
+        exit(0)
+    }
+}
+
+let result: [String: Any] = ["updated": updated, "errors": errors]
+if let data = try? JSONSerialization.data(withJSONObject: result, options: [.sortedKeys]),
+   let str = String(data: data, encoding: .utf8) {
+    print(str)
+} else {
+    outputError("serialization_error", "Failed to serialize result")
+}


### PR DESCRIPTION
## Summary

New `update_events` tool for updating multiple events in one operation.

- Same stdin JSON + `store.commit()` pattern as `create_events`
- Each update object requires `uid` + at least one field to update
- Supports all fields: summary, start/end, location, description, alerts, availability, timezone, recurrence, clear_* flags
- Returns updated UIDs and errors separately (partial success)

### Usage
```python
update_events("Work", '[
  {"uid": "ABC-123", "summary": "New Title", "location": "Room B"},
  {"uid": "DEF-456", "alerts": [15, 30]},
  {"uid": "GHI-789", "start": "2026-04-01T15:00:00", "end": "2026-04-01T16:00:00"}
]')
```

Closes #100

## Test plan

- [x] `make test` — 133 unit tests pass
- [x] `make test-integration` — 46 integration tests pass
- [x] Manual test: batch update 3 events with different fields → all verified
- [x] Blind evals: 4/4 pass (batch vs single selection, time shift, alerts, availability)

🤖 Generated with [Claude Code](https://claude.com/claude-code)