### PR TITLE
Add smart availability filtering (issue #101)

### DIFF
--- a/src/apple_calendar_mcp/calendar_connector.py
+++ b/src/apple_calendar_mcp/calendar_connector.py
@@ -581,11 +581,74 @@ class CalendarConnector:
 
         return merged
 
+    @staticmethod
+    def _parse_time_string(time_str: str) -> tuple[int, int]:
+        """Parse 'HH:MM' time string to (hour, minute) tuple."""
+        parts = time_str.split(":")
+        if len(parts) != 2:
+            raise ValueError(
+                f"Invalid time format '{time_str}'. Expected 'HH:MM' (e.g., '09:00')"
+            )
+        try:
+            hour, minute = int(parts[0]), int(parts[1])
+        except ValueError:
+            raise ValueError(
+                f"Invalid time format '{time_str}'. Expected 'HH:MM' (e.g., '09:00')"
+            )
+        if not (0 <= hour <= 23 and 0 <= minute <= 59):
+            raise ValueError(
+                f"Invalid time '{time_str}'. Hour must be 0-23, minute must be 0-59"
+            )
+        return (hour, minute)
+
+    def _clip_to_working_hours(
+        self,
+        slots: list[dict[str, Any]],
+        wh_start: tuple[int, int],
+        wh_end: tuple[int, int],
+    ) -> list[dict[str, Any]]:
+        """Clip free slots to working hours, splitting multi-day slots per day."""
+        clipped: list[dict[str, Any]] = []
+        for slot in slots:
+            slot_start = self._parse_iso_datetime(slot["start_date"])
+            slot_end = self._parse_iso_datetime(slot["end_date"])
+
+            current_day = slot_start.date()
+            end_day = slot_end.date()
+            if slot_end.time() == datetime.min.time() and end_day > current_day:
+                end_day -= timedelta(days=1)
+
+            while current_day <= end_day:
+                wh_begin = datetime(
+                    current_day.year, current_day.month, current_day.day,
+                    wh_start[0], wh_start[1],
+                )
+                wh_finish = datetime(
+                    current_day.year, current_day.month, current_day.day,
+                    wh_end[0], wh_end[1],
+                )
+                clipped_start = max(slot_start, wh_begin)
+                clipped_end = min(slot_end, wh_finish)
+
+                if clipped_start < clipped_end:
+                    duration = int((clipped_end - clipped_start).total_seconds() / 60)
+                    clipped.append({
+                        "start_date": clipped_start.isoformat(),
+                        "end_date": clipped_end.isoformat(),
+                        "duration_minutes": duration,
+                    })
+                current_day += timedelta(days=1)
+
+        return clipped
+
     def get_availability(
         self,
         calendar_names: list[str],
         start_date: str,
         end_date: str,
+        min_duration_minutes: int | None = None,
+        working_hours_start: str | None = None,
+        working_hours_end: str | None = None,
     ) -> list[dict[str, Any]]:
         """Get free time slots across one or more calendars.
 
@@ -596,6 +659,9 @@ class CalendarConnector:
             calendar_names: List of calendar names to check
             start_date: Start of range in ISO 8601 format
             end_date: End of range in ISO 8601 format
+            min_duration_minutes: Only return slots of at least this many minutes
+            working_hours_start: Start of working hours as 'HH:MM' (e.g., '09:00')
+            working_hours_end: End of working hours as 'HH:MM' (e.g., '17:00')
 
         Returns:
             List of dicts with 'start_date', 'end_date', 'duration_minutes' keys
@@ -605,6 +671,23 @@ class CalendarConnector:
             ValueError: If date format is invalid, calendar not found, or no calendars provided
             PermissionError: If EventKit calendar access is denied
         """
+        if min_duration_minutes is not None and min_duration_minutes < 1:
+            raise ValueError("min_duration_minutes must be a positive integer")
+
+        wh_start = None
+        wh_end = None
+        if working_hours_start is not None or working_hours_end is not None:
+            if working_hours_start is None or working_hours_end is None:
+                raise ValueError(
+                    "Both working_hours_start and working_hours_end must be provided together"
+                )
+            wh_start = self._parse_time_string(working_hours_start)
+            wh_end = self._parse_time_string(working_hours_end)
+            if wh_start >= wh_end:
+                raise ValueError(
+                    "working_hours_start must be before working_hours_end"
+                )
+
         if not calendar_names:
             raise ValueError("At least one calendar name must be provided")
 
@@ -640,6 +723,14 @@ class CalendarConnector:
                 "end_date": range_end.isoformat(),
                 "duration_minutes": duration,
             })
+
+        if wh_start is not None and wh_end is not None:
+            free_slots = self._clip_to_working_hours(free_slots, wh_start, wh_end)
+
+        if min_duration_minutes is not None:
+            free_slots = [
+                s for s in free_slots if s["duration_minutes"] >= min_duration_minutes
+            ]
 
         return free_slots
 

--- a/src/apple_calendar_mcp/server_fastmcp.py
+++ b/src/apple_calendar_mcp/server_fastmcp.py
@@ -390,6 +390,9 @@ def get_availability(
     calendar_names: list[str],
     start_date: str,
     end_date: str,
+    min_duration_minutes: int | None = None,
+    working_hours_start: str | None = None,
+    working_hours_end: str | None = None,
 ) -> str:
     """Find free time slots across one or more calendars.
 
@@ -402,6 +405,9 @@ def get_availability(
         calendar_names: List of calendar names to check for combined availability
         start_date: Start of range in ISO 8601 format (e.g., "2026-03-15T09:00:00")
         end_date: End of range in ISO 8601 format (e.g., "2026-03-15T17:00:00")
+        min_duration_minutes: Only return slots of at least this many minutes (e.g., 45)
+        working_hours_start: Start of working hours as HH:MM (e.g., "09:00")
+        working_hours_end: End of working hours as HH:MM (e.g., "17:00")
     """
     client = get_client()
     try:
@@ -409,16 +415,26 @@ def get_availability(
             calendar_names=calendar_names,
             start_date=start_date,
             end_date=end_date,
+            min_duration_minutes=min_duration_minutes,
+            working_hours_start=working_hours_start,
+            working_hours_end=working_hours_end,
         )
     except Exception as e:
         return f"Error checking availability: {e}"
 
     cal_list = ", ".join(f"'{c}'" for c in calendar_names)
+    filters = []
+    if min_duration_minutes:
+        filters.append(f">= {min_duration_minutes} min")
+    if working_hours_start and working_hours_end:
+        filters.append(f"{working_hours_start}-{working_hours_end}")
+    filter_desc = f" ({', '.join(filters)})" if filters else ""
+
     if not slots:
-        return f"No free time in {cal_list} between {start_date} and {end_date}."
+        return f"No free time in {cal_list} between {start_date} and {end_date}{filter_desc}."
 
     lines = [_format_free_slot(slot) for slot in slots]
-    return f"Found {len(slots)} free slot(s) across {cal_list}:\n\n" + "\n".join(lines)
+    return f"Found {len(slots)} free slot(s) across {cal_list}{filter_desc}:\n\n" + "\n".join(lines)
 
 
 @mcp.tool()

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -555,6 +555,50 @@ class TestGetAvailabilityIntegration:
         assert len(slots) == 1
         assert slots[0]["duration_minutes"] == 480
 
+    def test_min_duration_filters_short_slots(self, connector):
+        """Create event leaving short gaps, verify min_duration filters them."""
+        uid = connector.create_event(
+            calendar_name=TEST_CALENDAR,
+            summary="Availability Filter Test",
+            start_date="2099-07-01T09:20:00",
+            end_date="2099-07-01T10:00:00",
+        )
+        try:
+            # Without filter: 9:00-9:20 (20m) and 10:00-12:00 (120m)
+            all_slots = connector.get_availability(
+                calendar_names=[TEST_CALENDAR],
+                start_date="2099-07-01T09:00:00",
+                end_date="2099-07-01T12:00:00",
+            )
+            assert len(all_slots) == 2
+
+            # With filter: only 10:00-12:00 (120m) passes
+            filtered = connector.get_availability(
+                calendar_names=[TEST_CALENDAR],
+                start_date="2099-07-01T09:00:00",
+                end_date="2099-07-01T12:00:00",
+                min_duration_minutes=30,
+            )
+            assert len(filtered) == 1
+            assert filtered[0]["start_date"] == "2099-07-01T10:00:00"
+            assert filtered[0]["duration_minutes"] == 120
+        finally:
+            _delete_event_by_uid(uid)
+
+    def test_working_hours_clips_range(self, connector):
+        """Working hours clip free slots to the specified window."""
+        slots = connector.get_availability(
+            calendar_names=[TEST_CALENDAR],
+            start_date="2099-08-01T00:00:00",
+            end_date="2099-08-02T00:00:00",
+            working_hours_start="09:00",
+            working_hours_end="17:00",
+        )
+        assert len(slots) == 1
+        assert slots[0]["start_date"] == "2099-08-01T09:00:00"
+        assert slots[0]["end_date"] == "2099-08-01T17:00:00"
+        assert slots[0]["duration_minutes"] == 480
+
 
 class TestRecurringEventsIntegration:
     """Integration tests for recurring event handling."""

--- a/tests/unit/test_calendar_connector.py
+++ b/tests/unit/test_calendar_connector.py
@@ -747,6 +747,194 @@ class TestGetAvailability:
         assert result[2]["start_date"] == "2026-03-15T15:00:00"
 
 
+# ── get_availability: smart filtering ──────────────────────────────────────
+
+
+class TestGetAvailabilityFiltering:
+    """Tests for get_availability min_duration and working_hours params."""
+
+    def setup_method(self):
+        self.connector = CalendarConnector()
+
+    def _make_event(self, start, end):
+        return {
+            "uid": "UID-1", "summary": "Event", "start_date": start,
+            "end_date": end, "allday_event": False, "location": "",
+            "description": "", "url": "", "status": "confirmed",
+            "calendar_name": "Work",
+        }
+
+    @patch("apple_calendar_mcp.calendar_connector.run_swift_helper")
+    def test_min_duration_filters_short_slots(self, mock_swift):
+        """Slots shorter than min_duration_minutes are excluded."""
+        mock_swift.return_value = json.dumps([
+            self._make_event("2026-03-15T10:00:00", "2026-03-15T10:30:00"),
+            self._make_event("2026-03-15T12:00:00", "2026-03-15T13:00:00"),
+        ])
+        result = self.connector.get_availability(
+            ["Work"], "2026-03-15T09:00:00", "2026-03-15T17:00:00",
+            min_duration_minutes=45,
+        )
+        # 9:00-10:00 (60m) ✓, 10:30-12:00 (90m) ✓, 13:00-17:00 (240m) ✓
+        assert len(result) == 3
+        assert all(s["duration_minutes"] >= 45 for s in result)
+
+    @patch("apple_calendar_mcp.calendar_connector.run_swift_helper")
+    def test_min_duration_excludes_all(self, mock_swift):
+        """All slots shorter than threshold → empty result."""
+        mock_swift.return_value = json.dumps([
+            self._make_event("2026-03-15T09:30:00", "2026-03-15T10:00:00"),
+        ])
+        result = self.connector.get_availability(
+            ["Work"], "2026-03-15T09:00:00", "2026-03-15T10:30:00",
+            min_duration_minutes=60,
+        )
+        # 9:00-9:30 (30m) ✗, 10:00-10:30 (30m) ✗
+        assert len(result) == 0
+
+    @patch("apple_calendar_mcp.calendar_connector.run_swift_helper")
+    def test_working_hours_clips_single_day(self, mock_swift):
+        """Free slot clipped to working hours window."""
+        mock_swift.return_value = "[]"
+        result = self.connector.get_availability(
+            ["Work"], "2026-03-15T00:00:00", "2026-03-16T00:00:00",
+            working_hours_start="09:00", working_hours_end="17:00",
+        )
+        assert len(result) == 1
+        assert result[0]["start_date"] == "2026-03-15T09:00:00"
+        assert result[0]["end_date"] == "2026-03-15T17:00:00"
+        assert result[0]["duration_minutes"] == 480
+
+    @patch("apple_calendar_mcp.calendar_connector.run_swift_helper")
+    def test_working_hours_clips_partial_overlap(self, mock_swift):
+        """Slot starting before working hours gets clipped to start."""
+        mock_swift.return_value = json.dumps([
+            self._make_event("2026-03-15T12:00:00", "2026-03-15T13:00:00"),
+        ])
+        result = self.connector.get_availability(
+            ["Work"], "2026-03-15T06:00:00", "2026-03-15T20:00:00",
+            working_hours_start="09:00", working_hours_end="17:00",
+        )
+        # 6:00-12:00 clipped to 9:00-12:00 (180m), 13:00-20:00 clipped to 13:00-17:00 (240m)
+        assert len(result) == 2
+        assert result[0]["start_date"] == "2026-03-15T09:00:00"
+        assert result[0]["end_date"] == "2026-03-15T12:00:00"
+        assert result[0]["duration_minutes"] == 180
+        assert result[1]["start_date"] == "2026-03-15T13:00:00"
+        assert result[1]["end_date"] == "2026-03-15T17:00:00"
+        assert result[1]["duration_minutes"] == 240
+
+    @patch("apple_calendar_mcp.calendar_connector.run_swift_helper")
+    def test_working_hours_slot_outside_window(self, mock_swift):
+        """Slot entirely outside working hours is excluded."""
+        mock_swift.return_value = json.dumps([
+            self._make_event("2026-03-15T09:00:00", "2026-03-15T17:00:00"),
+        ])
+        result = self.connector.get_availability(
+            ["Work"], "2026-03-15T06:00:00", "2026-03-15T20:00:00",
+            working_hours_start="09:00", working_hours_end="17:00",
+        )
+        # 6:00-9:00 outside WH, 17:00-20:00 outside WH → both excluded
+        assert len(result) == 0
+
+    @patch("apple_calendar_mcp.calendar_connector.run_swift_helper")
+    def test_working_hours_multi_day_split(self, mock_swift):
+        """Multi-day free slot split into per-day working hour windows."""
+        mock_swift.return_value = "[]"
+        result = self.connector.get_availability(
+            ["Work"], "2026-03-15T00:00:00", "2026-03-18T00:00:00",
+            working_hours_start="09:00", working_hours_end="17:00",
+        )
+        # 3 days: Mar 15, 16, 17 → 3 slots of 8h each
+        assert len(result) == 3
+        assert result[0]["start_date"] == "2026-03-15T09:00:00"
+        assert result[0]["end_date"] == "2026-03-15T17:00:00"
+        assert result[1]["start_date"] == "2026-03-16T09:00:00"
+        assert result[2]["start_date"] == "2026-03-17T09:00:00"
+        assert all(s["duration_minutes"] == 480 for s in result)
+
+    @patch("apple_calendar_mcp.calendar_connector.run_swift_helper")
+    def test_combined_working_hours_and_min_duration(self, mock_swift):
+        """Working hours clip first, then min_duration filters remainders."""
+        mock_swift.return_value = json.dumps([
+            self._make_event("2026-03-15T09:00:00", "2026-03-15T09:30:00"),
+            self._make_event("2026-03-15T12:00:00", "2026-03-15T16:45:00"),
+        ])
+        result = self.connector.get_availability(
+            ["Work"], "2026-03-15T06:00:00", "2026-03-15T20:00:00",
+            min_duration_minutes=30,
+            working_hours_start="09:00", working_hours_end="17:00",
+        )
+        # After WH clip: 9:30-12:00 (150m) ✓, 16:45-17:00 (15m) ✗
+        assert len(result) == 1
+        assert result[0]["start_date"] == "2026-03-15T09:30:00"
+        assert result[0]["duration_minutes"] == 150
+
+    def test_working_hours_start_only_raises(self):
+        with pytest.raises(ValueError, match="Both working_hours"):
+            self.connector.get_availability(
+                ["Work"], "2026-03-15T09:00:00", "2026-03-15T17:00:00",
+                working_hours_start="09:00",
+            )
+
+    def test_working_hours_end_only_raises(self):
+        with pytest.raises(ValueError, match="Both working_hours"):
+            self.connector.get_availability(
+                ["Work"], "2026-03-15T09:00:00", "2026-03-15T17:00:00",
+                working_hours_end="17:00",
+            )
+
+    def test_invalid_time_format_raises(self):
+        with pytest.raises(ValueError, match="Invalid time format"):
+            self.connector.get_availability(
+                ["Work"], "2026-03-15T09:00:00", "2026-03-15T17:00:00",
+                working_hours_start="9am", working_hours_end="5pm",
+            )
+
+    def test_working_hours_start_after_end_raises(self):
+        with pytest.raises(ValueError, match="must be before"):
+            self.connector.get_availability(
+                ["Work"], "2026-03-15T09:00:00", "2026-03-15T17:00:00",
+                working_hours_start="17:00", working_hours_end="09:00",
+            )
+
+    def test_min_duration_zero_raises(self):
+        with pytest.raises(ValueError, match="positive integer"):
+            self.connector.get_availability(
+                ["Work"], "2026-03-15T09:00:00", "2026-03-15T17:00:00",
+                min_duration_minutes=0,
+            )
+
+    def test_min_duration_negative_raises(self):
+        with pytest.raises(ValueError, match="positive integer"):
+            self.connector.get_availability(
+                ["Work"], "2026-03-15T09:00:00", "2026-03-15T17:00:00",
+                min_duration_minutes=-10,
+            )
+
+
+class TestParseTimeString:
+    """Tests for CalendarConnector._parse_time_string()."""
+
+    def test_valid_time(self):
+        assert CalendarConnector._parse_time_string("09:00") == (9, 0)
+        assert CalendarConnector._parse_time_string("17:30") == (17, 30)
+        assert CalendarConnector._parse_time_string("00:00") == (0, 0)
+        assert CalendarConnector._parse_time_string("23:59") == (23, 59)
+
+    def test_invalid_format(self):
+        with pytest.raises(ValueError, match="Invalid time format"):
+            CalendarConnector._parse_time_string("9am")
+
+    def test_out_of_range_hour(self):
+        with pytest.raises(ValueError, match="Hour must be 0-23"):
+            CalendarConnector._parse_time_string("25:00")
+
+    def test_out_of_range_minute(self):
+        with pytest.raises(ValueError, match="minute must be 0-59"):
+            CalendarConnector._parse_time_string("09:60")
+
+
 # ── update_event ────────────────────────────────────────────────────────────
 
 

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -389,6 +389,9 @@ class TestGetAvailabilityTool:
             calendar_names=["Work", "Personal"],
             start_date="2026-03-15T09:00:00",
             end_date="2026-03-15T17:00:00",
+            min_duration_minutes=None,
+            working_hours_start=None,
+            working_hours_end=None,
         )
 
     @patch("apple_calendar_mcp.server_fastmcp.get_client")
@@ -414,6 +417,65 @@ class TestGetAvailabilityTool:
         from apple_calendar_mcp.server_fastmcp import get_availability
         result = get_availability(calendar_names=["Work"], start_date="2026-03-15T09:00:00", end_date="2026-03-15T17:00:00")
         assert "30m" in result
+
+    @patch("apple_calendar_mcp.server_fastmcp.get_client")
+    def test_passes_filter_params_through(self, mock_get_client):
+        mock_client = MagicMock()
+        mock_client.get_availability.return_value = []
+        mock_get_client.return_value = mock_client
+
+        from apple_calendar_mcp.server_fastmcp import get_availability
+        get_availability(
+            calendar_names=["Work"],
+            start_date="2026-03-15T09:00:00",
+            end_date="2026-03-15T17:00:00",
+            min_duration_minutes=45,
+            working_hours_start="09:00",
+            working_hours_end="17:00",
+        )
+        mock_client.get_availability.assert_called_once_with(
+            calendar_names=["Work"],
+            start_date="2026-03-15T09:00:00",
+            end_date="2026-03-15T17:00:00",
+            min_duration_minutes=45,
+            working_hours_start="09:00",
+            working_hours_end="17:00",
+        )
+
+    @patch("apple_calendar_mcp.server_fastmcp.get_client")
+    def test_output_includes_filter_description(self, mock_get_client):
+        mock_client = MagicMock()
+        mock_client.get_availability.return_value = [
+            {"start_date": "2026-03-15T09:00:00", "end_date": "2026-03-15T10:00:00", "duration_minutes": 60},
+        ]
+        mock_get_client.return_value = mock_client
+
+        from apple_calendar_mcp.server_fastmcp import get_availability
+        result = get_availability(
+            calendar_names=["Work"],
+            start_date="2026-03-15T09:00:00",
+            end_date="2026-03-15T17:00:00",
+            min_duration_minutes=45,
+            working_hours_start="09:00",
+            working_hours_end="17:00",
+        )
+        assert ">= 45 min" in result
+        assert "09:00-17:00" in result
+
+    @patch("apple_calendar_mcp.server_fastmcp.get_client")
+    def test_no_filter_description_without_params(self, mock_get_client):
+        mock_client = MagicMock()
+        mock_client.get_availability.return_value = []
+        mock_get_client.return_value = mock_client
+
+        from apple_calendar_mcp.server_fastmcp import get_availability
+        result = get_availability(
+            calendar_names=["Work"],
+            start_date="2026-03-15T09:00:00",
+            end_date="2026-03-15T17:00:00",
+        )
+        assert ">=" not in result
+        assert "09:00-17:00" not in result
 
 
 class TestUpdateEventTool:


### PR DESCRIPTION
## Summary
- Add `min_duration_minutes` param to `get_availability` — only return slots of at least N minutes
- Add `working_hours_start`/`working_hours_end` params — clip free slots to daily working hours window (e.g., 09:00-17:00), splitting multi-day slots per day
- Working hours clipping applied first, then min_duration filtering
- Output message includes active filter description when filters are used

Closes #101

## Test plan
- [x] 13 new unit tests for filtering logic (min_duration, working hours clip, multi-day split, combined, validation errors)
- [x] 4 new unit tests for `_parse_time_string` helper
- [x] 3 new server tool tests (pass-through, filter description, no-filter baseline)
- [x] 2 new integration tests (min_duration filtering, working hours clipping)
- [x] All 153 tests pass, no complexity violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)