### PR TITLE
Rename 'description' to 'notes' across API surface (#108)

### DIFF
--- a/src/apple_calendar_mcp/calendar_connector.py
+++ b/src/apple_calendar_mcp/calendar_connector.py
@@ -160,7 +160,7 @@ class CalendarConnector:
         start_date: str,
         end_date: str,
         location: Optional[str] = None,
-        description: Optional[str] = None,
+        notes: Optional[str] = None,
         url: Optional[str] = None,
         allday_event: bool = False,
         recurrence_rule: Optional[str] = None,
@@ -176,7 +176,7 @@ class CalendarConnector:
             start_date: Start date/time in ISO 8601 format
             end_date: End date/time in ISO 8601 format
             location: Event location (optional)
-            description: Event notes (optional)
+            notes: Event notes (optional)
             url: URL associated with the event (optional)
             allday_event: Whether this is an all-day event
             recurrence_rule: iCalendar RRULE string (optional, e.g. "FREQ=WEEKLY;BYDAY=MO,WE,FR")
@@ -198,8 +198,8 @@ class CalendarConnector:
                 "--start", start_date, "--end", end_date]
         if location:
             args += ["--location", location]
-        if description:
-            args += ["--description", description]
+        if notes:
+            args += ["--notes", notes]
         if url:
             args += ["--url", url]
         if allday_event:
@@ -227,7 +227,7 @@ class CalendarConnector:
         Args:
             calendar_name: Name of the target calendar (all events go to same calendar)
             events: List of event dicts, each with keys: summary, start, end,
-                    and optional: location, description, url, allday, recurrence,
+                    and optional: location, notes, url, allday, recurrence,
                     alerts (list of int), availability, timezone
 
         Returns:
@@ -253,9 +253,9 @@ class CalendarConnector:
         Args:
             calendar_name: Name of the calendar containing the events
             updates: List of update dicts, each with 'uid' (required) and optional fields
-                     to update: summary, start, end, location, description, url, allday,
+                     to update: summary, start, end, location, notes, url, allday,
                      alerts, availability, timezone, recurrence, clear_location,
-                     clear_description, clear_url, clear_alerts, clear_recurrence
+                     clear_notes, clear_url, clear_alerts, clear_recurrence
 
         Returns:
             Dict with 'updated' (list of {uid, summary, updated_fields}) and 'errors'
@@ -304,7 +304,7 @@ class CalendarConnector:
 
         Returns:
             List of event dicts with keys: uid, summary, start_date, end_date,
-            allday_event, location, description, url, status, calendar_name.
+            allday_event, location, notes, url, status, calendar_name.
 
         Raises:
             ValueError: If date format is invalid or calendar not found
@@ -325,7 +325,7 @@ class CalendarConnector:
     ) -> list[dict[str, Any]]:
         """Search events by text across one or all calendars.
 
-        Searches event summaries, descriptions, and locations with
+        Searches event summaries, notes, and locations with
         case-insensitive matching.
 
         Args:
@@ -371,7 +371,7 @@ class CalendarConnector:
         start_date: str | None = None,
         end_date: str | None = None,
         location: str | None = None,
-        description: str | None = None,
+        notes: str | None = None,
         url: str | None = None,
         allday_event: bool | None = None,
         alert_minutes: list[int] | None = None,
@@ -393,7 +393,7 @@ class CalendarConnector:
             start_date: New start date/time in ISO 8601 format (optional)
             end_date: New end date/time in ISO 8601 format (optional)
             location: New location (optional, "" to clear)
-            description: New description (optional, "" to clear)
+            notes: New notes (optional, "" to clear)
             url: New URL (optional, "" to clear)
             allday_event: New all-day status (optional)
             occurrence_date: For recurring events, the date of the specific occurrence to update (optional)
@@ -413,7 +413,7 @@ class CalendarConnector:
             "start_date": start_date,
             "end_date": end_date,
             "location": location,
-            "description": description,
+            "notes": notes,
             "url": url,
             "allday_event": allday_event,
         }
@@ -466,10 +466,10 @@ class CalendarConnector:
             "start_date": "--start",
             "end_date": "--end",
             "location": "--location",
-            "description": "--description",
+            "notes": "--notes",
             "url": "--url",
         }
-        clearable = {"location", "description", "url"}
+        clearable = {"location", "notes", "url"}
         date_fields = {"start_date", "end_date"}
 
         for field_name, value in fields.items():

--- a/src/apple_calendar_mcp/server_fastmcp.py
+++ b/src/apple_calendar_mcp/server_fastmcp.py
@@ -14,7 +14,7 @@ CALENDARS: Each calendar has a name, writable status, type (caldav, subscription
 
 CALENDAR IDENTIFICATION: Calendars are identified by name (not UID — UIDs are not accessible via AppleScript). When specifying a calendar, use the exact name as returned by get_calendars.
 
-EVENTS: Events have summary (title), start/end dates, location, description (notes), URL, status, recurrence, attendees, and editability info. Events are identified by their UID (UUID format). The is_editable field indicates whether the event can be modified — events on read-only calendars or events where you are not the organizer (invited events) are not editable. Attendees are read-only — they cannot be added via this server (use Calendar.app or email invitations).
+EVENTS: Events have summary (title), start/end dates, location, notes, URL, status, recurrence, attendees, and editability info. Events are identified by their UID (UUID format). The is_editable field indicates whether the event can be modified — events on read-only calendars or events where you are not the organizer (invited events) are not editable. Attendees are read-only — they cannot be added via this server (use Calendar.app or email invitations).
 
 RECURRING EVENTS: Recurring events share the same UID across all occurrences. Each occurrence has a unique occurrence_date. The is_recurring field indicates if an event is part of a series. The recurrence_rule field contains the iCalendar RRULE (e.g., "FREQ=WEEKLY;INTERVAL=1;BYDAY=MO,WE,FR"). To modify or delete a specific occurrence, pass occurrence_date and span="this_event". To modify or delete the series from a point onward, use span="future_events".
 
@@ -112,7 +112,7 @@ def create_event(
     start_date: str,
     end_date: str,
     location: str = "",
-    description: str = "",
+    notes: str = "",
     url: str = "",
     allday_event: bool = False,
     recurrence_rule: str = "",
@@ -128,7 +128,7 @@ def create_event(
         start_date: Start date/time in ISO 8601 format (e.g., "2026-03-15" for all-day, "2026-03-15T14:30:00" for timed)
         end_date: End date/time in ISO 8601 format (must be after start_date)
         location: Event location (optional)
-        description: Event notes/description (optional)
+        notes: Event notes (optional)
         url: URL associated with the event (optional)
         allday_event: Whether this is an all-day event (default: false). When true, use date-only format for start_date/end_date.
         recurrence_rule: iCalendar RRULE string for recurring events (optional, e.g., "FREQ=WEEKLY;BYDAY=MO,WE,FR" or "FREQ=DAILY;COUNT=10")
@@ -145,7 +145,7 @@ def create_event(
             start_date=start_date,
             end_date=end_date,
             location=location or None,
-            description=description or None,
+            notes=notes or None,
             url=url or None,
             allday_event=allday_event,
             recurrence_rule=recurrence_rule or None,
@@ -180,7 +180,7 @@ def create_events(
         calendar_name: Exact name of the target calendar
         events: JSON array of event objects. Each object has keys: summary (required),
                 start (required, ISO 8601), end (required, ISO 8601), and optional:
-                location, description, url, allday (bool), recurrence (RRULE string),
+                location, notes, url, allday (bool), recurrence (RRULE string),
                 alerts (list of minutes, e.g. [15, 60]), availability ("free"/"busy"/"tentative"),
                 timezone (IANA identifier, e.g. "America/Los_Angeles")
     """
@@ -228,9 +228,9 @@ def update_events(
         calendar_name: Exact name of the calendar containing the events
         updates: JSON array of update objects. Each object must have "uid" (required)
                  and at least one field to update: summary, start (ISO 8601), end (ISO 8601),
-                 location, description, url, allday (bool), alerts (list of minutes),
+                 location, notes, url, allday (bool), alerts (list of minutes),
                  availability ("free"/"busy"/"tentative"), timezone (IANA identifier),
-                 recurrence (RRULE string), clear_location (bool), clear_description (bool),
+                 recurrence (RRULE string), clear_location (bool), clear_notes (bool),
                  clear_url (bool), clear_alerts (bool), clear_recurrence (bool)
     """
     try:
@@ -273,8 +273,8 @@ def _format_event(event: dict) -> str:
         result += "All-day event\n"
     if event.get("location"):
         result += f"Location: {event['location']}\n"
-    if event.get("description"):
-        result += f"Description: {event['description']}\n"
+    if event.get("notes"):
+        result += f"Notes: {event['notes']}\n"
     if event.get("url"):
         result += f"URL: {event['url']}\n"
     if event.get("is_recurring"):
@@ -342,12 +342,12 @@ def search_events(
 ) -> str:
     """Search events by text across one or all calendars.
 
-    Searches event summaries, descriptions, and locations with case-insensitive
+    Searches event summaries, notes, and locations with case-insensitive
     matching. If no calendar is specified, searches all calendars. If no date
     range is specified, searches from 1 month ago to 6 months from now.
 
     Args:
-        query: Text to search for in event titles, descriptions, and locations
+        query: Text to search for in event titles, notes, and locations
         calendar_name: Calendar to search (optional — searches all calendars if empty)
         start_date: Start of date range in ISO 8601 format (optional)
         end_date: End of date range in ISO 8601 format (optional)
@@ -445,7 +445,7 @@ def update_event(
     start_date: str | None = None,
     end_date: str | None = None,
     location: str | None = None,
-    description: str | None = None,
+    notes: str | None = None,
     url: str | None = None,
     allday_event: bool | None = None,
     alert_minutes: str = "",
@@ -458,7 +458,7 @@ def update_event(
     """Update an existing event's properties by UID.
 
     Only provided fields are updated; omitted fields are left unchanged.
-    To clear a text field (location, description, url), pass an empty string "".
+    To clear a text field (location, notes, url), pass an empty string "".
 
     Use get_events first to find the event's UID and calendar_name.
 
@@ -472,7 +472,7 @@ def update_event(
         start_date: New start date/time in ISO 8601 format (optional)
         end_date: New end date/time in ISO 8601 format (optional)
         location: New location, or "" to clear (optional)
-        description: New description/notes, or "" to clear (optional)
+        notes: New notes, or "" to clear (optional)
         url: New URL, or "" to clear (optional)
         allday_event: New all-day status (optional)
         alert_minutes: Comma-separated minutes before event to alert (e.g., "15,60"), or "none" to clear all alerts (optional)
@@ -499,7 +499,7 @@ def update_event(
             start_date=start_date,
             end_date=end_date,
             location=location,
-            description=description,
+            notes=notes,
             url=url,
             allday_event=allday_event,
             alert_minutes=parsed_alerts,

--- a/src/apple_calendar_mcp/swift/create_event.swift
+++ b/src/apple_calendar_mcp/swift/create_event.swift
@@ -9,7 +9,7 @@ struct CreateEventArgs {
     let start: String
     let end: String
     var location: String?
-    var description: String?
+    var notes: String?
     var url: String?
     var allday: Bool = false
     var recurrence: String?
@@ -25,7 +25,7 @@ func parseArgs() -> CreateEventArgs? {
     var start: String?
     var end: String?
     var location: String?
-    var description: String?
+    var notes: String?
     var url: String?
     var allday = false
     var recurrence: String?
@@ -46,8 +46,8 @@ func parseArgs() -> CreateEventArgs? {
             i += 1; if i < args.count { end = args[i] }
         case "--location":
             i += 1; if i < args.count { location = args[i] }
-        case "--description":
-            i += 1; if i < args.count { description = args[i] }
+        case "--notes":
+            i += 1; if i < args.count { notes = args[i] }
         case "--url":
             i += 1; if i < args.count { url = args[i] }
         case "--allday":
@@ -71,7 +71,7 @@ func parseArgs() -> CreateEventArgs? {
     }
     var result = CreateEventArgs(calendar: cal, summary: sum, start: s, end: e)
     result.location = location
-    result.description = description
+    result.notes = notes
     result.url = url
     result.allday = allday
     result.recurrence = recurrence
@@ -271,8 +271,8 @@ event.isAllDay = parsed.allday
 if let location = parsed.location {
     event.location = location
 }
-if let description = parsed.description {
-    event.notes = description
+if let notes = parsed.notes {
+    event.notes = notes
 }
 if let urlStr = parsed.url, let url = URL(string: urlStr) {
     event.url = url

--- a/src/apple_calendar_mcp/swift/create_events.swift
+++ b/src/apple_calendar_mcp/swift/create_events.swift
@@ -176,7 +176,7 @@ for (index, eventData) in eventsJson.enumerated() {
     event.isAllDay = eventData["allday"] as? Bool ?? false
 
     if let location = eventData["location"] as? String { event.location = location }
-    if let description = eventData["description"] as? String { event.notes = description }
+    if let notes = eventData["notes"] as? String { event.notes = notes }
     if let urlStr = eventData["url"] as? String, let url = URL(string: urlStr) { event.url = url }
     if let rrule = eventData["recurrence"] as? String, let rule = parseRecurrenceRule(rrule) {
         event.addRecurrenceRule(rule)

--- a/src/apple_calendar_mcp/swift/get_events.swift
+++ b/src/apple_calendar_mcp/swift/get_events.swift
@@ -91,7 +91,7 @@ func eventToDict(_ event: EKEvent) -> [String: Any] {
     ]
 
     dict["location"] = event.location ?? ""
-    dict["description"] = event.notes ?? ""
+    dict["notes"] = event.notes ?? ""
     dict["url"] = event.url?.absoluteString ?? ""
 
     switch event.status {

--- a/src/apple_calendar_mcp/swift/update_event.swift
+++ b/src/apple_calendar_mcp/swift/update_event.swift
@@ -11,8 +11,8 @@ struct UpdateEventArgs {
     var end: String?
     var location: String?
     var clearLocation = false
-    var description: String?
-    var clearDescription = false
+    var notes: String?
+    var clearNotes = false
     var url: String?
     var clearUrl = false
     var allday: Bool?
@@ -50,10 +50,10 @@ func parseArgs() -> UpdateEventArgs? {
             i += 1; if i < args.count { result.location = args[i]; result.updatedFields.append("location") }
         case "--clear-location":
             result.clearLocation = true; result.updatedFields.append("location")
-        case "--description":
-            i += 1; if i < args.count { result.description = args[i]; result.updatedFields.append("description") }
-        case "--clear-description":
-            result.clearDescription = true; result.updatedFields.append("description")
+        case "--notes":
+            i += 1; if i < args.count { result.notes = args[i]; result.updatedFields.append("notes") }
+        case "--clear-notes":
+            result.clearNotes = true; result.updatedFields.append("notes")
         case "--url":
             i += 1; if i < args.count { result.url = args[i]; result.updatedFields.append("url") }
         case "--clear-url":
@@ -93,7 +93,7 @@ func parseArgs() -> UpdateEventArgs? {
         calendar: cal, uid: u,
         summary: result.summary, start: result.start, end: result.end,
         location: result.location, clearLocation: result.clearLocation,
-        description: result.description, clearDescription: result.clearDescription,
+        notes: result.notes, clearNotes: result.clearNotes,
         url: result.url, clearUrl: result.clearUrl,
         allday: result.allday, alertMinutes: result.alertMinutes,
         clearAlerts: result.clearAlerts, recurrence: result.recurrence,
@@ -304,9 +304,9 @@ if let location = parsed.location {
 } else if parsed.clearLocation {
     event.location = nil
 }
-if let description = parsed.description {
-    event.notes = description
-} else if parsed.clearDescription {
+if let notes = parsed.notes {
+    event.notes = notes
+} else if parsed.clearNotes {
     event.notes = nil
 }
 if let urlStr = parsed.url, let url = URL(string: urlStr) {
@@ -348,7 +348,7 @@ if isDateChange && isRecurringThisEvent {
     let newStart = (parsed.start != nil ? parseISO8601(parsed.start!, timeZone: eventTimeZone) : nil) ?? event.startDate!
     let newEnd = (parsed.end != nil ? parseISO8601(parsed.end!, timeZone: eventTimeZone) : nil) ?? event.endDate!
     let newLocation = parsed.clearLocation ? nil : (parsed.location ?? event.location)
-    let newNotes = parsed.clearDescription ? nil : (parsed.description ?? event.notes)
+    let newNotes = parsed.clearNotes ? nil : (parsed.notes ?? event.notes)
     let newUrl = parsed.clearUrl ? nil : (parsed.url.flatMap { URL(string: $0) } ?? event.url)
     let newAllDay = parsed.allday ?? event.isAllDay
     let newAlarms = event.alarms

--- a/src/apple_calendar_mcp/swift/update_events.swift
+++ b/src/apple_calendar_mcp/swift/update_events.swift
@@ -173,10 +173,10 @@ for (index, updateData) in updatesJson.enumerated() {
     } else if updateData["clear_location"] as? Bool == true {
         event.location = nil; updatedFields.append("location")
     }
-    if let description = updateData["description"] as? String {
-        event.notes = description; updatedFields.append("description")
-    } else if updateData["clear_description"] as? Bool == true {
-        event.notes = nil; updatedFields.append("description")
+    if let notes = updateData["notes"] as? String {
+        event.notes = notes; updatedFields.append("notes")
+    } else if updateData["clear_notes"] as? Bool == true {
+        event.notes = nil; updatedFields.append("notes")
     }
     if let urlStr = updateData["url"] as? String, let url = URL(string: urlStr) {
         event.url = url; updatedFields.append("url")

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -155,14 +155,14 @@ end tell'''
             _delete_event_by_uid(uid)
 
     def test_creates_event_with_optional_fields(self, connector):
-        """Creating an event with location, description, and URL should succeed."""
+        """Creating an event with location, notes, and URL should succeed."""
         uid = connector.create_event(
             calendar_name=TEST_CALENDAR,
             summary="Full Event Test",
             start_date="2026-06-15T09:00:00",
             end_date="2026-06-15T10:00:00",
             location="Conference Room B",
-            description="Test description with details",
+            notes="Test description with details",
             url="https://example.com/test",
         )
         try:
@@ -262,7 +262,7 @@ class TestGetEventsIntegration:
             assert len(test_events) == 1
             event = test_events[0]
             for key in ["uid", "summary", "start_date", "end_date", "allday_event",
-                         "location", "description", "url", "status", "calendar_name"]:
+                         "location", "notes", "url", "status", "calendar_name"]:
                 assert key in event, f"Missing key '{key}' in event"
             assert event["location"] == "Test Location"
             assert event["calendar_name"] == TEST_CALENDAR
@@ -841,7 +841,7 @@ class TestRoundTripIntegration:
             start_date="2027-03-01T14:00:00",
             end_date="2027-03-01T15:00:00",
             location="Conference Room",
-            description="Testing round-trip",
+            notes="Testing round-trip",
             url="https://example.com/test",
         )
         try:
@@ -851,7 +851,7 @@ class TestRoundTripIntegration:
             event = matches[0]
             assert event["summary"] == "Round Trip Test"
             assert event["location"] == "Conference Room"
-            assert event["description"] == "Testing round-trip"
+            assert event["notes"] == "Testing round-trip"
             assert event["url"] == "https://example.com/test"
             assert event["calendar_name"] == TEST_CALENDAR
         finally:

--- a/tests/unit/test_calendar_connector.py
+++ b/tests/unit/test_calendar_connector.py
@@ -390,13 +390,13 @@ class TestCreateEvent:
             start_date="2026-03-15T12:00:00",
             end_date="2026-03-15T13:00:00",
             location="Conference Room A",
-            description="Discuss project updates",
+            notes="Discuss project updates",
             url="https://example.com/meeting",
         )
         args = mock_swift.call_args[0][1]
         assert "--location" in args
         assert "Conference Room A" in args
-        assert "--description" in args
+        assert "--notes" in args
         assert "Discuss project updates" in args
         assert "--url" in args
         assert "https://example.com/meeting" in args
@@ -505,7 +505,7 @@ class TestGetEvents:
         mock_swift.return_value = json.dumps([
             {"uid": "ABC-123", "summary": "Meeting", "start_date": "2026-03-15T14:00:00",
              "end_date": "2026-03-15T15:00:00", "allday_event": False, "location": "",
-             "description": "", "url": "", "status": "confirmed", "calendar_name": "Work"},
+             "notes": "", "url": "", "status": "confirmed", "calendar_name": "Work"},
         ])
         result = self.connector.get_events("Work", "2026-03-15T00:00:00", "2026-03-16T00:00:00")
         assert isinstance(result, list)
@@ -554,7 +554,7 @@ class TestGetEvents:
         mock_swift.return_value = json.dumps([
             {"uid": "REC-123", "summary": "Weekly Standup", "start_date": "2026-07-01T09:00:00",
              "end_date": "2026-07-01T09:30:00", "allday_event": False, "location": "",
-             "description": "", "url": "", "status": "confirmed", "calendar_name": "Work",
+             "notes": "", "url": "", "status": "confirmed", "calendar_name": "Work",
              "is_recurring": True, "recurrence_rule": "FREQ=WEEKLY;INTERVAL=1;BYDAY=MO,WE,FR",
              "is_detached": False, "occurrence_date": "2026-07-01T09:00:00"},
         ])
@@ -570,7 +570,7 @@ class TestGetEvents:
         mock_swift.return_value = json.dumps([
             {"uid": "ATT-123", "summary": "Team Meeting", "start_date": "2026-07-01T14:00:00",
              "end_date": "2026-07-01T15:00:00", "allday_event": False, "location": "",
-             "description": "", "url": "", "status": "confirmed", "calendar_name": "Work",
+             "notes": "", "url": "", "status": "confirmed", "calendar_name": "Work",
              "is_recurring": False, "recurrence_rule": None, "is_detached": False,
              "occurrence_date": "2026-07-01T14:00:00",
              "attendees": [
@@ -590,7 +590,7 @@ class TestGetEvents:
         mock_swift.return_value = json.dumps([
             {"uid": "NO-ATT", "summary": "Solo Event", "start_date": "2026-07-01T10:00:00",
              "end_date": "2026-07-01T11:00:00", "allday_event": False, "location": "",
-             "description": "", "url": "", "status": "confirmed", "calendar_name": "Work",
+             "notes": "", "url": "", "status": "confirmed", "calendar_name": "Work",
              "is_recurring": False, "recurrence_rule": None, "is_detached": False,
              "occurrence_date": "2026-07-01T10:00:00", "attendees": []},
         ])
@@ -611,7 +611,7 @@ class TestGetAvailability:
         return {
             "uid": "UID-1", "summary": "Event", "start_date": start,
             "end_date": end, "allday_event": allday, "location": "",
-            "description": "", "url": "", "status": "confirmed",
+            "notes": "", "url": "", "status": "confirmed",
             "calendar_name": calendar,
         }
 
@@ -760,7 +760,7 @@ class TestGetAvailabilityFiltering:
         return {
             "uid": "UID-1", "summary": "Event", "start_date": start,
             "end_date": end, "allday_event": False, "location": "",
-            "description": "", "url": "", "status": "confirmed",
+            "notes": "", "url": "", "status": "confirmed",
             "calendar_name": "Work",
         }
 

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -194,7 +194,7 @@ class TestCreateEventTool:
             start_date="2026-03-15T12:00:00",
             end_date="2026-03-15T13:00:00",
             location="Room A",
-            description="Notes here",
+            notes="Notes here",
             url="https://example.com",
             allday_event=True,
         )
@@ -204,7 +204,7 @@ class TestCreateEventTool:
             start_date="2026-03-15T12:00:00",
             end_date="2026-03-15T13:00:00",
             location="Room A",
-            description="Notes here",
+            notes="Notes here",
             url="https://example.com",
             allday_event=True,
             recurrence_rule=None,
@@ -258,7 +258,7 @@ class TestGetEventsTool:
         mock_client.get_events.return_value = [
             {"uid": "ABC-123", "summary": "Team Meeting", "start_date": "2026-03-15T14:00:00",
              "end_date": "2026-03-15T15:00:00", "allday_event": False, "location": "Room 4",
-             "description": "Weekly sync", "url": "", "status": "confirmed", "calendar_name": "Work"},
+             "notes": "Weekly sync", "url": "", "status": "confirmed", "calendar_name": "Work"},
         ]
         mock_get_client.return_value = mock_client
 
@@ -274,7 +274,7 @@ class TestGetEventsTool:
         mock_client.get_events.return_value = [
             {"uid": "REC-123", "summary": "Weekly Standup", "start_date": "2026-07-01T09:00:00",
              "end_date": "2026-07-01T09:30:00", "allday_event": False, "location": "",
-             "description": "", "url": "", "status": "confirmed", "calendar_name": "Work",
+             "notes": "", "url": "", "status": "confirmed", "calendar_name": "Work",
              "is_recurring": True, "recurrence_rule": "FREQ=WEEKLY;INTERVAL=1;BYDAY=MO,WE,FR",
              "is_detached": False, "occurrence_date": "2026-07-01T09:00:00"},
         ]
@@ -291,7 +291,7 @@ class TestGetEventsTool:
         mock_client.get_events.return_value = [
             {"uid": "ATT-123", "summary": "Team Meeting", "start_date": "2026-07-01T14:00:00",
              "end_date": "2026-07-01T15:00:00", "allday_event": False, "location": "",
-             "description": "", "url": "", "status": "confirmed", "calendar_name": "Work",
+             "notes": "", "url": "", "status": "confirmed", "calendar_name": "Work",
              "attendees": [
                  {"name": "Alice", "email": "alice@example.com", "role": "required", "status": "accepted"},
                  {"name": "", "email": "bob@example.com", "role": "optional", "status": "pending"},
@@ -514,7 +514,7 @@ class TestUpdateEventTool:
         update_event(calendar_name="Work", event_uid="ABC-123", summary="New")
         call_kwargs = mock_client.update_event.call_args[1]
         assert call_kwargs["location"] is None
-        assert call_kwargs["description"] is None
+        assert call_kwargs["notes"] is None
         assert call_kwargs["url"] is None
         assert call_kwargs["allday_event"] is None
 


### PR DESCRIPTION
## Summary
- Rename the `description` field/param to `notes` across the entire API surface
- EventKit uses `event.notes` and Calendar.app displays "Notes" — this aligns the API with what users see
- Claude was observed deleting and recreating events instead of using `update_event(description=...)`, likely because "description" didn't map to the "Notes" field in Calendar.app

Closes #108

## Test plan
- [x] All 153 unit tests pass
- [x] Grep confirms no leftover `--description` or `clear_description` references in source
- [x] Calendar-level `description` fields (different concept) correctly left unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)