### PR TITLE
Fix 6 issues from comprehensive code review (#63)

### DIFF
--- a/src/apple_calendar_mcp/calendar_connector.py
+++ b/src/apple_calendar_mcp/calendar_connector.py
@@ -114,34 +114,17 @@ class CalendarConnector:
         text = text.replace('"', '\\"')
         return text
 
-    def _iso_to_applescript_date(self, iso_date: str) -> str:
-        """Convert ISO 8601 date to AppleScript date format.
-
-        Args:
-            iso_date: Date in ISO 8601 format (e.g., "2026-03-15" or "2026-03-15T14:30:00")
-
-        Returns:
-            str: Date in AppleScript format (e.g., "March 15, 2026 02:30:00 PM")
-        """
-        try:
-            if "T" in iso_date:
-                dt = datetime.fromisoformat(iso_date.replace("Z", "+00:00"))
-            else:
-                dt = datetime.fromisoformat(iso_date + "T00:00:00")
-        except ValueError as e:
-            raise ValueError(
-                f"Invalid date format '{iso_date}'. "
-                "Expected ISO 8601 format like '2026-03-15' or '2026-03-15T14:30:00'"
-            ) from e
-
-        # Format for AppleScript: "March 15, 2026 02:30:00 PM"
-        return dt.strftime("%B %d, %Y %I:%M:%S %p")
-
     def _run_swift_helper_json(
         self, script_name: str, args: list[str], stdin_data: Optional[str] = None
     ) -> dict:
         """Run a Swift helper and parse JSON response, raising on errors."""
-        result = run_swift_helper(script_name, args, stdin_data=stdin_data)
+        try:
+            result = run_swift_helper(script_name, args, stdin_data=stdin_data)
+        except subprocess.CalledProcessError as e:
+            # Swift helpers exit(1) on error but still write JSON to stdout
+            result = (e.stdout or "").strip()
+            if not result:
+                raise RuntimeError(f"Swift helper '{script_name}' failed with no output") from e
         parsed = json.loads(result)
         if isinstance(parsed, dict) and "error" in parsed:
             error_map = {
@@ -264,6 +247,13 @@ class CalendarConnector:
 
         if not updates:
             raise ValueError("At least one update must be provided")
+
+        for i, update in enumerate(updates):
+            if "occurrence_date" in update:
+                raise ValueError(
+                    f"update_events does not support occurrence_date (update index {i}). "
+                    "Use update_event (singular) to target specific recurring event occurrences."
+                )
 
         stdin_data = json.dumps(updates)
         return self._run_swift_helper_json(
@@ -442,12 +432,14 @@ class CalendarConnector:
 
         if timezone:
             args += ["--timezone", timezone]
+            updated_fields.append("timezone")
 
         if not updated_fields:
             raise ValueError("At least one field must be provided to update")
 
-        self._run_swift_helper_json("update_event", args)
-        return {"uid": event_uid, "updated_fields": updated_fields}
+        result = self._run_swift_helper_json("update_event", args)
+        returned_uid = result.get("uid", event_uid) if isinstance(result, dict) else event_uid
+        return {"uid": returned_uid, "updated_fields": updated_fields}
 
     def _build_update_args(
         self,

--- a/src/apple_calendar_mcp/server_fastmcp.py
+++ b/src/apple_calendar_mcp/server_fastmcp.py
@@ -119,7 +119,12 @@ def _parse_alert_minutes(alert_minutes: str) -> list[int] | None:
     """Parse comma-separated alert minutes string into a list of ints."""
     if not alert_minutes:
         return None
-    return [int(m.strip()) for m in alert_minutes.split(",") if m.strip()]
+    try:
+        return [int(m.strip()) for m in alert_minutes.split(",") if m.strip()]
+    except ValueError:
+        raise ValueError(
+            f"alert_minutes must be comma-separated integers (e.g., '15,60'), got: {alert_minutes!r}"
+        )
 
 
 def _build_create_response(

--- a/src/apple_calendar_mcp/swift/create_event.swift
+++ b/src/apple_calendar_mcp/swift/create_event.swift
@@ -215,7 +215,7 @@ func outputSuccess(_ uid: String) {
 
 guard let parsed = parseArgs() else {
     outputError("invalid_args", "Required: --calendar <name> --summary <text> --start <ISO8601> --end <ISO8601>")
-    exit(0)
+    exit(1)
 }
 
 // Resolve timezone for date parsing
@@ -223,12 +223,12 @@ let eventTimeZone: TimeZone? = parsed.timezone.flatMap { TimeZone(identifier: $0
 
 guard let startDate = parseISO8601(parsed.start, timeZone: eventTimeZone) else {
     outputError("invalid_date", "Cannot parse start date: \(parsed.start)")
-    exit(0)
+    exit(1)
 }
 
 guard let endDate = parseISO8601(parsed.end, timeZone: eventTimeZone) else {
     outputError("invalid_date", "Cannot parse end date: \(parsed.end)")
-    exit(0)
+    exit(1)
 }
 
 let store = EKEventStore()
@@ -247,7 +247,7 @@ semaphore.wait()
 if !accessGranted {
     let msg = accessError?.localizedDescription ?? "Calendar access denied."
     outputError("calendar_access_denied", msg)
-    exit(0)
+    exit(1)
 }
 
 store.refreshSourcesIfNecessary()
@@ -257,7 +257,7 @@ let allCalendars = store.calendars(for: .event)
 guard let calendar = allCalendars.first(where: { $0.title == parsed.calendar }) else {
     let available = allCalendars.map { $0.title }.joined(separator: ", ")
     outputError("calendar_not_found", "Calendar '\(parsed.calendar)' not found. Available: \(available)")
-    exit(0)
+    exit(1)
 }
 
 // Create the event

--- a/src/apple_calendar_mcp/swift/create_events.swift
+++ b/src/apple_calendar_mcp/swift/create_events.swift
@@ -112,14 +112,14 @@ func outputError(_ error: String, _ message: String) {
 
 guard let calendarName = parseArgs() else {
     outputError("invalid_args", "Required: --calendar <name>. Event data is read from stdin as JSON array.")
-    exit(0)
+    exit(1)
 }
 
 // Read JSON from stdin
 let stdinData = FileHandle.standardInput.readDataToEndOfFile()
 guard let eventsJson = try? JSONSerialization.jsonObject(with: stdinData) as? [[String: Any]] else {
     outputError("invalid_input", "Expected JSON array of event objects on stdin")
-    exit(0)
+    exit(1)
 }
 
 let store = EKEventStore()
@@ -133,7 +133,7 @@ semaphore.wait()
 
 if !accessGranted {
     outputError("calendar_access_denied", "Calendar access denied.")
-    exit(0)
+    exit(1)
 }
 
 store.refreshSourcesIfNecessary()
@@ -141,7 +141,7 @@ store.refreshSourcesIfNecessary()
 guard let calendar = store.calendars(for: .event).first(where: { $0.title == calendarName }) else {
     let available = store.calendars(for: .event).map { $0.title }.joined(separator: ", ")
     outputError("calendar_not_found", "Calendar '\(calendarName)' not found. Available: \(available)")
-    exit(0)
+    exit(1)
 }
 
 // Create events
@@ -204,7 +204,7 @@ if !created.isEmpty {
         try store.commit()
     } catch {
         outputError("commit_failed", "Failed to commit batch: \(error.localizedDescription)")
-        exit(0)
+        exit(1)
     }
 }
 

--- a/src/apple_calendar_mcp/swift/delete_events.swift
+++ b/src/apple_calendar_mcp/swift/delete_events.swift
@@ -63,7 +63,7 @@ func outputError(_ error: String, _ message: String) {
 
 guard let parsed = parseArgs() else {
     outputError("invalid_args", "Required: --calendar <name> --uid <uid> [--uid <uid> ...]")
-    exit(0)
+    exit(1)
 }
 
 let store = EKEventStore()
@@ -82,7 +82,7 @@ semaphore.wait()
 if !accessGranted {
     let msg = accessError?.localizedDescription ?? "Calendar access denied."
     outputError("calendar_access_denied", msg)
-    exit(0)
+    exit(1)
 }
 
 store.refreshSourcesIfNecessary()
@@ -92,7 +92,7 @@ let allCalendars = store.calendars(for: .event)
 guard let calendar = allCalendars.first(where: { $0.title == parsed.calendar }) else {
     let available = allCalendars.map { $0.title }.joined(separator: ", ")
     outputError("calendar_not_found", "Calendar '\(parsed.calendar)' not found. Available: \(available)")
-    exit(0)
+    exit(1)
 }
 
 // Delete events by UID
@@ -140,7 +140,7 @@ if !deletedUids.isEmpty {
         try store.commit()
     } catch {
         outputError("delete_failed", "Failed to commit deletions: \(error.localizedDescription)")
-        exit(0)
+        exit(1)
     }
 }
 

--- a/src/apple_calendar_mcp/swift/get_calendars.swift
+++ b/src/apple_calendar_mcp/swift/get_calendars.swift
@@ -41,7 +41,7 @@ semaphore.wait()
 if !accessGranted {
     let msg = accessError?.localizedDescription ?? "Calendar access denied. Grant permission in System Settings > Privacy & Security > Calendars."
     outputError("calendar_access_denied", msg)
-    exit(0)
+    exit(1)
 }
 
 store.refreshSourcesIfNecessary()

--- a/src/apple_calendar_mcp/swift/get_events.swift
+++ b/src/apple_calendar_mcp/swift/get_events.swift
@@ -185,17 +185,17 @@ func participantStatusString(_ status: EKParticipantStatus) -> String {
 
 guard let parsed = parseArgs() else {
     outputError("invalid_args", "Required: --calendar <name> --start <ISO8601> --end <ISO8601>")
-    exit(0)
+    exit(1)
 }
 
 guard let startDate = parseISO8601(parsed.start) else {
     outputError("invalid_date", "Cannot parse start date: \(parsed.start)")
-    exit(0)
+    exit(1)
 }
 
 guard let endDate = parseISO8601(parsed.end) else {
     outputError("invalid_date", "Cannot parse end date: \(parsed.end)")
-    exit(0)
+    exit(1)
 }
 
 let store = EKEventStore()
@@ -214,7 +214,7 @@ semaphore.wait()
 if !accessGranted {
     let msg = accessError?.localizedDescription ?? "Calendar access denied. Grant permission in System Settings > Privacy & Security > Calendars."
     outputError("calendar_access_denied", msg)
-    exit(0)
+    exit(1)
 }
 
 // Refresh sources to pick up recently-created events
@@ -225,7 +225,7 @@ let allCalendars = store.calendars(for: .event)
 guard let calendar = allCalendars.first(where: { $0.title == parsed.calendar }) else {
     let available = allCalendars.map { $0.title }.joined(separator: ", ")
     outputError("calendar_not_found", "Calendar '\(parsed.calendar)' not found. Available: \(available)")
-    exit(0)
+    exit(1)
 }
 
 // Query events

--- a/src/apple_calendar_mcp/swift/update_event.swift
+++ b/src/apple_calendar_mcp/swift/update_event.swift
@@ -225,12 +225,12 @@ func outputError(_ error: String, _ message: String) {
 
 guard let parsed = parseArgs() else {
     outputError("invalid_args", "Required: --calendar <name> --uid <uid> and at least one field to update")
-    exit(0)
+    exit(1)
 }
 
 if parsed.updatedFields.isEmpty {
     outputError("no_fields", "At least one field must be provided to update")
-    exit(0)
+    exit(1)
 }
 
 let store = EKEventStore()
@@ -249,7 +249,7 @@ semaphore.wait()
 if !accessGranted {
     let msg = accessError?.localizedDescription ?? "Calendar access denied."
     outputError("calendar_access_denied", msg)
-    exit(0)
+    exit(1)
 }
 
 store.refreshSourcesIfNecessary()
@@ -277,7 +277,7 @@ if let occDateStr = parsed.occurrenceDate, let occDate = parseISO8601(occDateStr
 
 guard let event = event else {
     outputError("event_not_found", "Event not found: \(parsed.uid)")
-    exit(0)
+    exit(1)
 }
 
 // Resolve timezone for date parsing
@@ -291,13 +291,13 @@ if let startStr = parsed.start, let startDate = parseISO8601(startStr, timeZone:
     event.startDate = startDate
 } else if parsed.start != nil {
     outputError("invalid_date", "Cannot parse start date: \(parsed.start!)")
-    exit(0)
+    exit(1)
 }
 if let endStr = parsed.end, let endDate = parseISO8601(endStr, timeZone: eventTimeZone) {
     event.endDate = endDate
 } else if parsed.end != nil {
     outputError("invalid_date", "Cannot parse end date: \(parsed.end!)")
-    exit(0)
+    exit(1)
 }
 if let location = parsed.location {
     event.location = location
@@ -358,7 +358,7 @@ if isDateChange && isRecurringThisEvent {
         try store.remove(event, span: .thisEvent)
     } catch {
         outputError("remove_failed", "Failed to remove occurrence: \(error.localizedDescription)")
-        exit(0)
+        exit(1)
     }
 
     // Create standalone event with same properties at new time
@@ -379,7 +379,7 @@ if isDateChange && isRecurringThisEvent {
         try store.save(newEvent, span: .thisEvent)
     } catch {
         outputError("save_failed", "Failed to create rescheduled event: \(error.localizedDescription)")
-        exit(0)
+        exit(1)
     }
 
     let result: [String: Any] = [
@@ -400,7 +400,7 @@ do {
     try store.save(event, span: saveSpan)
 } catch {
     outputError("save_failed", "Failed to save event: \(error.localizedDescription)")
-    exit(0)
+    exit(1)
 }
 
 // Output result

--- a/src/apple_calendar_mcp/swift/update_events.swift
+++ b/src/apple_calendar_mcp/swift/update_events.swift
@@ -109,13 +109,13 @@ func outputError(_ error: String, _ message: String) {
 
 guard let calendarName = parseArgs() else {
     outputError("invalid_args", "Required: --calendar <name>. Update data is read from stdin as JSON array.")
-    exit(0)
+    exit(1)
 }
 
 let stdinData = FileHandle.standardInput.readDataToEndOfFile()
 guard let updatesJson = try? JSONSerialization.jsonObject(with: stdinData) as? [[String: Any]] else {
     outputError("invalid_input", "Expected JSON array of update objects on stdin")
-    exit(0)
+    exit(1)
 }
 
 let store = EKEventStore()
@@ -129,7 +129,7 @@ semaphore.wait()
 
 if !accessGranted {
     outputError("calendar_access_denied", "Calendar access denied.")
-    exit(0)
+    exit(1)
 }
 
 store.refreshSourcesIfNecessary()
@@ -137,7 +137,7 @@ store.refreshSourcesIfNecessary()
 guard let calendar = store.calendars(for: .event).first(where: { $0.title == calendarName }) else {
     let available = store.calendars(for: .event).map { $0.title }.joined(separator: ", ")
     outputError("calendar_not_found", "Calendar '\(calendarName)' not found. Available: \(available)")
-    exit(0)
+    exit(1)
 }
 
 var updated: [[String: Any]] = []
@@ -227,7 +227,7 @@ if !updated.isEmpty {
         try store.commit()
     } catch {
         outputError("commit_failed", "Failed to commit batch: \(error.localizedDescription)")
-        exit(0)
+        exit(1)
     }
 }
 

--- a/tests/unit/test_calendar_connector.py
+++ b/tests/unit/test_calendar_connector.py
@@ -154,37 +154,6 @@ class TestEscapeApplescriptString:
 # ── _iso_to_applescript_date ─────────────────────────────────────────────────
 
 
-class TestIsoToApplescriptDate:
-    """Tests for ISO 8601 to AppleScript date conversion."""
-
-    def setup_method(self):
-        self.connector = CalendarConnector()
-
-    def test_date_only(self):
-        result = self.connector._iso_to_applescript_date("2026-03-15")
-        assert result == "March 15, 2026 12:00:00 AM"
-
-    def test_date_with_time(self):
-        result = self.connector._iso_to_applescript_date("2026-03-15T14:30:00")
-        assert result == "March 15, 2026 02:30:00 PM"
-
-    def test_date_with_midnight(self):
-        result = self.connector._iso_to_applescript_date("2026-03-15T00:00:00")
-        assert result == "March 15, 2026 12:00:00 AM"
-
-    def test_date_with_noon(self):
-        result = self.connector._iso_to_applescript_date("2026-03-15T12:00:00")
-        assert result == "March 15, 2026 12:00:00 PM"
-
-    def test_invalid_date_raises_error(self):
-        with pytest.raises(ValueError, match="Invalid date format"):
-            self.connector._iso_to_applescript_date("not-a-date")
-
-    def test_date_with_z_suffix(self):
-        result = self.connector._iso_to_applescript_date("2026-03-15T14:30:00Z")
-        assert result == "March 15, 2026 02:30:00 PM"
-
-
 # ── CalendarSafetyError ─────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

Comprehensive code review found 8 issues; this PR fixes the 6 actionable ones.

### Critical fixes
- **update_event returns stale UID** — when rescheduling a recurring event occurrence, Swift creates a new event but Python was ignoring the returned UID. Now surfaces the correct UID.
- **Swift helpers exit(0) on errors** — all error paths now exit(1), and `_run_swift_helper_json` catches `CalledProcessError` to extract the JSON error from stdout.

### Important fixes
- **`_parse_alert_minutes` validation** — raises descriptive error instead of raw `ValueError`
- **Dead code removed** — `_iso_to_applescript_date` and its 6 unit tests (never called in production)
- **Batch `update_events` rejects `occurrence_date`** — prevents silent ignore; directs users to `update_event` (singular)
- **`timezone` tracked in `updated_fields`** — was silently applied but not reported

### Not addressed (by design)
- #7: Private KVC key for calendar descriptions — unavoidable, safe fallback
- #8: `search_events` silent `ValueError` swallow — low risk, deferred

## Test plan
- [x] `make test-unit` — 147 passed (6 fewer: removed dead `TestIsoToApplescriptDate`)
- [x] `make test-integration` — 56/57 passed (1 pre-existing flaky test unrelated to changes)

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)