### PR TITLE
Fix documentation inaccuracies from accuracy audit (#65)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -3,7 +3,7 @@
 An MCP server bridging Claude and Apple Calendar via AppleScript and EventKit on macOS.
 
 **Stack:** Python 3.10+, FastMCP, AppleScript (via `osascript`), Swift/EventKit (via `swift`)
-**Version:** v0.6.0 | **Tests:** 133 unit, 46 integration | **Coverage:** TBD
+**Version:** v0.6.0 | **Tests:** 147 unit, 57 integration | **Coverage:** TBD
 
 ## Commands
 
@@ -24,8 +24,6 @@ make test-verbose          # Tests with verbose output
 - **Calendars:** `get_calendars`, `create_calendar`, `delete_calendar`
 - **Events:** `get_events`, `search_events`, `create_event`, `create_events`, `update_event`, `update_events`, `delete_events`
 - **Availability:** `get_availability`
-
-Planned (filed as issues): `update_events`
 
 ## Core API Principles
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Calendar names are not guaranteed unique — the same name can appear across dif
 
 ```bash
 make install           # Create venv and install dependencies
-make test              # Run all tests (102 unit, 24 integration skipped)
+make test              # Run all tests (147 unit, 57 integration)
 make test-unit         # Unit tests only
 make test-integration  # Integration tests (requires test calendar)
 make test-verbose      # Tests with verbose output


### PR DESCRIPTION
## Summary
- Update test counts in README.md and CLAUDE.md: 147 unit, 57 integration
- Remove stale "Planned: update_events" note from CLAUDE.md (implemented in v0.6.0)

All other documentation verified accurate: CHANGELOG, CONTRIBUTING, tool_descriptions.md, version numbers, API surface, architecture notes.

Closes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)