### PR TITLE
Add get_conflicts tool for detecting double-bookings (#103)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -19,11 +19,11 @@ make test-verbose          # Tests with verbose output
 
 **Running the server:** `uv run python -m apple_calendar_mcp.server_fastmcp` or via Claude Desktop config.
 
-## API Surface (11 functions)
+## API Surface (12 functions)
 
 - **Calendars:** `get_calendars`, `create_calendar`, `delete_calendar`
 - **Events:** `get_events`, `search_events`, `create_event`, `create_events`, `update_event`, `update_events`, `delete_events`
-- **Availability:** `get_availability`
+- **Availability:** `get_availability`, `get_conflicts`
 
 ## Core API Principles
 

--- a/evals/agent_tool_usability/tool_descriptions.md
+++ b/evals/agent_tool_usability/tool_descriptions.md
@@ -190,6 +190,23 @@ Use get_calendars first to find available calendar names.
 
 ---
 
+### get_conflicts
+
+Detect double-bookings and overlapping events across calendars.
+
+Finds all pairs of events that overlap in time within the date range. Useful for checking if you have scheduling conflicts before adding new events.
+
+Use get_calendars first to find available calendar names.
+
+**Parameters:**
+- `calendar_names` (list[str], required): List of calendar names to check for conflicts
+- `start_date` (str, required): Start of range in ISO 8601 format (e.g., "2026-03-15T00:00:00")
+- `end_date` (str, required): End of range in ISO 8601 format (e.g., "2026-03-22T00:00:00")
+
+**Returns:** Each conflict includes two overlapping events with their UIDs, summaries, times, and calendar names, plus the overlap window and duration in minutes. Events marked as "free" availability are excluded. Returns "No conflicts" if no overlapping events found.
+
+---
+
 ### delete_events
 
 Delete one or more events from a calendar by UID.

--- a/src/apple_calendar_mcp/calendar_connector.py
+++ b/src/apple_calendar_mcp/calendar_connector.py
@@ -726,6 +726,90 @@ class CalendarConnector:
 
         return free_slots
 
+    def get_conflicts(
+        self,
+        calendar_names: list[str],
+        start_date: str,
+        end_date: str,
+    ) -> list[dict[str, Any]]:
+        """Detect overlapping events across one or more calendars.
+
+        Fetches events from all specified calendars, filters out events marked
+        as "free", and returns pairs of events that overlap in time.
+
+        Args:
+            calendar_names: List of calendar names to check
+            start_date: Start of range in ISO 8601 format
+            end_date: End of range in ISO 8601 format
+
+        Returns:
+            List of conflict dicts, each with 'event_a', 'event_b',
+            'overlap_start', 'overlap_end', and 'overlap_minutes' keys.
+
+        Raises:
+            ValueError: If date format is invalid, calendar not found, or no calendars provided
+            PermissionError: If EventKit calendar access is denied
+        """
+        if not calendar_names:
+            raise ValueError("At least one calendar name must be provided")
+
+        all_events = []
+        for cal_name in calendar_names:
+            all_events.extend(self.get_events(cal_name, start_date, end_date))
+
+        # Filter out free events — only busy/tentative can conflict
+        busy_events = [
+            e for e in all_events
+            if e.get("availability", "busy") != "free"
+        ]
+
+        # Parse dates and sort
+        parsed = []
+        for event in busy_events:
+            evt_start = self._parse_iso_datetime(event["start_date"])
+            evt_end = self._parse_iso_datetime(event["end_date"])
+            if event.get("allday_event"):
+                evt_start = evt_start.replace(hour=0, minute=0, second=0)
+                evt_end = evt_end.replace(hour=0, minute=0, second=0)
+                if evt_end == evt_start:
+                    evt_end += timedelta(days=1)
+            parsed.append((evt_start, evt_end, event))
+        parsed.sort(key=lambda x: x[0])
+
+        # Find all overlapping pairs
+        conflicts = []
+        for i in range(len(parsed)):
+            for j in range(i + 1, len(parsed)):
+                start_a, end_a, event_a = parsed[i]
+                start_b, end_b, event_b = parsed[j]
+                if start_b >= end_a:
+                    break  # No more overlaps possible for event i
+                overlap_start = max(start_a, start_b)
+                overlap_end = min(end_a, end_b)
+                overlap_minutes = int((overlap_end - overlap_start).total_seconds() / 60)
+                if overlap_minutes > 0:
+                    conflicts.append({
+                        "event_a": {
+                            "uid": event_a["uid"],
+                            "summary": event_a["summary"],
+                            "start_date": event_a["start_date"],
+                            "end_date": event_a["end_date"],
+                            "calendar_name": event_a["calendar_name"],
+                        },
+                        "event_b": {
+                            "uid": event_b["uid"],
+                            "summary": event_b["summary"],
+                            "start_date": event_b["start_date"],
+                            "end_date": event_b["end_date"],
+                            "calendar_name": event_b["calendar_name"],
+                        },
+                        "overlap_start": overlap_start.isoformat(),
+                        "overlap_end": overlap_end.isoformat(),
+                        "overlap_minutes": overlap_minutes,
+                    })
+
+        return conflicts
+
     def get_calendars(self) -> list[dict[str, Any]]:
         """Get all calendars from Apple Calendar.
 

--- a/src/apple_calendar_mcp/server_fastmcp.py
+++ b/src/apple_calendar_mcp/server_fastmcp.py
@@ -520,6 +520,62 @@ def get_availability(
     return f"Found {len(slots)} free slot(s) across {cal_list}{filter_desc}:\n\n" + "\n".join(lines)
 
 
+def _format_conflict(conflict: dict) -> str:
+    """Format a conflict pair as human-readable text."""
+    a = conflict["event_a"]
+    b = conflict["event_b"]
+    overlap = f"{conflict['overlap_start']} to {conflict['overlap_end']}"
+    lines = [
+        f"{conflict['overlap_minutes']} min overlap ({overlap}):",
+        f"  \"{a['summary']}\" on {a['calendar_name']} ({a['start_date']} to {a['end_date']})",
+        f"  \"{b['summary']}\" on {b['calendar_name']} ({b['start_date']} to {b['end_date']})",
+    ]
+    return "\n".join(lines)
+
+
+@mcp.tool()
+def get_conflicts(
+    calendar_names: list[str],
+    start_date: str,
+    end_date: str,
+) -> str:
+    """Detect double-bookings and overlapping events across calendars.
+
+    Finds all pairs of events that overlap in time within the date range.
+    Useful for checking if you have scheduling conflicts before adding new events.
+
+    Use get_calendars first to find available calendar names.
+
+    Args:
+        calendar_names: List of calendar names to check for conflicts
+        start_date: Start of range in ISO 8601 format (e.g., "2026-03-15T00:00:00")
+        end_date: End of range in ISO 8601 format (e.g., "2026-03-22T00:00:00")
+
+    Returns:
+        Each conflict includes two overlapping events with their UIDs, summaries,
+        times, and calendar names, plus the overlap window and duration in minutes.
+        Events marked as "free" availability are excluded. Returns "No conflicts"
+        if no overlapping events found.
+    """
+    client = get_client()
+    try:
+        conflicts = client.get_conflicts(
+            calendar_names=calendar_names,
+            start_date=start_date,
+            end_date=end_date,
+        )
+    except Exception as e:
+        return f"Error checking conflicts: {e}"
+
+    cal_list = ", ".join(f"'{c}'" for c in calendar_names)
+
+    if not conflicts:
+        return f"No conflicts found in {cal_list} between {start_date} and {end_date}."
+
+    lines = [_format_conflict(c) for c in conflicts]
+    return f"Found {len(conflicts)} conflict(s) across {cal_list}:\n\n" + "\n\n".join(lines)
+
+
 @mcp.tool()
 def update_event(
     calendar_name: str,

--- a/tests/unit/test_calendar_connector.py
+++ b/tests/unit/test_calendar_connector.py
@@ -882,6 +882,103 @@ class TestGetAvailabilityFiltering:
             )
 
 
+class TestGetConflicts:
+    """Tests for CalendarConnector.get_conflicts()."""
+
+    def setup_method(self):
+        self.connector = CalendarConnector(enable_safety_checks=False)
+
+    def _make_event(self, uid, summary, start, end, calendar="Work", availability="busy", allday=False):
+        return {
+            "uid": uid, "summary": summary,
+            "start_date": start, "end_date": end,
+            "calendar_name": calendar, "availability": availability,
+            "allday_event": allday,
+        }
+
+    @patch.object(CalendarConnector, "get_events")
+    def test_no_events_returns_empty(self, mock_get):
+        mock_get.return_value = []
+        result = self.connector.get_conflicts(["Work"], "2026-03-15", "2026-03-16")
+        assert result == []
+
+    @patch.object(CalendarConnector, "get_events")
+    def test_no_overlap_returns_empty(self, mock_get):
+        mock_get.return_value = [
+            self._make_event("A", "Meeting", "2026-03-15T10:00:00", "2026-03-15T11:00:00"),
+            self._make_event("B", "Lunch", "2026-03-15T12:00:00", "2026-03-15T13:00:00"),
+        ]
+        result = self.connector.get_conflicts(["Work"], "2026-03-15", "2026-03-16")
+        assert result == []
+
+    @patch.object(CalendarConnector, "get_events")
+    def test_simple_overlap(self, mock_get):
+        mock_get.return_value = [
+            self._make_event("A", "Meeting", "2026-03-15T10:00:00", "2026-03-15T11:00:00"),
+            self._make_event("B", "Call", "2026-03-15T10:30:00", "2026-03-15T11:30:00"),
+        ]
+        result = self.connector.get_conflicts(["Work"], "2026-03-15", "2026-03-16")
+        assert len(result) == 1
+        assert result[0]["event_a"]["uid"] == "A"
+        assert result[0]["event_b"]["uid"] == "B"
+        assert result[0]["overlap_minutes"] == 30
+        assert result[0]["overlap_start"] == "2026-03-15T10:30:00"
+        assert result[0]["overlap_end"] == "2026-03-15T11:00:00"
+
+    @patch.object(CalendarConnector, "get_events")
+    def test_three_way_overlap(self, mock_get):
+        mock_get.return_value = [
+            self._make_event("A", "Meeting", "2026-03-15T10:00:00", "2026-03-15T11:00:00"),
+            self._make_event("B", "Call", "2026-03-15T10:00:00", "2026-03-15T11:00:00"),
+            self._make_event("C", "Review", "2026-03-15T10:30:00", "2026-03-15T11:30:00"),
+        ]
+        result = self.connector.get_conflicts(["Work"], "2026-03-15", "2026-03-16")
+        assert len(result) == 3  # A-B, A-C, B-C
+
+    @patch.object(CalendarConnector, "get_events")
+    def test_free_events_excluded(self, mock_get):
+        mock_get.return_value = [
+            self._make_event("A", "Meeting", "2026-03-15T10:00:00", "2026-03-15T11:00:00", availability="busy"),
+            self._make_event("B", "Lunch", "2026-03-15T10:30:00", "2026-03-15T11:30:00", availability="free"),
+        ]
+        result = self.connector.get_conflicts(["Work"], "2026-03-15", "2026-03-16")
+        assert result == []
+
+    @patch.object(CalendarConnector, "get_events")
+    def test_tentative_events_included(self, mock_get):
+        mock_get.return_value = [
+            self._make_event("A", "Meeting", "2026-03-15T10:00:00", "2026-03-15T11:00:00", availability="busy"),
+            self._make_event("B", "Maybe", "2026-03-15T10:30:00", "2026-03-15T11:30:00", availability="tentative"),
+        ]
+        result = self.connector.get_conflicts(["Work"], "2026-03-15", "2026-03-16")
+        assert len(result) == 1
+
+    @patch.object(CalendarConnector, "get_events")
+    def test_multi_calendar(self, mock_get):
+        def side_effect(cal_name, start, end):
+            if cal_name == "Work":
+                return [self._make_event("A", "Meeting", "2026-03-15T10:00:00", "2026-03-15T11:00:00", "Work")]
+            return [self._make_event("B", "Dentist", "2026-03-15T10:30:00", "2026-03-15T11:30:00", "Personal")]
+        mock_get.side_effect = side_effect
+        result = self.connector.get_conflicts(["Work", "Personal"], "2026-03-15", "2026-03-16")
+        assert len(result) == 1
+        assert result[0]["event_a"]["calendar_name"] == "Work"
+        assert result[0]["event_b"]["calendar_name"] == "Personal"
+
+    @patch.object(CalendarConnector, "get_events")
+    def test_adjacent_events_no_conflict(self, mock_get):
+        mock_get.return_value = [
+            self._make_event("A", "Meeting", "2026-03-15T10:00:00", "2026-03-15T11:00:00"),
+            self._make_event("B", "Call", "2026-03-15T11:00:00", "2026-03-15T12:00:00"),
+        ]
+        result = self.connector.get_conflicts(["Work"], "2026-03-15", "2026-03-16")
+        assert result == []
+
+    def test_empty_calendar_list_raises(self):
+        with pytest.raises(ValueError, match="At least one calendar"):
+            self.connector.get_conflicts([], "2026-03-15", "2026-03-16")
+
+
 class TestParseTimeString:
     """Tests for CalendarConnector._parse_time_string()."""
 


### PR DESCRIPTION
## Summary
- New `get_conflicts` tool: detects overlapping events across one or more calendars
- Returns conflict pairs with overlap window and duration in minutes
- Events marked as "free" availability are excluded (only busy/tentative conflict)
- 9 unit tests covering all edge cases
- API surface: 11 → 12 functions
- Updated CLAUDE.md and tool_descriptions.md

Also filed #124 for `get_availability` to respect event availability status (same filtering).

## Test plan
- [x] `make test-unit` — 156 passed (147 existing + 9 new)

Closes #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)