### PR TITLE
Fix get_availability to respect event availability status (#124)

### DIFF
--- a/src/apple_calendar_mcp/calendar_connector.py
+++ b/src/apple_calendar_mcp/calendar_connector.py
@@ -690,7 +690,10 @@ class CalendarConnector:
         for cal_name in calendar_names:
             all_events.extend(self.get_events(cal_name, start_date, end_date))
 
-        merged = self._build_busy_blocks(all_events)
+        # Only busy/tentative events block availability — free events are excluded
+        busy_events = [e for e in all_events if e.get("availability", "busy") != "free"]
+
+        merged = self._build_busy_blocks(busy_events)
 
         free_slots = []
         cursor = range_start

--- a/tests/unit/test_calendar_connector.py
+++ b/tests/unit/test_calendar_connector.py
@@ -715,6 +715,19 @@ class TestGetAvailability:
         assert result[1]["end_date"] == "2026-03-15T14:00:00"
         assert result[2]["start_date"] == "2026-03-15T15:00:00"
 
+    @patch("apple_calendar_mcp.calendar_connector.run_swift_helper")
+    def test_free_events_do_not_block_availability(self, mock_swift):
+        """Events with availability='free' should not reduce available time."""
+        event = self._make_event("2026-03-15T10:00:00", "2026-03-15T11:00:00")
+        event["availability"] = "free"
+        mock_swift.return_value = json.dumps([event])
+        result = self.connector.get_availability(
+            ["Work"], "2026-03-15T09:00:00", "2026-03-15T17:00:00"
+        )
+        # Entire range should be free since the event is marked "free"
+        assert len(result) == 1
+        assert result[0]["duration_minutes"] == 480
+
 
 # ── get_availability: smart filtering ──────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- Events marked as "free" no longer block time slots in `get_availability`
- Only "busy" and "tentative" events reduce available time
- Same filtering pattern already used in `get_conflicts`
- 1 new unit test

## Test plan
- [x] `make test-unit` — 157 passed (156 + 1 new)

Closes #124

🤖 Generated with [Claude Code](https://claude.com/claude-code)