### PR TITLE
Add __version__ and complete pyproject.toml metadata (#133)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,9 +8,28 @@ version = "0.6.1"
 description = "MCP server for Apple Calendar integration"
 readme = "README.md"
 requires-python = ">=3.10"
+license = {text = "MIT"}
+authors = [{name = "Morgan Jeffries"}]
+keywords = ["mcp", "apple-calendar", "calendar", "eventkit", "model-context-protocol"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: MacOS",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Office/Business :: Scheduling",
+]
 dependencies = [
     "fastmcp>=2.12.0",
 ]
+
+[project.urls]
+Repository = "https://github.com/s-morgan-jeffries/apple-calendar-mcp"
+"Bug Tracker" = "https://github.com/s-morgan-jeffries/apple-calendar-mcp/issues"
 
 [project.optional-dependencies]
 dev = [

--- a/scripts/check_version_sync.sh
+++ b/scripts/check_version_sync.sh
@@ -1,16 +1,27 @@
 #!/bin/bash
-# Verify version is consistent across pyproject.toml and CLAUDE.md
+# Verify version is consistent across pyproject.toml, CLAUDE.md, and __init__.py
 
 PYPROJECT_VERSION=$(grep 'version = ' pyproject.toml | head -1 | sed 's/.*"\(.*\)".*/\1/')
 CLAUDE_VERSION=$(grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+' .claude/CLAUDE.md | head -1 | sed 's/v//')
+INIT_VERSION=$(grep '__version__' src/apple_calendar_mcp/__init__.py | sed 's/.*"\(.*\)".*/\1/')
 
 echo "pyproject.toml: $PYPROJECT_VERSION"
 echo "CLAUDE.md:      $CLAUDE_VERSION"
+echo "__init__.py:    $INIT_VERSION"
 
-if [ "$PYPROJECT_VERSION" = "$CLAUDE_VERSION" ]; then
+MISMATCH=0
+if [ "$PYPROJECT_VERSION" != "$CLAUDE_VERSION" ]; then
+    echo "ERROR: pyproject.toml and CLAUDE.md versions differ!"
+    MISMATCH=1
+fi
+if [ "$PYPROJECT_VERSION" != "$INIT_VERSION" ]; then
+    echo "ERROR: pyproject.toml and __init__.py versions differ!"
+    MISMATCH=1
+fi
+
+if [ "$MISMATCH" -eq 0 ]; then
     echo "Versions are in sync."
     exit 0
 else
-    echo "ERROR: Version mismatch!"
     exit 1
 fi

--- a/src/apple_calendar_mcp/__init__.py
+++ b/src/apple_calendar_mcp/__init__.py
@@ -1,1 +1,3 @@
 """Apple Calendar MCP Server."""
+
+__version__ = "0.6.1"


### PR DESCRIPTION
## Summary
- Add `__version__ = "0.6.1"` to `__init__.py`
- Add license, authors, keywords, classifiers, and project URLs to `pyproject.toml`
- Update `check_version_sync.sh` to verify `__init__.py` alongside `pyproject.toml` and `CLAUDE.md`

## Test plan
- [x] `make test-unit` — 157 passed
- [x] `./scripts/check_version_sync.sh` — all 3 sources in sync

Closes #133

🤖 Generated with [Claude Code](https://claude.com/claude-code)