### PR TITLE
Add git hooks (pre-commit, pre-push, pre-tag) with installer (#131)

### DIFF
--- a/scripts/check_changelog_date.sh
+++ b/scripts/check_changelog_date.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+# Check if CHANGELOG.md date has been updated from "TBD" before final release tag
+
+TAG_NAME="${1:-}"
+
+echo "Checking CHANGELOG.md date..."
+
+VERSION=$(grep '^version = ' pyproject.toml | cut -d'"' -f2)
+
+if [ -z "$VERSION" ]; then
+    echo "Could not read version from pyproject.toml"
+    exit 1
+fi
+
+echo "   Current version: $VERSION"
+
+if [ ! -f "CHANGELOG.md" ]; then
+    echo "CHANGELOG.md not found"
+    exit 1
+fi
+
+CHANGELOG_LINE=$(grep -E "^## \[$VERSION\]" CHANGELOG.md | head -1)
+
+if [ -z "$CHANGELOG_LINE" ]; then
+    echo "Version $VERSION not found in CHANGELOG.md"
+    echo "   Expected format: ## [$VERSION] - DATE"
+    exit 1
+fi
+
+CHANGELOG_DATE=$(echo "$CHANGELOG_LINE" | sed -E 's/^## \[[^]]+\] - (.+)$/\1/')
+
+echo "   CHANGELOG date: $CHANGELOG_DATE"
+echo ""
+
+if [ "$CHANGELOG_DATE" = "TBD" ]; then
+    echo "CHANGELOG.md still has 'TBD' date!"
+    echo "   Version: $VERSION"
+    echo "   Current line: $CHANGELOG_LINE"
+    echo ""
+    echo "Action required:"
+    echo "   1. Update CHANGELOG.md to replace 'TBD' with actual release date"
+    echo "   2. Format: ## [$VERSION] - YYYY-MM-DD"
+    echo "   3. Commit the date update"
+    echo "   4. Then create the release tag"
+    exit 1
+fi
+
+if echo "$CHANGELOG_DATE" | grep -qE '^[0-9]{4}-[0-9]{2}-[0-9]{2}$'; then
+    DATE_FORMAT="Valid format (YYYY-MM-DD)"
+else
+    DATE_FORMAT="Non-standard format (expected YYYY-MM-DD)"
+fi
+
+echo "CHANGELOG.md date is set!"
+echo "   Version: $VERSION"
+echo "   Date: $CHANGELOG_DATE"
+echo "   $DATE_FORMAT"
+exit 0

--- a/scripts/git-hooks/pre-commit
+++ b/scripts/git-hooks/pre-commit
@@ -1,0 +1,40 @@
+#!/bin/bash
+# Git pre-commit hook
+# Checks: branch protection, version sync
+
+# Check 1: Block commits to main/master (unless hotfix/emergency)
+BRANCH=$(git symbolic-ref --short HEAD 2>/dev/null)
+
+if [ "$BRANCH" = "main" ] || [ "$BRANCH" = "master" ]; then
+    COMMIT_MSG_FILE=".git/COMMIT_EDITMSG"
+    if [ -f "$COMMIT_MSG_FILE" ] && grep -qi "hotfix\|emergency" "$COMMIT_MSG_FILE"; then
+        exit 0
+    fi
+
+    LAST_MSG=$(git log -1 --pretty=%B 2>/dev/null || echo "")
+    if echo "$LAST_MSG" | grep -qi "hotfix\|emergency"; then
+        exit 0
+    fi
+
+    echo ""
+    echo "Direct commits to $BRANCH are not allowed."
+    echo "Create a feature branch: git checkout -b feature/description"
+    echo "For hotfixes, include 'hotfix' in commit message."
+    exit 1
+fi
+
+# Check 2: Version sync — if pyproject.toml version changed, warn if CHANGELOG not staged
+STAGED_FILES=$(git diff --cached --name-only --diff-filter=ACM)
+
+if echo "$STAGED_FILES" | grep -q "pyproject.toml"; then
+    VERSION_CHANGED=$(git diff --cached pyproject.toml | grep "^+version = ")
+    if [ -n "$VERSION_CHANGED" ]; then
+        if ! echo "$STAGED_FILES" | grep -q "CHANGELOG.md"; then
+            echo ""
+            echo "Warning: Version bump detected but CHANGELOG.md not staged."
+            echo ""
+        fi
+    fi
+fi
+
+exit 0

--- a/scripts/git-hooks/pre-push
+++ b/scripts/git-hooks/pre-push
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Git pre-push hook
+# Runs tests before allowing push to ensure CI won't fail
+
+set -e
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+echo -e "${YELLOW}Running pre-push checks...${NC}"
+
+# Check if we're actually pushing refs
+if [ -t 0 ]; then
+    echo -e "${YELLOW}No refs being pushed, skipping checks${NC}"
+    exit 0
+fi
+
+while read local_ref local_sha remote_ref remote_sha; do
+    BRANCH=$(echo "$remote_ref" | sed 's|refs/heads/||')
+    echo -e "${YELLOW}Pushing to branch: $BRANCH${NC}"
+
+    echo -e "${YELLOW}Running unit tests...${NC}"
+
+    if ! make test; then
+        echo -e "${RED}Unit tests failed!${NC}"
+        echo -e "${RED}Cannot push until tests pass locally${NC}"
+        echo ""
+        echo "Fix the failures and try again."
+        exit 1
+    fi
+
+    echo -e "${GREEN}Unit tests passed${NC}"
+done
+
+echo -e "${GREEN}All pre-push checks passed${NC}"
+exit 0

--- a/scripts/git-hooks/pre-tag
+++ b/scripts/git-hooks/pre-tag
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Git pre-tag hook — validates tag format and branch requirements
+
+TAG_NAME="$1"
+
+# Only check version tags
+if [[ ! "$TAG_NAME" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-rc[0-9]+)?$ ]]; then
+    exit 0
+fi
+
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+
+# RC tags must be on release/* branches
+if [[ "$TAG_NAME" =~ -rc[0-9]+$ ]]; then
+    if [[ ! "$CURRENT_BRANCH" =~ ^release/ ]]; then
+        echo "RC tags must be created on release/* branches."
+        echo "Current branch: $CURRENT_BRANCH"
+        echo "Create a release branch: git checkout -b release/${TAG_NAME%-rc*}"
+        exit 1
+    fi
+else
+    # Final release tags must be on main or release/* branches
+    if [ "$CURRENT_BRANCH" != "main" ] && [[ ! "$CURRENT_BRANCH" =~ ^release/ ]]; then
+        echo "Final release tags must be created on main or release/* branches."
+        echo "Current branch: $CURRENT_BRANCH"
+        exit 1
+    fi
+
+    # Check CHANGELOG.md date is set
+    if [ -f "./scripts/check_changelog_date.sh" ]; then
+        if ! ./scripts/check_changelog_date.sh "$TAG_NAME" 2>&1; then
+            echo "Fix CHANGELOG date before creating final release tag."
+            exit 1
+        fi
+    fi
+fi
+
+exit 0

--- a/scripts/install-git-hooks.sh
+++ b/scripts/install-git-hooks.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# Install git hooks for branch protection, test enforcement, and release hygiene
+
+echo "Installing git hooks..."
+echo ""
+
+# Install pre-commit hook
+if [ -f ".git/hooks/pre-commit" ] || [ -L ".git/hooks/pre-commit" ]; then
+    echo "  .git/hooks/pre-commit already exists, backing up"
+    mv .git/hooks/pre-commit .git/hooks/pre-commit.backup
+fi
+
+ln -sf ../../scripts/git-hooks/pre-commit .git/hooks/pre-commit
+echo "  Installed pre-commit hook"
+echo "    - Blocks commits to main/master (except hotfixes)"
+echo "    - Warns on version bump without CHANGELOG staged"
+echo ""
+
+# Install pre-push hook
+if [ -f ".git/hooks/pre-push" ] || [ -L ".git/hooks/pre-push" ]; then
+    echo "  .git/hooks/pre-push already exists, backing up"
+    mv .git/hooks/pre-push .git/hooks/pre-push.backup
+fi
+
+ln -sf ../../scripts/git-hooks/pre-push .git/hooks/pre-push
+echo "  Installed pre-push hook"
+echo "    - Runs unit tests before push"
+echo "    - Prevents pushing failing tests to remote"
+echo ""
+
+# Install pre-tag hook
+if [ -f ".git/hooks/pre-tag" ] || [ -L ".git/hooks/pre-tag" ]; then
+    echo "  .git/hooks/pre-tag already exists, backing up"
+    mv .git/hooks/pre-tag .git/hooks/pre-tag.backup
+fi
+
+ln -sf ../../scripts/git-hooks/pre-tag .git/hooks/pre-tag
+echo "  Installed pre-tag hook"
+echo "    - Validates tag format (vX.Y.Z or vX.Y.Z-rcN)"
+echo "    - Enforces branch requirements (RC on release/*, final on main)"
+echo "    - Checks CHANGELOG date is not TBD"
+echo ""
+
+echo "Git hooks installed successfully!"
+echo ""
+echo "To uninstall:"
+echo "  rm .git/hooks/pre-commit .git/hooks/pre-push .git/hooks/pre-tag"


### PR DESCRIPTION
## Summary
- **pre-commit:** blocks direct commits to main, warns on version bump without CHANGELOG staged
- **pre-push:** runs full unit test suite before push, blocks if failing
- **pre-tag:** validates tag format (vX.Y.Z/vX.Y.Z-rcN), enforces branch requirements, checks CHANGELOG date
- **install-git-hooks.sh:** symlinks hooks into .git/hooks/ with backup of existing hooks
- **check_changelog_date.sh:** validates CHANGELOG date is not "TBD" before final release tags

Ported from OF MCP project, adapted for Calendar MCP.

## Test plan
- [x] `./scripts/install-git-hooks.sh` runs successfully
- [x] `./scripts/check_changelog_date.sh` passes (current CHANGELOG has real dates)
- [x] Pre-push hook ran during push — 157 tests passed

Closes #131

🤖 Generated with [Claude Code](https://claude.com/claude-code)