### PR TITLE
Add release automation workflows (#128)

### DIFF
--- a/.github/workflows/release-hygiene.yml
+++ b/.github/workflows/release-hygiene.yml
@@ -1,0 +1,112 @@
+name: Release Hygiene Checks
+
+on:
+  push:
+    tags:
+      - 'v*-rc*'  # Triggers on v0.7.0-rc1, v0.7.0-rc2, etc.
+
+jobs:
+  hygiene-checks:
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+
+      - name: Run all unit tests
+        run: |
+          pytest tests/ -v --tb=short
+
+      - name: Check version synchronization
+        run: |
+          ./scripts/check_version_sync.sh
+
+      - name: Check code complexity
+        run: |
+          ./scripts/check_complexity.sh
+
+      - name: Verify milestone status
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG_NAME=${GITHUB_REF#refs/tags/}
+          VERSION=${TAG_NAME%-rc*}
+
+          echo "Checking milestone: $VERSION"
+
+          if ! gh api repos/${{ github.repository }}/milestones --jq ".[].title" | grep -q "^${VERSION}$"; then
+            echo "Milestone $VERSION does not exist"
+            exit 1
+          fi
+
+          MILESTONE_NUM=$(gh api repos/${{ github.repository }}/milestones --jq ".[] | select(.title == \"${VERSION}\") | .number")
+
+          OPEN_ISSUES=$(gh api repos/${{ github.repository }}/issues --jq ".[] | select(.milestone.number == ${MILESTONE_NUM} and .state == \"open\") | .number")
+
+          if [ -n "$OPEN_ISSUES" ]; then
+            echo "Milestone $VERSION has open issues:"
+            echo "$OPEN_ISSUES" | while read -r issue; do
+              TITLE=$(gh issue view "$issue" --json title --jq '.title')
+              echo "  - #$issue: $TITLE"
+            done
+            exit 1
+          fi
+
+          echo "Milestone $VERSION has no open issues"
+
+          # Check if next milestone exists
+          CURRENT_VERSION=$(echo "$VERSION" | sed 's/^v//')
+          MAJOR=$(echo "$CURRENT_VERSION" | cut -d. -f1)
+          MINOR=$(echo "$CURRENT_VERSION" | cut -d. -f2)
+          PATCH=$(echo "$CURRENT_VERSION" | cut -d. -f3)
+
+          NEXT_PATCH="v${MAJOR}.${MINOR}.$((PATCH + 1))"
+          NEXT_MINOR="v${MAJOR}.$((MINOR + 1)).0"
+
+          FOUND_NEXT=false
+          for CANDIDATE in "$NEXT_MINOR" "$NEXT_PATCH"; do
+            if gh api repos/${{ github.repository }}/milestones --jq ".[].title" | grep -q "^${CANDIDATE}$"; then
+              echo "Next milestone $CANDIDATE exists"
+              FOUND_NEXT=true
+              break
+            fi
+          done
+
+          if [ "$FOUND_NEXT" = false ]; then
+            echo "Warning: No next milestone found ($NEXT_MINOR or $NEXT_PATCH)"
+            echo "Consider creating one for future work planning"
+          fi
+
+      - name: Post results summary
+        if: always()
+        run: |
+          TAG_NAME=${GITHUB_REF#refs/tags/}
+          VERSION=${TAG_NAME%-rc*}
+
+          echo "## Release Hygiene Check Results for $TAG_NAME" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Target Version:** $VERSION" >> $GITHUB_STEP_SUMMARY
+          echo "**RC Tag:** $TAG_NAME" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+
+          if [ "${{ job.status }}" == "success" ]; then
+            echo "**All hygiene checks passed!**" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "Ready to merge and tag final release." >> $GITHUB_STEP_SUMMARY
+          else
+            echo "**Some hygiene checks failed.**" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "Fix issues and tag a new RC." >> $GITHUB_STEP_SUMMARY
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,131 @@
+name: Create Release
+
+on:
+  push:
+    tags:
+      - 'v*'  # Triggers on any v* tag
+      - '!v*-rc*'  # But NOT on RC tags
+
+jobs:
+  create-release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Extract version from tag
+        id: version
+        run: |
+          TAG_NAME=${GITHUB_REF#refs/tags/}
+          echo "tag=$TAG_NAME" >> $GITHUB_OUTPUT
+          echo "version=${TAG_NAME#v}" >> $GITHUB_OUTPUT
+
+      - name: Extract changelog for this version
+        id: changelog
+        run: |
+          TAG_NAME=${{ steps.version.outputs.tag }}
+
+          # Extract section from CHANGELOG.md for this version
+          awk "/^## \[$TAG_NAME\]/,/^## \[/ {print}" CHANGELOG.md | \
+            sed '$d' | \
+            tail -n +2 > /tmp/release-notes.md
+
+          # If empty, create generic release notes
+          if [ ! -s /tmp/release-notes.md ]; then
+            echo "Release $TAG_NAME" > /tmp/release-notes.md
+            echo "" >> /tmp/release-notes.md
+            echo "See [CHANGELOG.md](CHANGELOG.md) for details." >> /tmp/release-notes.md
+          fi
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG_NAME=${{ steps.version.outputs.tag }}
+
+          gh release create "$TAG_NAME" \
+            --title "Release $TAG_NAME" \
+            --notes-file /tmp/release-notes.md
+
+      - name: Close milestone
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG_NAME=${{ steps.version.outputs.tag }}
+
+          MILESTONE_NUM=$(gh api repos/${{ github.repository }}/milestones \
+            --jq ".[] | select(.title == \"${TAG_NAME}\") | .number")
+
+          if [ -n "$MILESTONE_NUM" ]; then
+            echo "Closing milestone: $TAG_NAME (#$MILESTONE_NUM)"
+
+            gh api --method PATCH "repos/${{ github.repository }}/milestones/$MILESTONE_NUM" \
+              -f state=closed
+
+            echo "Milestone $TAG_NAME closed"
+          else
+            echo "No milestone found for $TAG_NAME"
+          fi
+
+      - name: Verify next milestone exists
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG_NAME=${{ steps.version.outputs.tag }}
+
+          VERSION=$(echo "$TAG_NAME" | sed 's/^v//')
+          MAJOR=$(echo "$VERSION" | cut -d. -f1)
+          MINOR=$(echo "$VERSION" | cut -d. -f2)
+          PATCH=$(echo "$VERSION" | cut -d. -f3)
+
+          NEXT_PATCH="v${MAJOR}.${MINOR}.$((PATCH + 1))"
+          NEXT_MINOR="v${MAJOR}.$((MINOR + 1)).0"
+          NEXT_MAJOR="v$((MAJOR + 1)).0.0"
+
+          echo "Current version: $TAG_NAME"
+          echo "Checking for next milestone (priority: minor > major > patch)..."
+
+          NEXT_VERSION=""
+          for CANDIDATE in "$NEXT_MINOR" "$NEXT_MAJOR" "$NEXT_PATCH"; do
+            echo "  Checking: $CANDIDATE"
+            EXISTS=$(gh api repos/${{ github.repository }}/milestones \
+              --jq ".[] | select(.title == \"${CANDIDATE}\") | .number")
+
+            if [ -n "$EXISTS" ]; then
+              echo "  Found existing milestone: $CANDIDATE"
+              NEXT_VERSION="$CANDIDATE"
+              break
+            fi
+          done
+
+          if [ -z "$NEXT_VERSION" ]; then
+            NEXT_VERSION="$NEXT_PATCH"
+            echo "No existing milestone found. Creating: $NEXT_VERSION"
+
+            gh api --method POST "repos/${{ github.repository }}/milestones" \
+              -f title="$NEXT_VERSION" \
+              -f description="Planned work for $NEXT_VERSION"
+
+            echo "Milestone $NEXT_VERSION created"
+          else
+            echo "Using existing milestone: $NEXT_VERSION"
+          fi
+
+      - name: Post release summary
+        if: always()
+        run: |
+          TAG_NAME=${{ steps.version.outputs.tag }}
+
+          echo "## Release $TAG_NAME Created" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "- GitHub Release created" >> $GITHUB_STEP_SUMMARY
+          echo "- Milestone closed" >> $GITHUB_STEP_SUMMARY
+          echo "- Next milestone verified/created" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Release URL:** https://github.com/${{ github.repository }}/releases/tag/$TAG_NAME" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary
- **release.yml:** triggered on `v*` tags (not RC), creates GitHub Release from CHANGELOG section, closes milestone, verifies/creates next milestone
- **release-hygiene.yml:** triggered on `v*-rc*` tags, runs unit tests, version sync check, complexity check, and milestone status validation with detailed summary output

Ported from OF MCP project. Adapted: removed client-server parity check (separate issue #129), fixed hardcoded next-milestone logic to be version-agnostic.

## Test plan
- [x] YAML syntax valid
- [x] Pre-push hook ran 157 tests — all passed
- [ ] Will be fully tested on next release tag

Closes #128

🤖 Generated with [Claude Code](https://claude.com/claude-code)