### PR TITLE
Add parity check, coverage enforcement (95%), and 58 new tests (#129)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,8 +27,8 @@ jobs:
           pip install -e .
           pip install pytest pytest-asyncio pytest-cov radon
 
-      - name: Run unit tests
-        run: pytest tests/ -m "not integration" -v
+      - name: Run unit tests with coverage
+        run: pytest tests/ -m "not integration" -v --cov=apple_calendar_mcp --cov-report=term-missing --cov-fail-under=90
         timeout-minutes: 5
 
       - name: Check code complexity
@@ -37,6 +37,9 @@ jobs:
 
       - name: Verify version sync
         run: ./scripts/check_version_sync.sh
+
+      - name: Check connector/server parity
+        run: ./scripts/check_client_server_parity.sh
 
   test-summary:
     name: Test Summary

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,14 @@ markers = [
     "integration: mark test as an integration test",
 ]
 
+[tool.coverage.run]
+source = ["apple_calendar_mcp"]
+
+[tool.coverage.report]
+fail_under = 90
+show_missing = true
+exclude_lines = ["if __name__ == \"__main__\""]
+
 [tool.pyright]
 include = ["src", "tests"]
 exclude = ["**/node_modules", "**/__pycache__", ".venv", "venv"]

--- a/scripts/check_client_server_parity.sh
+++ b/scripts/check_client_server_parity.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# Check that all public connector functions have corresponding MCP tools
+
+CLIENT_FILE="src/apple_calendar_mcp/calendar_connector.py"
+SERVER_FILE="src/apple_calendar_mcp/server_fastmcp.py"
+
+echo "Checking client/server parity..."
+echo ""
+
+# Extract public function names from connector (exclude private/internal)
+CLIENT_FUNCTIONS=$(grep -E "^    def [a-z][a-z_]*\(" "$CLIENT_FILE" | \
+    grep -v "def _" | \
+    sed 's/.*def \([a-z_]*\).*/\1/' | \
+    sort | uniq)
+
+# Extract tool function names from server
+SERVER_TOOLS=$(grep -A1 "@mcp.tool()" "$SERVER_FILE" | \
+    grep "^def " | \
+    sed 's/def \([a-z_]*\).*/\1/' | \
+    sort | uniq)
+
+# Find functions missing from server
+MISSING=()
+for func in $CLIENT_FUNCTIONS; do
+    if ! echo "$SERVER_TOOLS" | grep -q "^${func}$"; then
+        MISSING+=("$func")
+    fi
+done
+
+# Display results
+if [ ${#MISSING[@]} -eq 0 ]; then
+    echo "Client/server parity check PASSED"
+    echo ""
+    echo "All $(echo "$CLIENT_FUNCTIONS" | wc -l | tr -d ' ') connector functions have corresponding MCP tools."
+    exit 0
+else
+    echo "Client/server parity check FAILED"
+    echo ""
+    echo "The following connector functions are missing MCP tool exposure:"
+    printf '  - %s\n' "${MISSING[@]}"
+    echo ""
+    echo "Action required:"
+    echo "1. Add @mcp.tool() wrapper in $SERVER_FILE for each missing function"
+    echo "2. Re-run this check"
+    exit 1
+fi

--- a/tests/unit/test_calendar_connector.py
+++ b/tests/unit/test_calendar_connector.py
@@ -1198,3 +1198,186 @@ class TestDeleteEvents:
         self.connector.delete_events("MCP-Test-Calendar", "ABC-123")
         args = mock_swift.call_args[0][1]
         assert "--span" not in args
+
+
+# ── _run_swift_helper_json error handling ─────────────────────────────────
+
+
+class TestRunSwiftHelperJson:
+    """Tests for CalendarConnector._run_swift_helper_json() error paths."""
+
+    def setup_method(self):
+        self.connector = CalendarConnector(enable_safety_checks=False)
+
+    @patch("apple_calendar_mcp.calendar_connector.run_swift_helper")
+    def test_called_process_error_with_json_stdout(self, mock_swift):
+        """CalledProcessError with JSON error in stdout should map to correct exception."""
+        error = subprocess.CalledProcessError(1, "swift")
+        error.stdout = json.dumps({"error": "calendar_not_found", "message": "Calendar 'X' not found"})
+        mock_swift.side_effect = error
+        with pytest.raises(ValueError, match="Calendar 'X' not found"):
+            self.connector._run_swift_helper_json("test_script", [])
+
+    @patch("apple_calendar_mcp.calendar_connector.run_swift_helper")
+    def test_called_process_error_with_no_output(self, mock_swift):
+        """CalledProcessError with empty stdout should raise RuntimeError."""
+        error = subprocess.CalledProcessError(1, "swift")
+        error.stdout = ""
+        mock_swift.side_effect = error
+        with pytest.raises(RuntimeError, match="failed with no output"):
+            self.connector._run_swift_helper_json("test_script", [])
+
+    @patch("apple_calendar_mcp.calendar_connector.run_swift_helper")
+    def test_called_process_error_with_none_stdout(self, mock_swift):
+        """CalledProcessError with None stdout should raise RuntimeError."""
+        error = subprocess.CalledProcessError(1, "swift")
+        error.stdout = None
+        mock_swift.side_effect = error
+        with pytest.raises(RuntimeError, match="failed with no output"):
+            self.connector._run_swift_helper_json("test_script", [])
+
+
+# ── create_events (batch) ─────────────────────────────────────────────────
+
+
+class TestCreateEvents:
+    """Tests for CalendarConnector.create_events()."""
+
+    def setup_method(self):
+        self.connector = CalendarConnector(enable_safety_checks=False)
+
+    @patch("apple_calendar_mcp.calendar_connector.run_swift_helper")
+    def test_creates_batch_events(self, mock_swift):
+        mock_swift.return_value = json.dumps({
+            "created": [{"uid": "UID-1", "summary": "Event 1"}, {"uid": "UID-2", "summary": "Event 2"}],
+            "errors": [],
+        })
+        events = [
+            {"summary": "Event 1", "start": "2026-03-15T10:00:00", "end": "2026-03-15T11:00:00"},
+            {"summary": "Event 2", "start": "2026-03-15T12:00:00", "end": "2026-03-15T13:00:00"},
+        ]
+        result = self.connector.create_events("MCP-Test-Calendar", events)
+        assert len(result["created"]) == 2
+        assert result["errors"] == []
+
+    @patch("apple_calendar_mcp.calendar_connector.run_swift_helper")
+    def test_partial_success(self, mock_swift):
+        mock_swift.return_value = json.dumps({
+            "created": [{"uid": "UID-1", "summary": "Event 1"}],
+            "errors": [{"index": 1, "summary": "Bad Event", "error": "invalid date"}],
+        })
+        result = self.connector.create_events("MCP-Test-Calendar", [{"summary": "Event 1"}, {"summary": "Bad Event"}])
+        assert len(result["created"]) == 1
+        assert len(result["errors"]) == 1
+
+    def test_empty_list_raises(self):
+        with pytest.raises(ValueError, match="At least one event"):
+            self.connector.create_events("MCP-Test-Calendar", [])
+
+    def test_safety_blocks_non_test_calendar(self):
+        connector = CalendarConnector(enable_safety_checks=True)
+        with pytest.raises(CalendarSafetyError):
+            connector.create_events("Personal", [{"summary": "Test"}])
+
+
+# ── update_events (batch) ─────────────────────────────────────────────────
+
+
+class TestUpdateEvents:
+    """Tests for CalendarConnector.update_events()."""
+
+    def setup_method(self):
+        self.connector = CalendarConnector(enable_safety_checks=False)
+
+    @patch("apple_calendar_mcp.calendar_connector.run_swift_helper")
+    def test_updates_batch(self, mock_swift):
+        mock_swift.return_value = json.dumps({
+            "updated": [{"uid": "UID-1", "summary": "Updated", "updated_fields": ["summary"]}],
+            "errors": [],
+        })
+        result = self.connector.update_events("MCP-Test-Calendar", [{"uid": "UID-1", "summary": "Updated"}])
+        assert len(result["updated"]) == 1
+
+    def test_empty_list_raises(self):
+        with pytest.raises(ValueError, match="At least one update"):
+            self.connector.update_events("MCP-Test-Calendar", [])
+
+    def test_occurrence_date_rejected(self):
+        with pytest.raises(ValueError, match="does not support occurrence_date"):
+            self.connector.update_events("MCP-Test-Calendar", [{"uid": "UID-1", "occurrence_date": "2026-03-15"}])
+
+    def test_safety_blocks_non_test_calendar(self):
+        connector = CalendarConnector(enable_safety_checks=True)
+        with pytest.raises(CalendarSafetyError):
+            connector.update_events("Personal", [{"uid": "UID-1", "summary": "Test"}])
+
+
+# ── search_events ─────────────────────────────────────────────────────────
+
+
+class TestSearchEvents:
+    """Tests for CalendarConnector.search_events()."""
+
+    def setup_method(self):
+        self.connector = CalendarConnector(enable_safety_checks=False)
+
+    @patch("apple_calendar_mcp.calendar_connector.run_swift_helper")
+    def test_searches_specific_calendar(self, mock_swift):
+        mock_swift.return_value = json.dumps([
+            {"uid": "UID-1", "summary": "Team Lunch", "start_date": "2026-03-15T12:00:00",
+             "end_date": "2026-03-15T13:00:00", "calendar_name": "Work"},
+        ])
+        results = self.connector.search_events("lunch", calendar_name="Work",
+                                                start_date="2026-03-01", end_date="2026-04-01")
+        assert len(results) == 1
+        assert results[0]["summary"] == "Team Lunch"
+        args = mock_swift.call_args[0][1]
+        assert "--query" in args
+        assert "lunch" in args
+
+    @patch("apple_calendar_mcp.calendar_connector.run_swift_helper")
+    def test_searches_all_calendars(self, mock_swift):
+        """When no calendar_name, searches all calendars."""
+        # get_calendars returns two calendars
+        def side_effect(script, args, **kwargs):
+            if script == "get_calendars":
+                return json.dumps([
+                    {"name": "Work", "writable": True, "description": "", "color": "#FF0000"},
+                    {"name": "Personal", "writable": True, "description": "", "color": "#0000FF"},
+                ])
+            # get_events returns for each calendar
+            return json.dumps([])
+        mock_swift.side_effect = side_effect
+        results = self.connector.search_events("lunch", start_date="2026-03-01", end_date="2026-04-01")
+        assert results == []
+        # Should have called get_calendars + get_events for each calendar
+        assert mock_swift.call_count == 3  # get_calendars + 2x get_events
+
+    @patch("apple_calendar_mcp.calendar_connector.run_swift_helper")
+    def test_default_date_range(self, mock_swift):
+        """When no dates, defaults to 1 month ago to 6 months from now."""
+        mock_swift.return_value = json.dumps([])
+        self.connector.search_events("test", calendar_name="Work")
+        args = mock_swift.call_args[0][1]
+        # Should have --start and --end with auto-generated dates
+        assert "--start" in args
+        assert "--end" in args
+
+    @patch("apple_calendar_mcp.calendar_connector.run_swift_helper")
+    def test_skips_calendar_not_found(self, mock_swift):
+        """Calendar not found errors should be silently skipped."""
+        def side_effect(script, args, **kwargs):
+            if script == "get_calendars":
+                return json.dumps([
+                    {"name": "Work", "writable": True, "description": "", "color": "#FF0000"},
+                    {"name": "Missing", "writable": True, "description": "", "color": "#00FF00"},
+                ])
+            # Work returns events, Missing raises ValueError
+            cal_arg_idx = args.index("--calendar") + 1 if "--calendar" in args else -1
+            if cal_arg_idx >= 0 and args[cal_arg_idx] == "Missing":
+                return json.dumps({"error": "calendar_not_found", "message": "not found"})
+            return json.dumps([{"uid": "UID-1", "summary": "Found", "start_date": "2026-03-15T10:00:00",
+                                "end_date": "2026-03-15T11:00:00", "calendar_name": "Work"}])
+        mock_swift.side_effect = side_effect
+        results = self.connector.search_events("found", start_date="2026-03-01", end_date="2026-04-01")
+        assert len(results) == 1

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -602,3 +602,502 @@ class TestServerConfiguration:
 
     def test_server_name(self):
         assert mcp.name == "apple-calendar-mcp"
+
+
+class TestParseAlertMinutes:
+    """Tests for the _parse_alert_minutes helper."""
+
+    def test_valid_single_value(self):
+        from apple_calendar_mcp.server_fastmcp import _parse_alert_minutes
+        assert _parse_alert_minutes("15") == [15]
+
+    def test_valid_multiple_values(self):
+        from apple_calendar_mcp.server_fastmcp import _parse_alert_minutes
+        assert _parse_alert_minutes("15,60") == [15, 60]
+
+    def test_whitespace_handling(self):
+        from apple_calendar_mcp.server_fastmcp import _parse_alert_minutes
+        assert _parse_alert_minutes(" 15 , 60 ") == [15, 60]
+
+    def test_empty_string_returns_none(self):
+        from apple_calendar_mcp.server_fastmcp import _parse_alert_minutes
+        assert _parse_alert_minutes("") is None
+
+    def test_invalid_value_raises_error(self):
+        from apple_calendar_mcp.server_fastmcp import _parse_alert_minutes
+        with pytest.raises(ValueError, match="comma-separated integers"):
+            _parse_alert_minutes("15,abc")
+
+    def test_all_invalid_raises_error(self):
+        from apple_calendar_mcp.server_fastmcp import _parse_alert_minutes
+        with pytest.raises(ValueError, match="comma-separated integers"):
+            _parse_alert_minutes("not_a_number")
+
+
+class TestFormatCalendarDescription:
+    """Tests for _format_calendar with description field."""
+
+    def test_calendar_with_description(self):
+        from apple_calendar_mcp.server_fastmcp import _format_calendar
+        cal = {"name": "Work", "writable": True, "description": "My work calendar", "color": "#FF0000"}
+        result = _format_calendar(cal)
+        assert "Description: My work calendar" in result
+
+    def test_calendar_without_description(self):
+        from apple_calendar_mcp.server_fastmcp import _format_calendar
+        cal = {"name": "Work", "writable": True, "description": "", "color": "#FF0000"}
+        result = _format_calendar(cal)
+        assert "Description" not in result
+
+
+class TestFormatEventDetails:
+    """Tests for _format_event_details, _format_alerts, and _format_recurrence."""
+
+    def test_allday_event(self):
+        from apple_calendar_mcp.server_fastmcp import _format_event_details
+        event = {"allday_event": True}
+        lines = _format_event_details(event)
+        assert "All-day event" in lines
+
+    def test_non_allday_event(self):
+        from apple_calendar_mcp.server_fastmcp import _format_event_details
+        event = {"allday_event": False}
+        lines = _format_event_details(event)
+        assert "All-day event" not in lines
+
+    def test_availability_free(self):
+        from apple_calendar_mcp.server_fastmcp import _format_event_details
+        event = {"availability": "free"}
+        lines = _format_event_details(event)
+        assert "Availability: free" in lines
+
+    def test_availability_busy_not_shown(self):
+        from apple_calendar_mcp.server_fastmcp import _format_event_details
+        event = {"availability": "busy"}
+        lines = _format_event_details(event)
+        assert all("Availability" not in line for line in lines)
+
+    def test_format_alerts(self):
+        from apple_calendar_mcp.server_fastmcp import _format_alerts
+        alerts = [{"minutes_before": 15}, {"minutes_before": 60}]
+        lines = _format_alerts(alerts)
+        assert len(lines) == 1
+        assert "15m before" in lines[0]
+        assert "60m before" in lines[0]
+
+    def test_format_alerts_empty(self):
+        from apple_calendar_mcp.server_fastmcp import _format_alerts
+        assert _format_alerts([]) == []
+
+    def test_format_recurrence_not_recurring(self):
+        from apple_calendar_mcp.server_fastmcp import _format_recurrence
+        event = {"is_recurring": False}
+        assert _format_recurrence(event) == []
+
+    def test_format_recurrence_detached(self):
+        from apple_calendar_mcp.server_fastmcp import _format_recurrence
+        event = {"is_recurring": True, "recurrence_rule": "FREQ=DAILY", "is_detached": True}
+        lines = _format_recurrence(event)
+        assert any("detached" in line.lower() for line in lines)
+
+
+class TestCreateEventsTool:
+    """Tests for the create_events MCP tool (batch)."""
+
+    @patch("apple_calendar_mcp.server_fastmcp.get_client")
+    def test_batch_create_success(self, mock_get_client):
+        mock_client = MagicMock()
+        mock_client.create_events.return_value = {
+            "created": [
+                {"summary": "Event A", "uid": "UID-A"},
+                {"summary": "Event B", "uid": "UID-B"},
+            ],
+            "errors": [],
+        }
+        mock_get_client.return_value = mock_client
+
+        from apple_calendar_mcp.server_fastmcp import create_events
+        events_json = json.dumps([
+            {"summary": "Event A", "start": "2026-03-15T10:00:00", "end": "2026-03-15T11:00:00"},
+            {"summary": "Event B", "start": "2026-03-15T12:00:00", "end": "2026-03-15T13:00:00"},
+        ])
+        result = create_events(calendar_name="Work", events=events_json)
+        assert "Created 2 event(s)" in result
+        assert "Event A" in result
+        assert "UID-A" in result
+        assert "Event B" in result
+        assert isinstance(result, str)
+
+    @patch("apple_calendar_mcp.server_fastmcp.get_client")
+    def test_batch_create_error(self, mock_get_client):
+        mock_client = MagicMock()
+        mock_client.create_events.side_effect = Exception("Calendar not found")
+        mock_get_client.return_value = mock_client
+
+        from apple_calendar_mcp.server_fastmcp import create_events
+        events_json = json.dumps([
+            {"summary": "Event A", "start": "2026-03-15T10:00:00", "end": "2026-03-15T11:00:00"},
+        ])
+        result = create_events(calendar_name="Nonexistent", events=events_json)
+        assert "Error" in result
+        assert isinstance(result, str)
+
+    @patch("apple_calendar_mcp.server_fastmcp.get_client")
+    def test_batch_create_partial_success(self, mock_get_client):
+        mock_client = MagicMock()
+        mock_client.create_events.return_value = {
+            "created": [{"summary": "Event A", "uid": "UID-A"}],
+            "errors": [{"index": 1, "summary": "Event B", "error": "Invalid date"}],
+        }
+        mock_get_client.return_value = mock_client
+
+        from apple_calendar_mcp.server_fastmcp import create_events
+        events_json = json.dumps([
+            {"summary": "Event A", "start": "2026-03-15T10:00:00", "end": "2026-03-15T11:00:00"},
+            {"summary": "Event B", "start": "bad-date", "end": "bad-date"},
+        ])
+        result = create_events(calendar_name="Work", events=events_json)
+        assert "Created 1 event(s)" in result
+        assert "1 error(s)" in result
+        assert "Invalid date" in result
+
+    def test_invalid_json(self):
+        from apple_calendar_mcp.server_fastmcp import create_events
+        result = create_events(calendar_name="Work", events="not json")
+        assert "Error" in result
+        assert "invalid JSON" in result
+
+    def test_non_array_json(self):
+        from apple_calendar_mcp.server_fastmcp import create_events
+        result = create_events(calendar_name="Work", events='{"summary": "test"}')
+        assert "Error" in result
+        assert "JSON array" in result
+
+
+class TestUpdateEventsTool:
+    """Tests for the update_events MCP tool (batch)."""
+
+    @patch("apple_calendar_mcp.server_fastmcp.get_client")
+    def test_batch_update_success(self, mock_get_client):
+        mock_client = MagicMock()
+        mock_client.update_events.return_value = {
+            "updated": [
+                {"summary": "Event A", "updated_fields": ["start", "end"]},
+                {"summary": "Event B", "updated_fields": ["location"]},
+            ],
+            "errors": [],
+        }
+        mock_get_client.return_value = mock_client
+
+        from apple_calendar_mcp.server_fastmcp import update_events
+        updates_json = json.dumps([
+            {"uid": "UID-A", "start": "2026-03-15T11:00:00", "end": "2026-03-15T12:00:00"},
+            {"uid": "UID-B", "location": "Room B"},
+        ])
+        result = update_events(calendar_name="Work", updates=updates_json)
+        assert "Updated 2 event(s)" in result
+        assert "Event A" in result
+        assert "start, end" in result
+        assert "location" in result
+        assert isinstance(result, str)
+
+    @patch("apple_calendar_mcp.server_fastmcp.get_client")
+    def test_batch_update_error(self, mock_get_client):
+        mock_client = MagicMock()
+        mock_client.update_events.side_effect = Exception("Calendar not found")
+        mock_get_client.return_value = mock_client
+
+        from apple_calendar_mcp.server_fastmcp import update_events
+        updates_json = json.dumps([{"uid": "UID-A", "summary": "New"}])
+        result = update_events(calendar_name="Nonexistent", updates=updates_json)
+        assert "Error" in result
+        assert isinstance(result, str)
+
+    @patch("apple_calendar_mcp.server_fastmcp.get_client")
+    def test_batch_update_partial_with_errors(self, mock_get_client):
+        mock_client = MagicMock()
+        mock_client.update_events.return_value = {
+            "updated": [{"summary": "Event A", "updated_fields": ["summary"]}],
+            "errors": [{"index": 1, "uid": "UID-B", "error": "Event not found"}],
+        }
+        mock_get_client.return_value = mock_client
+
+        from apple_calendar_mcp.server_fastmcp import update_events
+        updates_json = json.dumps([
+            {"uid": "UID-A", "summary": "New A"},
+            {"uid": "UID-B", "summary": "New B"},
+        ])
+        result = update_events(calendar_name="Work", updates=updates_json)
+        assert "Updated 1 event(s)" in result
+        assert "1 error(s)" in result
+        assert "Event not found" in result
+
+    def test_invalid_json(self):
+        from apple_calendar_mcp.server_fastmcp import update_events
+        result = update_events(calendar_name="Work", updates="not json")
+        assert "Error" in result
+        assert "invalid JSON" in result
+
+    def test_non_array_json(self):
+        from apple_calendar_mcp.server_fastmcp import update_events
+        result = update_events(calendar_name="Work", updates='{"uid": "test"}')
+        assert "Error" in result
+        assert "JSON array" in result
+
+
+class TestSearchEventsTool:
+    """Tests for the search_events MCP tool."""
+
+    @patch("apple_calendar_mcp.server_fastmcp.get_client")
+    def test_search_with_results(self, mock_get_client):
+        mock_client = MagicMock()
+        mock_client.search_events.return_value = [
+            {"uid": "S-123", "summary": "Team Standup", "start_date": "2026-03-15T09:00:00",
+             "end_date": "2026-03-15T09:30:00", "allday_event": False, "location": "",
+             "notes": "", "url": "", "status": "confirmed", "calendar_name": "Work"},
+        ]
+        mock_get_client.return_value = mock_client
+
+        from apple_calendar_mcp.server_fastmcp import search_events
+        result = search_events(query="standup", calendar_name="Work")
+        assert "Found 1 event(s)" in result
+        assert "Team Standup" in result
+        assert "in 'Work'" in result
+        assert isinstance(result, str)
+
+    @patch("apple_calendar_mcp.server_fastmcp.get_client")
+    def test_search_no_results_specific_calendar(self, mock_get_client):
+        mock_client = MagicMock()
+        mock_client.search_events.return_value = []
+        mock_get_client.return_value = mock_client
+
+        from apple_calendar_mcp.server_fastmcp import search_events
+        result = search_events(query="nonexistent", calendar_name="Work")
+        assert "No events matching" in result
+        assert "in 'Work'" in result
+
+    @patch("apple_calendar_mcp.server_fastmcp.get_client")
+    def test_search_no_results_all_calendars(self, mock_get_client):
+        mock_client = MagicMock()
+        mock_client.search_events.return_value = []
+        mock_get_client.return_value = mock_client
+
+        from apple_calendar_mcp.server_fastmcp import search_events
+        result = search_events(query="nonexistent")
+        assert "No events matching" in result
+        assert "across all calendars" in result
+
+    @patch("apple_calendar_mcp.server_fastmcp.get_client")
+    def test_search_error(self, mock_get_client):
+        mock_client = MagicMock()
+        mock_client.search_events.side_effect = Exception("Search failed")
+        mock_get_client.return_value = mock_client
+
+        from apple_calendar_mcp.server_fastmcp import search_events
+        result = search_events(query="test")
+        assert "Error" in result
+        assert isinstance(result, str)
+
+    @patch("apple_calendar_mcp.server_fastmcp.get_client")
+    def test_search_passes_none_for_empty_optional_params(self, mock_get_client):
+        mock_client = MagicMock()
+        mock_client.search_events.return_value = []
+        mock_get_client.return_value = mock_client
+
+        from apple_calendar_mcp.server_fastmcp import search_events
+        search_events(query="test")
+        mock_client.search_events.assert_called_once_with(
+            query="test",
+            calendar_name=None,
+            start_date=None,
+            end_date=None,
+        )
+
+    @patch("apple_calendar_mcp.server_fastmcp.get_client")
+    def test_search_results_across_all_calendars(self, mock_get_client):
+        mock_client = MagicMock()
+        mock_client.search_events.return_value = [
+            {"uid": "S-1", "summary": "Lunch", "start_date": "2026-03-15T12:00:00",
+             "end_date": "2026-03-15T13:00:00", "allday_event": False, "location": "",
+             "notes": "", "url": "", "status": "confirmed", "calendar_name": "Personal"},
+        ]
+        mock_get_client.return_value = mock_client
+
+        from apple_calendar_mcp.server_fastmcp import search_events
+        result = search_events(query="lunch")
+        assert "across all calendars" in result
+
+
+class TestGetConflictsTool:
+    """Tests for the get_conflicts MCP tool."""
+
+    @patch("apple_calendar_mcp.server_fastmcp.get_client")
+    def test_conflicts_found(self, mock_get_client):
+        mock_client = MagicMock()
+        mock_client.get_conflicts.return_value = [
+            {
+                "event_a": {"summary": "Meeting A", "calendar_name": "Work",
+                            "start_date": "2026-03-15T10:00:00", "end_date": "2026-03-15T11:00:00"},
+                "event_b": {"summary": "Meeting B", "calendar_name": "Work",
+                            "start_date": "2026-03-15T10:30:00", "end_date": "2026-03-15T11:30:00"},
+                "overlap_start": "2026-03-15T10:30:00",
+                "overlap_end": "2026-03-15T11:00:00",
+                "overlap_minutes": 30,
+            }
+        ]
+        mock_get_client.return_value = mock_client
+
+        from apple_calendar_mcp.server_fastmcp import get_conflicts
+        result = get_conflicts(calendar_names=["Work"], start_date="2026-03-15T00:00:00", end_date="2026-03-16T00:00:00")
+        assert "Found 1 conflict(s)" in result
+        assert "Meeting A" in result
+        assert "Meeting B" in result
+        assert "30 min overlap" in result
+        assert isinstance(result, str)
+
+    @patch("apple_calendar_mcp.server_fastmcp.get_client")
+    def test_no_conflicts(self, mock_get_client):
+        mock_client = MagicMock()
+        mock_client.get_conflicts.return_value = []
+        mock_get_client.return_value = mock_client
+
+        from apple_calendar_mcp.server_fastmcp import get_conflicts
+        result = get_conflicts(calendar_names=["Work"], start_date="2026-03-15T00:00:00", end_date="2026-03-16T00:00:00")
+        assert "No conflicts found" in result
+
+    @patch("apple_calendar_mcp.server_fastmcp.get_client")
+    def test_conflicts_error(self, mock_get_client):
+        mock_client = MagicMock()
+        mock_client.get_conflicts.side_effect = Exception("Calendar not found")
+        mock_get_client.return_value = mock_client
+
+        from apple_calendar_mcp.server_fastmcp import get_conflicts
+        result = get_conflicts(calendar_names=["Bad"], start_date="2026-03-15T00:00:00", end_date="2026-03-16T00:00:00")
+        assert "Error" in result
+        assert isinstance(result, str)
+
+
+class TestUpdateEventToolBranches:
+    """Tests for uncovered branches in the update_event tool."""
+
+    @patch("apple_calendar_mcp.server_fastmcp.get_client")
+    def test_alert_minutes_none_clears_alerts(self, mock_get_client):
+        mock_client = MagicMock()
+        mock_client.update_event.return_value = {"uid": "ABC-123", "updated_fields": ["alert_minutes"]}
+        mock_get_client.return_value = mock_client
+
+        from apple_calendar_mcp.server_fastmcp import update_event
+        result = update_event(calendar_name="Work", event_uid="ABC-123", alert_minutes="none")
+        call_kwargs = mock_client.update_event.call_args[1]
+        assert call_kwargs["alert_minutes"] == []
+        assert "ABC-123" in result
+
+    @patch("apple_calendar_mcp.server_fastmcp.get_client")
+    def test_alert_minutes_parsed(self, mock_get_client):
+        mock_client = MagicMock()
+        mock_client.update_event.return_value = {"uid": "ABC-123", "updated_fields": ["alert_minutes"]}
+        mock_get_client.return_value = mock_client
+
+        from apple_calendar_mcp.server_fastmcp import update_event
+        update_event(calendar_name="Work", event_uid="ABC-123", alert_minutes="15,60")
+        call_kwargs = mock_client.update_event.call_args[1]
+        assert call_kwargs["alert_minutes"] == [15, 60]
+
+    @patch("apple_calendar_mcp.server_fastmcp.get_client")
+    def test_recurrence_rule_passed_through(self, mock_get_client):
+        mock_client = MagicMock()
+        mock_client.update_event.return_value = {"uid": "ABC-123", "updated_fields": ["recurrence_rule"]}
+        mock_get_client.return_value = mock_client
+
+        from apple_calendar_mcp.server_fastmcp import update_event
+        update_event(calendar_name="Work", event_uid="ABC-123", recurrence_rule="FREQ=DAILY")
+        call_kwargs = mock_client.update_event.call_args[1]
+        assert call_kwargs["recurrence_rule"] == "FREQ=DAILY"
+
+    @patch("apple_calendar_mcp.server_fastmcp.get_client")
+    def test_recurrence_rule_empty_string_clears(self, mock_get_client):
+        mock_client = MagicMock()
+        mock_client.update_event.return_value = {"uid": "ABC-123", "updated_fields": ["recurrence_rule"]}
+        mock_get_client.return_value = mock_client
+
+        from apple_calendar_mcp.server_fastmcp import update_event
+        update_event(calendar_name="Work", event_uid="ABC-123", recurrence_rule="")
+        call_kwargs = mock_client.update_event.call_args[1]
+        assert call_kwargs["recurrence_rule"] == ""
+
+    @patch("apple_calendar_mcp.server_fastmcp.get_client")
+    def test_timezone_and_occurrence_date_passed(self, mock_get_client):
+        mock_client = MagicMock()
+        mock_client.update_event.return_value = {"uid": "ABC-123", "updated_fields": ["start_date"]}
+        mock_get_client.return_value = mock_client
+
+        from apple_calendar_mcp.server_fastmcp import update_event
+        update_event(
+            calendar_name="Work", event_uid="ABC-123",
+            start_date="2026-03-15T10:00:00",
+            timezone="America/Los_Angeles",
+            occurrence_date="2026-03-15T09:00:00",
+            span="future_events",
+        )
+        call_kwargs = mock_client.update_event.call_args[1]
+        assert call_kwargs["timezone"] == "America/Los_Angeles"
+        assert call_kwargs["occurrence_date"] == "2026-03-15T09:00:00"
+        assert call_kwargs["span"] == "future_events"
+
+
+class TestDeleteEventsToolBranches:
+    """Tests for uncovered branches in the delete_events tool."""
+
+    @patch("apple_calendar_mcp.server_fastmcp.get_client")
+    def test_single_uid_string_passed_directly(self, mock_get_client):
+        mock_client = MagicMock()
+        mock_client.delete_events.return_value = {
+            "deleted_uids": ["UID-1"],
+            "not_found_uids": [],
+        }
+        mock_get_client.return_value = mock_client
+
+        from apple_calendar_mcp.server_fastmcp import delete_events
+        result = delete_events(calendar_name="Work", event_uid="UID-1")
+        # event_uid is passed as-is (string) to event_uids
+        mock_client.delete_events.assert_called_once_with(
+            calendar_name="Work",
+            event_uids="UID-1",
+            span="this_event",
+            occurrence_date=None,
+        )
+        assert "Deleted 1 event(s)" in result
+
+    @patch("apple_calendar_mcp.server_fastmcp.get_client")
+    def test_occurrence_date_and_span_passed(self, mock_get_client):
+        mock_client = MagicMock()
+        mock_client.delete_events.return_value = {
+            "deleted_uids": ["UID-1"],
+            "not_found_uids": [],
+        }
+        mock_get_client.return_value = mock_client
+
+        from apple_calendar_mcp.server_fastmcp import delete_events
+        delete_events(
+            calendar_name="Work", event_uid="UID-1",
+            span="future_events",
+            occurrence_date="2026-03-15T09:00:00",
+        )
+        call_kwargs = mock_client.delete_events.call_args[1]
+        assert call_kwargs["span"] == "future_events"
+        assert call_kwargs["occurrence_date"] == "2026-03-15T09:00:00"
+
+    @patch("apple_calendar_mcp.server_fastmcp.get_client")
+    def test_not_found_uids_reported(self, mock_get_client):
+        mock_client = MagicMock()
+        mock_client.delete_events.return_value = {
+            "deleted_uids": [],
+            "not_found_uids": ["UID-GONE"],
+        }
+        mock_get_client.return_value = mock_client
+
+        from apple_calendar_mcp.server_fastmcp import delete_events
+        result = delete_events(calendar_name="Work", event_uid="UID-GONE")
+        assert "Deleted 0 event(s)" in result
+        assert "Not found" in result
+        assert "UID-GONE" in result


### PR DESCRIPTION
## Summary
- **Connector/server parity check:** `check_client_server_parity.sh` verifies all 12 connector methods have corresponding @mcp.tool() functions
- **Coverage enforcement:** 90% minimum threshold (currently 95.47%)
- **58 new unit tests** covering previously untested code paths:
  - `_run_swift_helper_json` CalledProcessError handling
  - `create_events` batch operations
  - `update_events` batch + occurrence_date rejection
  - `search_events` (specific/all calendars, default dates, error skipping)
  - All server tool formatting functions
- **CI updated:** coverage reporting and parity check added to test.yml
- Test count: 157 → 215

## Test plan
- [x] `make test-unit` with coverage — 215 passed, 95.47% coverage
- [x] `./scripts/check_client_server_parity.sh` — all 12 functions matched

Closes #129

🤖 Generated with [Claude Code](https://claude.com/claude-code)