### PR TITLE
Add SECURITY.md, dependabot, and dependency audit (#130)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 5

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test test-unit test-integration test-verbose install clean complexity help
+.PHONY: test test-unit test-integration test-verbose install clean complexity audit help
 
 help:
 	@echo "Available targets:"
@@ -8,6 +8,7 @@ help:
 	@echo "  make test-integration - Run integration tests (requires test calendar)"
 	@echo "  make test-verbose     - Run tests with verbose output"
 	@echo "  make complexity       - Check code complexity with radon"
+	@echo "  make audit            - Check dependencies for vulnerabilities"
 	@echo "  make clean            - Remove cache and build artifacts"
 
 install:
@@ -29,6 +30,9 @@ test-verbose:
 
 complexity:
 	@./scripts/check_complexity.sh
+
+audit:
+	@./scripts/check_dependencies.sh
 
 clean:
 	rm -rf __pycache__ .pytest_cache .coverage htmlcov/

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,16 @@
+# Security Policy
+
+## Supported Versions
+
+Only the latest release receives security updates.
+
+## Reporting a Vulnerability
+
+Please report security vulnerabilities using [GitHub's private security advisory feature](https://github.com/s-morgan-jeffries/apple-calendar-mcp/security/advisories/new).
+
+**Do not** open a public issue for security vulnerabilities.
+
+### Timeline
+
+- **Acknowledgment:** Within 48 hours
+- **Assessment and response:** Within 7 days

--- a/scripts/check_dependencies.sh
+++ b/scripts/check_dependencies.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# Check for known security vulnerabilities in dependencies.
+# Uses pip-audit against the PyPI/OSV vulnerability database.
+#
+# Install: pip install pip-audit
+# Usage: ./scripts/check_dependencies.sh
+
+set -euo pipefail
+
+echo "Checking dependencies for known vulnerabilities..."
+echo ""
+
+# Check pip-audit is available
+if ! command -v pip-audit &> /dev/null; then
+    if [ -f "./venv/bin/pip-audit" ]; then
+        PIP_AUDIT="./venv/bin/pip-audit"
+    else
+        echo "ERROR: pip-audit not found."
+        echo "Install it: pip install pip-audit"
+        exit 1
+    fi
+else
+    PIP_AUDIT="pip-audit"
+fi
+
+if $PIP_AUDIT 2>&1; then
+    echo ""
+    echo "Dependency audit PASSED — no known vulnerabilities found."
+    exit 0
+else
+    echo ""
+    echo "Dependency audit FAILED — vulnerabilities found above."
+    echo "Run 'pip-audit --fix' to attempt automatic fixes, or update affected packages manually."
+    exit 1
+fi


### PR DESCRIPTION
## Summary
- **SECURITY.md:** private vulnerability disclosure via GitHub advisory, 48h acknowledgment / 7-day response SLA
- **dependabot.yml:** monthly pip dependency updates, 5 PR limit
- **check_dependencies.sh:** pip-audit wrapper for vulnerability scanning
- **Makefile:** `make audit` target

## Test plan
- [x] Manual verification of file contents

Closes #130

🤖 Generated with [Claude Code](https://claude.com/claude-code)