### PR TITLE
Add calendar source/account field to get_calendars (#141)

### DIFF
--- a/evals/agent_tool_usability/tool_descriptions.md
+++ b/evals/agent_tool_usability/tool_descriptions.md
@@ -24,11 +24,11 @@ DATES: All dates use ISO 8601 format in local time, without timezone suffix (e.g
 
 List all calendars in Apple Calendar.
 
-Returns all calendars with their names, access level (read-write or read-only), descriptions, and colors. Use this to discover available calendars before creating or querying events.
+Returns all calendars with their names, access level (read-write or read-only), source (account name), descriptions, and colors. Use this to discover available calendars before creating or querying events.
 
-Note: Calendar names may not be unique across accounts. Check the description field to distinguish calendars with the same name from different accounts.
+Note: Calendar names may not be unique across accounts. Use the source field (e.g., "iCloud", "Google") to distinguish calendars with the same name from different accounts.
 
-**Returns:** Each calendar includes: name, access level (read-write or read-only), description, color. Use calendar names exactly as shown when calling other tools.
+**Returns:** Each calendar includes: name, access level (read-write or read-only), source (account name like "iCloud" or "Google"), description, color. Use calendar names exactly as shown when calling other tools.
 
 **Parameters:** None
 

--- a/src/apple_calendar_mcp/calendar_connector.py
+++ b/src/apple_calendar_mcp/calendar_connector.py
@@ -819,8 +819,9 @@ class CalendarConnector:
         Uses EventKit via Swift helper for fast native access.
 
         Returns:
-            List of calendar dicts with keys: name, writable, description, color.
+            List of calendar dicts with keys: name, writable, description, color, type, source.
             Calendars are identified by name. Duplicate names may exist across accounts.
+            Use source (account name) to disambiguate.
 
         Raises:
             PermissionError: If EventKit calendar access is denied

--- a/src/apple_calendar_mcp/server_fastmcp.py
+++ b/src/apple_calendar_mcp/server_fastmcp.py
@@ -10,7 +10,7 @@ from .calendar_connector import CalendarConnector
 # Create FastMCP server
 mcp = FastMCP("apple-calendar-mcp", instructions="""Apple Calendar is the built-in macOS calendar application. This MCP server provides tools to interact with it.
 
-CALENDARS: Each calendar has a name, writable status, type (caldav, subscription, birthday, local), description, and color. Calendar names are NOT guaranteed unique — the same name can appear across different accounts (e.g., two "Family" calendars from iCloud and Google). Use description to disambiguate when needed.
+CALENDARS: Each calendar has a name, writable status, type (caldav, subscription, birthday, local), source (account name like "iCloud" or "Google"), description, and color. Calendar names are NOT guaranteed unique — the same name can appear across different accounts (e.g., two "Family" calendars from iCloud and Google). Use the source field to disambiguate when needed.
 
 CALENDAR IDENTIFICATION: Calendars are identified by name (not UID — UIDs are not accessible via AppleScript). When specifying a calendar, use the exact name as returned by get_calendars.
 
@@ -43,6 +43,8 @@ def _format_calendar(cal: dict) -> str:
     writable = "read-write" if cal["writable"] else "read-only"
     result = f"Name: {cal['name']}\n"
     result += f"Access: {writable}\n"
+    if cal.get("source"):
+        result += f"Source: {cal['source']}\n"
     if cal.get("description"):
         result += f"Description: {cal['description']}\n"
     result += f"Color: {cal['color']}\n"
@@ -57,11 +59,13 @@ def get_calendars() -> str:
     descriptions, and colors. Use this to discover available calendars before
     creating or querying events.
 
-    Note: Calendar names may not be unique across accounts. Check the description
-    field to distinguish calendars with the same name from different accounts.
+    Note: Calendar names may not be unique across accounts. Use the source field
+    (e.g., "iCloud", "Google") to distinguish calendars with the same name from
+    different accounts.
 
     Returns:
-        Each calendar includes: name, access level (read-write or read-only), description, color.
+        Each calendar includes: name, access level (read-write or read-only), source
+        (account name like "iCloud" or "Google"), description, color.
         Use calendar names exactly as shown when calling other tools.
     """
     client = get_client()

--- a/src/apple_calendar_mcp/swift/get_calendars.swift
+++ b/src/apple_calendar_mcp/swift/get_calendars.swift
@@ -66,6 +66,7 @@ let calendarDicts: [[String: Any]] = calendars.map { cal in
         "description": (cal as EKCalendar).value(forKey: "notes") as? String ?? "",
         "color": cgColorToHex(cal.cgColor),
         "type": calendarTypeString(cal.type),
+        "source": cal.source.title,
     ]
 }
 

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -86,13 +86,14 @@ class TestGetCalendarsIntegration:
         assert "MCP-Test-Calendar" in names
 
     def test_calendar_has_required_keys(self, connector):
-        """Each calendar should have name, writable, description, color."""
+        """Each calendar should have name, writable, description, color, source."""
         calendars = connector.get_calendars()
         for cal in calendars:
             assert "name" in cal, f"Missing 'name' in calendar: {cal}"
             assert "writable" in cal, f"Missing 'writable' in calendar: {cal}"
             assert "description" in cal, f"Missing 'description' in calendar: {cal}"
             assert "color" in cal, f"Missing 'color' in calendar: {cal}"
+            assert "source" in cal, f"Missing 'source' in calendar: {cal}"
 
     def test_writable_is_boolean(self, connector):
         """Writable should be a proper boolean."""

--- a/tests/unit/test_calendar_connector.py
+++ b/tests/unit/test_calendar_connector.py
@@ -210,8 +210,8 @@ class TestGetCalendars:
     @patch("apple_calendar_mcp.calendar_connector.run_swift_helper")
     def test_returns_list_of_calendar_dicts(self, mock_swift):
         mock_swift.return_value = json.dumps([
-            {"name": "Personal", "writable": True, "description": "", "color": "#0072FF"},
-            {"name": "Work", "writable": True, "description": "", "color": "#FF0023"},
+            {"name": "Personal", "writable": True, "description": "", "color": "#0072FF", "source": "iCloud"},
+            {"name": "Work", "writable": True, "description": "", "color": "#FF0023", "source": "Google"},
         ])
         result = self.connector.get_calendars()
         assert isinstance(result, list)
@@ -222,7 +222,7 @@ class TestGetCalendars:
     @patch("apple_calendar_mcp.calendar_connector.run_swift_helper")
     def test_calendar_has_expected_keys(self, mock_swift):
         mock_swift.return_value = json.dumps([
-            {"name": "Personal", "writable": True, "description": "my cal", "color": "#0072FF"},
+            {"name": "Personal", "writable": True, "description": "my cal", "color": "#0072FF", "source": "iCloud"},
         ])
         result = self.connector.get_calendars()
         cal = result[0]
@@ -240,7 +240,7 @@ class TestGetCalendars:
     @patch("apple_calendar_mcp.calendar_connector.run_swift_helper")
     def test_read_only_calendar(self, mock_swift):
         mock_swift.return_value = json.dumps([
-            {"name": "Holidays", "writable": False, "description": "US Holidays", "color": "#8882FE"},
+            {"name": "Holidays", "writable": False, "description": "US Holidays", "color": "#8882FE", "source": "Other"},
         ])
         result = self.connector.get_calendars()
         assert result[0]["writable"] is False
@@ -248,7 +248,7 @@ class TestGetCalendars:
     @patch("apple_calendar_mcp.calendar_connector.run_swift_helper")
     def test_calendar_with_empty_description(self, mock_swift):
         mock_swift.return_value = json.dumps([
-            {"name": "Work", "writable": True, "description": "", "color": "#FF0000"},
+            {"name": "Work", "writable": True, "description": "", "color": "#FF0000", "source": "iCloud"},
         ])
         result = self.connector.get_calendars()
         assert result[0]["description"] == ""
@@ -1342,7 +1342,7 @@ class TestSearchEvents:
         def side_effect(script, args, **kwargs):
             if script == "get_calendars":
                 return json.dumps([
-                    {"name": "Work", "writable": True, "description": "", "color": "#FF0000"},
+                    {"name": "Work", "writable": True, "description": "", "color": "#FF0000", "source": "iCloud"},
                     {"name": "Personal", "writable": True, "description": "", "color": "#0000FF"},
                 ])
             # get_events returns for each calendar
@@ -1369,7 +1369,7 @@ class TestSearchEvents:
         def side_effect(script, args, **kwargs):
             if script == "get_calendars":
                 return json.dumps([
-                    {"name": "Work", "writable": True, "description": "", "color": "#FF0000"},
+                    {"name": "Work", "writable": True, "description": "", "color": "#FF0000", "source": "iCloud"},
                     {"name": "Missing", "writable": True, "description": "", "color": "#00FF00"},
                 ])
             # Work returns events, Missing raises ValueError

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -58,8 +58,8 @@ class TestGetCalendarsTool:
     def test_returns_formatted_calendar_list(self, mock_get_client):
         mock_client = MagicMock()
         mock_client.get_calendars.return_value = [
-            {"name": "Personal", "writable": True, "description": "", "color": "#0072FF"},
-            {"name": "Work", "writable": True, "description": "", "color": "#FF0023"},
+            {"name": "Personal", "writable": True, "description": "", "color": "#0072FF", "source": "iCloud"},
+            {"name": "Work", "writable": True, "description": "", "color": "#FF0023", "source": "Google"},
         ]
         mock_get_client.return_value = mock_client
 
@@ -74,7 +74,7 @@ class TestGetCalendarsTool:
     def test_returns_string(self, mock_get_client):
         mock_client = MagicMock()
         mock_client.get_calendars.return_value = [
-            {"name": "Test", "writable": True, "description": "", "color": "#000000"},
+            {"name": "Test", "writable": True, "description": "", "color": "#000000", "source": "iCloud"},
         ]
         mock_get_client.return_value = mock_client
 
@@ -639,15 +639,17 @@ class TestFormatCalendarDescription:
 
     def test_calendar_with_description(self):
         from apple_calendar_mcp.server_fastmcp import _format_calendar
-        cal = {"name": "Work", "writable": True, "description": "My work calendar", "color": "#FF0000"}
+        cal = {"name": "Work", "writable": True, "description": "My work calendar", "color": "#FF0000", "source": "iCloud"}
         result = _format_calendar(cal)
         assert "Description: My work calendar" in result
+        assert "Source: iCloud" in result
 
     def test_calendar_without_description(self):
         from apple_calendar_mcp.server_fastmcp import _format_calendar
-        cal = {"name": "Work", "writable": True, "description": "", "color": "#FF0000"}
+        cal = {"name": "Work", "writable": True, "description": "", "color": "#FF0000", "source": "Google"}
         result = _format_calendar(cal)
         assert "Description" not in result
+        assert "Source: Google" in result
 
 
 class TestFormatEventDetails:


### PR DESCRIPTION
## Summary
- Adds `source` field to `get_calendars` output using public API `EKCalendar.source.title`
- Returns account name like "iCloud", "Google", "Exchange" for each calendar
- Helps disambiguate duplicate calendar names (4/5 models failed this in blind evals)
- Updated server instructions, docstrings, tool_descriptions.md, and all test mocks

## Test plan
- [x] `make test-unit` — 215 passed
- [ ] `make test-integration` — verify source field present in real calendar data

Closes #141

🤖 Generated with [Claude Code](https://claude.com/claude-code)