### PR TITLE
Make all-day event end_date inclusive (#142)

### DIFF
--- a/evals/agent_tool_usability/tool_descriptions.md
+++ b/evals/agent_tool_usability/tool_descriptions.md
@@ -70,7 +70,7 @@ Create a new event in a specified calendar.
 - `location` (str, optional, default: ""): Event location
 - `notes` (str, optional, default: ""): Event notes
 - `url` (str, optional, default: ""): URL associated with the event
-- `allday_event` (bool, optional, default: false): Whether this is an all-day event. When true, use date-only format for start_date/end_date.
+- `allday_event` (bool, optional, default: false): Whether this is an all-day event. When true, use date-only format for start_date/end_date. For a single-day event, end_date equals start_date. For multi-day events, end_date is the last day (inclusive).
 - `recurrence_rule` (str, optional, default: ""): iCalendar RRULE string for recurring events (e.g., "FREQ=WEEKLY;BYDAY=MO,WE,FR" or "FREQ=DAILY;COUNT=10")
 - `alert_minutes` (str, optional, default: ""): Comma-separated minutes before event to alert (e.g., "15" or "15,60")
 - `availability` (str, optional, default: ""): Event availability status: "free", "busy", or "tentative" (default: busy)
@@ -88,7 +88,7 @@ More efficient than calling create_event multiple times — all events are creat
 
 **Parameters:**
 - `calendar_name` (str, required): Exact name of the target calendar
-- `events` (str, required): JSON array of event objects. Each object has keys: summary (required), start (required, ISO 8601), end (required, ISO 8601), and optional: location, notes, url, allday (bool), recurrence (RRULE string), alerts (list of minutes, e.g. [15, 60]), availability ("free"/"busy"/"tentative"), timezone (IANA identifier, e.g. "America/Los_Angeles")
+- `events` (str, required): JSON array of event objects. Each object has keys: summary (required), start (required, ISO 8601), end (required, ISO 8601), and optional: location, notes, url, allday (bool — when true, end is the last day inclusive), recurrence (RRULE string), alerts (list of minutes, e.g. [15, 60]), availability ("free"/"busy"/"tentative"), timezone (IANA identifier, e.g. "America/Los_Angeles")
 
 **Returns:** Summary of created events, each with title and UID. Any per-event errors are listed separately. Partial success is possible — some events may be created while others fail.
 
@@ -113,7 +113,7 @@ For recurring events: use occurrence_date to target a specific occurrence, and s
 - `location` (str | None, optional, default: None): New location, or "" to clear
 - `notes` (str | None, optional, default: None): New notes, or "" to clear
 - `url` (str | None, optional, default: None): New URL, or "" to clear
-- `allday_event` (bool | None, optional, default: None): New all-day status
+- `allday_event` (bool | None, optional, default: None): New all-day status. When true, end_date is the last day (inclusive).
 - `alert_minutes` (str, optional, default: ""): Comma-separated minutes before event to alert (e.g., "15,60"), or "none" to clear all alerts
 - `availability` (str | None, optional, default: None): Event availability: "free", "busy", or "tentative"
 - `timezone` (str, optional, default: ""): IANA timezone for interpreting start/end times (e.g., "America/Los_Angeles", "US/Eastern"). When provided, times are interpreted in that timezone instead of the system's local timezone.
@@ -133,7 +133,7 @@ More efficient than calling update_event multiple times. All events must be on t
 
 **Parameters:**
 - `calendar_name` (str, required): Exact name of the calendar containing the events
-- `updates` (str, required): JSON array of update objects. Each object must have "uid" (required) and at least one field to update: summary, start (ISO 8601), end (ISO 8601), location, notes, url, allday (bool), alerts (list of minutes), availability ("free"/"busy"/"tentative"), timezone (IANA identifier), recurrence (RRULE string), clear_location (bool), clear_notes (bool), clear_url (bool), clear_alerts (bool), clear_recurrence (bool)
+- `updates` (str, required): JSON array of update objects. Each object must have "uid" (required) and at least one field to update: summary, start (ISO 8601), end (ISO 8601), location, notes, url, allday (bool — when true, end is the last day inclusive), alerts (list of minutes), availability ("free"/"busy"/"tentative"), timezone (IANA identifier), recurrence (RRULE string), clear_location (bool), clear_notes (bool), clear_url (bool), clear_alerts (bool), clear_recurrence (bool)
 
 **Returns:** Summary of updated events, each with title and list of changed fields. Any per-event errors are listed separately. Partial success is possible.
 
@@ -150,7 +150,7 @@ Returns all events in the specified calendar that overlap with the given date ra
 - `start_date` (str, required): Start of date range in ISO 8601 format (e.g., "2026-03-15" or "2026-03-15T00:00:00")
 - `end_date` (str, required): End of date range in ISO 8601 format (must be after start_date)
 
-**Returns:** Each event includes: uid, summary, start_date, end_date, allday_event, location, notes, url, status, calendar_name, availability. For recurring events: is_recurring, recurrence_rule, occurrence_date, is_detached. If alerts are set: alerts (list with minutes_before for each). If attendees exist: attendees (list with name, email, role, status for each). `uid` and `calendar_name` identify the event for update_event and delete_events. For recurring events, also use `occurrence_date` to target a specific occurrence.
+**Returns:** Each event includes: uid, summary, start_date, end_date, allday_event, location, notes, url, status, calendar_name, availability. For all-day events, end_date is the last day of the event (inclusive). For recurring events: is_recurring, recurrence_rule, occurrence_date, is_detached. If alerts are set: alerts (list with minutes_before for each). If attendees exist: attendees (list with name, email, role, status for each). `uid` and `calendar_name` identify the event for update_event and delete_events. For recurring events, also use `occurrence_date` to target a specific occurrence.
 
 ---
 

--- a/src/apple_calendar_mcp/calendar_connector.py
+++ b/src/apple_calendar_mcp/calendar_connector.py
@@ -304,7 +304,11 @@ class CalendarConnector:
         self._validate_date(end_date)
 
         args = ["--calendar", calendar_name, "--start", start_date, "--end", end_date]
-        return self._run_swift_helper_json("get_events", args)
+        events = self._run_swift_helper_json("get_events", args)
+        for event in events:
+            if event.get("allday_event"):
+                event["end_date"] = self._allday_end_from_eventkit(event["end_date"])
+        return events
 
     def search_events(
         self,
@@ -347,6 +351,9 @@ class CalendarConnector:
             try:
                 events = self._run_swift_helper_json("get_events", args)
                 if isinstance(events, list):
+                    for event in events:
+                        if event.get("allday_event"):
+                            event["end_date"] = self._allday_end_from_eventkit(event["end_date"])
                     all_results.extend(events)
             except ValueError:
                 continue  # skip calendars that error (e.g., not found)
@@ -523,6 +530,16 @@ class CalendarConnector:
         parsed = self._run_swift_helper_json("delete_events", args)
         return {"deleted_uids": parsed["deleted_uids"], "not_found_uids": parsed["not_found_uids"]}
 
+    def _allday_end_from_eventkit(self, end_date: str) -> str:
+        """Extract date portion from EventKit all-day end_date.
+
+        EventKit returns all-day end dates as the last day at 23:59:59
+        (e.g., "2027-08-01T23:59:59" for a single-day event on Aug 1).
+        This extracts just the date portion for a clean inclusive end date.
+        """
+        dt = self._parse_iso_datetime(end_date)
+        return dt.strftime("%Y-%m-%d")
+
     def _parse_iso_datetime(self, date_str: str) -> datetime:
         """Parse an ISO 8601 date string to a naive local-time datetime.
 
@@ -557,8 +574,7 @@ class CalendarConnector:
             if event.get("allday_event"):
                 evt_start = evt_start.replace(hour=0, minute=0, second=0)
                 evt_end = evt_end.replace(hour=0, minute=0, second=0)
-                if evt_end == evt_start:
-                    evt_end += timedelta(days=1)
+                evt_end += timedelta(days=1)  # Convert inclusive to exclusive for calculations
 
             blocks.append((evt_start, evt_end))
 
@@ -774,8 +790,7 @@ class CalendarConnector:
             if event.get("allday_event"):
                 evt_start = evt_start.replace(hour=0, minute=0, second=0)
                 evt_end = evt_end.replace(hour=0, minute=0, second=0)
-                if evt_end == evt_start:
-                    evt_end += timedelta(days=1)
+                evt_end += timedelta(days=1)  # Convert inclusive to exclusive for calculations
             parsed.append((evt_start, evt_end, event))
         parsed.sort(key=lambda x: x[0])
 

--- a/src/apple_calendar_mcp/server_fastmcp.py
+++ b/src/apple_calendar_mcp/server_fastmcp.py
@@ -171,7 +171,7 @@ def create_event(
         location: Event location (optional)
         notes: Event notes (optional)
         url: URL associated with the event (optional)
-        allday_event: Whether this is an all-day event (default: false). When true, use date-only format for start_date/end_date.
+        allday_event: Whether this is an all-day event (default: false). When true, use date-only format for start_date/end_date. For a single-day event, end_date equals start_date. For multi-day events, end_date is the last day (inclusive).
         recurrence_rule: iCalendar RRULE string for recurring events (optional, e.g., "FREQ=WEEKLY;BYDAY=MO,WE,FR" or "FREQ=DAILY;COUNT=10")
         alert_minutes: Comma-separated minutes before event to alert (optional, e.g., "15" or "15,60")
         availability: Event availability status: "free", "busy", or "tentative" (optional, default: busy)
@@ -218,8 +218,9 @@ def create_events(
         calendar_name: Exact name of the target calendar
         events: JSON array of event objects. Each object has keys: summary (required),
                 start (required, ISO 8601), end (required, ISO 8601), and optional:
-                location, notes, url, allday (bool), recurrence (RRULE string),
-                alerts (list of minutes, e.g. [15, 60]), availability ("free"/"busy"/"tentative"),
+                location, notes, url, allday (bool — when true, end is the last day inclusive),
+                recurrence (RRULE string), alerts (list of minutes, e.g. [15, 60]),
+                availability ("free"/"busy"/"tentative"),
                 timezone (IANA identifier, e.g. "America/Los_Angeles")
 
     Returns:
@@ -270,10 +271,10 @@ def update_events(
         calendar_name: Exact name of the calendar containing the events
         updates: JSON array of update objects. Each object must have "uid" (required)
                  and at least one field to update: summary, start (ISO 8601), end (ISO 8601),
-                 location, notes, url, allday (bool), alerts (list of minutes),
-                 availability ("free"/"busy"/"tentative"), timezone (IANA identifier),
-                 recurrence (RRULE string), clear_location (bool), clear_notes (bool),
-                 clear_url (bool), clear_alerts (bool), clear_recurrence (bool)
+                 location, notes, url, allday (bool — when true, end is the last day inclusive),
+                 alerts (list of minutes), availability ("free"/"busy"/"tentative"),
+                 timezone (IANA identifier), recurrence (RRULE string), clear_location (bool),
+                 clear_notes (bool), clear_url (bool), clear_alerts (bool), clear_recurrence (bool)
 
     Returns:
         Summary of updated events, each with title and list of changed fields. Any per-event
@@ -385,6 +386,7 @@ def get_events(
     Returns:
         Each event includes: uid, summary, start_date, end_date, allday_event, location, notes,
         url, status, calendar_name, availability.
+        For all-day events, end_date is the last day of the event (inclusive).
         For recurring events: is_recurring, recurrence_rule, occurrence_date, is_detached.
         If alerts are set: alerts (list with minutes_before for each).
         If attendees exist: attendees (list with name, email, role, status for each).
@@ -617,7 +619,7 @@ def update_event(
         location: New location, or "" to clear (optional)
         notes: New notes, or "" to clear (optional)
         url: New URL, or "" to clear (optional)
-        allday_event: New all-day status (optional)
+        allday_event: New all-day status (optional). When true, end_date is the last day (inclusive).
         alert_minutes: Comma-separated minutes before event to alert (e.g., "15,60"), or "none" to clear all alerts (optional)
         availability: Event availability: "free", "busy", or "tentative" (optional)
         recurrence_rule: iCalendar RRULE string to set/change recurrence (e.g., "FREQ=WEEKLY;BYDAY=MO,WE,FR"), or "" to remove recurrence (optional)

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -188,7 +188,7 @@ end tell'''
             calendar_name=TEST_CALENDAR,
             summary="All Day Test",
             start_date="2026-06-15",
-            end_date="2026-06-16",
+            end_date="2026-06-15",
             allday_event=True,
         )
         try:
@@ -442,7 +442,7 @@ class TestUpdateEventIntegration:
             calendar_name=TEST_CALENDAR,
             summary="All Day Update Test",
             start_date="2027-09-15",
-            end_date="2027-09-16",
+            end_date="2027-09-15",
             allday_event=True,
             location="Conference Room",
             notes="Original notes",
@@ -1079,12 +1079,12 @@ class TestTimezoneIntegration:
             _delete_event_by_uid(uid)
 
     def test_allday_event_fields(self, connector):
-        """All-day event should return allday_event=True with correct date boundaries."""
+        """All-day event should return allday_event=True with inclusive end_date."""
         uid = connector.create_event(
             calendar_name=TEST_CALENDAR,
             summary="All Day Test",
             start_date="2027-08-01",
-            end_date="2027-08-02",
+            end_date="2027-08-01",
             allday_event=True,
         )
         try:
@@ -1092,6 +1092,7 @@ class TestTimezoneIntegration:
             matches = [e for e in events if e["uid"] == uid]
             assert len(matches) == 1
             assert matches[0]["allday_event"] is True
+            assert "2027-08-01" in matches[0]["end_date"]
         finally:
             _delete_event_by_uid(uid)
 

--- a/tests/unit/test_calendar_connector.py
+++ b/tests/unit/test_calendar_connector.py
@@ -377,11 +377,14 @@ class TestCreateEvent:
             calendar_name="MCP-Test-Calendar",
             summary="Holiday",
             start_date="2026-03-15",
-            end_date="2026-03-16",
+            end_date="2026-03-15",
             allday_event=True,
         )
         args = mock_swift.call_args[0][1]
         assert "--allday" in args
+        # end_date passed through as-is — EventKit handles all-day boundaries internally
+        end_idx = args.index("--end") + 1
+        assert args[end_idx] == "2026-03-15"
 
     def test_invalid_start_date_raises_error(self):
         with pytest.raises(ValueError, match="Invalid date format"):
@@ -662,6 +665,7 @@ class TestGetAvailability:
 
     @patch("apple_calendar_mcp.calendar_connector.run_swift_helper")
     def test_allday_event_blocks_full_day(self, mock_swift):
+        # Swift returns exclusive end_date; get_events converts to inclusive
         mock_swift.return_value = json.dumps([
             self._make_event("2026-03-15", "2026-03-16", allday=True),
         ])
@@ -1381,3 +1385,41 @@ class TestSearchEvents:
         mock_swift.side_effect = side_effect
         results = self.connector.search_events("found", start_date="2026-03-01", end_date="2026-04-01")
         assert len(results) == 1
+
+
+# ── all-day inclusive end_date helpers ─────────────────────────────────────
+
+
+class TestAlldayEndDateConversion:
+    """Tests for all-day event inclusive end_date conversion."""
+
+    def setup_method(self):
+        self.connector = CalendarConnector(enable_safety_checks=False)
+
+    def test_allday_end_from_eventkit_extracts_date(self):
+        """EventKit all-day end_date (with time) should be stripped to date-only."""
+        assert self.connector._allday_end_from_eventkit("2026-03-15T23:59:59") == "2026-03-15"
+        assert self.connector._allday_end_from_eventkit("2026-12-31T23:59:59") == "2026-12-31"
+
+    def test_allday_end_from_eventkit_date_only(self):
+        """Date-only input should pass through unchanged."""
+        assert self.connector._allday_end_from_eventkit("2026-03-15") == "2026-03-15"
+
+    @patch("apple_calendar_mcp.calendar_connector.run_swift_helper")
+    def test_get_events_adjusts_allday_end_date(self, mock_swift):
+        """get_events should extract date portion of all-day end_date from EventKit."""
+        mock_swift.return_value = json.dumps([
+            {"uid": "AD-1", "summary": "Holiday", "start_date": "2026-03-15T00:00:00",
+             "end_date": "2026-03-15T23:59:59", "allday_event": True, "location": "",
+             "notes": "", "url": "", "status": "confirmed", "calendar_name": "Work"},
+            {"uid": "TM-1", "summary": "Meeting", "start_date": "2026-03-15T10:00:00",
+             "end_date": "2026-03-15T11:00:00", "allday_event": False, "location": "",
+             "notes": "", "url": "", "status": "confirmed", "calendar_name": "Work"},
+        ])
+        result = self.connector.get_events("Work", "2026-03-15", "2026-03-17")
+        # All-day event end_date should be date-only (inclusive)
+        assert result[0]["end_date"] == "2026-03-15"
+        # Timed event end_date should be unchanged
+        assert result[1]["end_date"] == "2026-03-15T11:00:00"
+        # Timed event end_date should not be changed
+        assert result[1]["end_date"] == "2026-03-15T11:00:00"


### PR DESCRIPTION
## Summary

All-day events now use intuitive inclusive end dates. A single-day event on March 15 has `end_date="2026-03-15"` (was `"2026-03-16"`).

**Key discovery:** EventKit returns all-day end dates as the last day at 23:59:59 (e.g., `2027-08-01T23:59:59` for a single-day Aug 1 event). The read path extracts the date portion. No write-path adjustment needed — EventKit handles all-day boundaries internally.

- Updated docstrings across all event tools
- Updated tool_descriptions.md
- Internal calculations (availability, conflicts) adjusted for inclusive dates
- 218 unit tests passing, 53/57 integration tests passing (4 pre-existing flaky calendar setup failures)

## Test plan
- [x] `make test-unit` — 218 passed
- [x] `make test-integration` — all-day tests pass (53/57, 4 failures are pre-existing)
- [x] Manual debug: verified raw EventKit output for single-day and multi-day all-day events

Closes #142

🤖 Generated with [Claude Code](https://claude.com/claude-code)