### PR TITLE
Migrate calendar create/delete to Swift/EventKit (#153)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -62,7 +62,7 @@ All event operations use Swift/EventKit via `swift` subprocess for native perfor
 
 - **Reads** (get_events, get_calendars, get_availability): EventKit predicate queries, sub-second
 - **Writes** (create_event, update_event, delete_events): EventKit save/remove with batch commit
-- **Calendar management** (create_calendar, delete_calendar): AppleScript (simple, fast enough)
+- **Calendar management** (create_calendar, delete_calendar): EventKit via Swift helper
 
 Swift helpers at `src/apple_calendar_mcp/swift/` use `EKEventStore`. First run triggers a macOS calendar access permission dialog. Scripts are interpreted by `swift` (cached after first compilation).
 

--- a/src/apple_calendar_mcp/calendar_connector.py
+++ b/src/apple_calendar_mcp/calendar_connector.py
@@ -106,14 +106,6 @@ class CalendarConnector:
                 f"Allowed: {self.ALLOWED_TEST_CALENDARS}"
             )
 
-    def _escape_applescript_string(self, text: Optional[str]) -> str:
-        """Escape quotes and backslashes for AppleScript strings."""
-        if not text:
-            return ""
-        text = text.replace("\\", "\\\\")
-        text = text.replace('"', '\\"')
-        return text
-
     def _run_swift_helper_json(
         self, script_name: str, args: list[str], stdin_data: Optional[str] = None
     ) -> dict:
@@ -782,23 +774,24 @@ class CalendarConnector:
     def create_calendar(self, name: str) -> dict[str, str]:
         """Create a new calendar in Apple Calendar.
 
+        Uses EventKit via Swift helper for native calendar creation.
+
         Args:
             name: Name for the new calendar
 
         Returns:
-            Dict with 'name' key of the created calendar
+            Dict with 'name' and optionally 'source' keys of the created calendar
 
         Raises:
-            subprocess.CalledProcessError: If AppleScript execution fails
+            RuntimeError: If Swift helper execution fails
+            PermissionError: If EventKit calendar access is denied
         """
-        escaped = self._escape_applescript_string(name)
-        run_applescript(
-            f'tell application "Calendar" to make new calendar with properties {{name:"{escaped}"}}'
-        )
-        return {"name": name}
+        return self._run_swift_helper_json("create_calendar", ["--name", name])
 
     def delete_calendar(self, name: str) -> dict[str, str]:
         """Delete a calendar from Apple Calendar.
+
+        Uses EventKit via Swift helper for native calendar deletion.
 
         Args:
             name: Name of the calendar to delete
@@ -809,12 +802,7 @@ class CalendarConnector:
         Raises:
             CalendarSafetyError: If safety checks block the target calendar
             ValueError: If the calendar doesn't exist
-            subprocess.CalledProcessError: If AppleScript execution fails
+            PermissionError: If EventKit calendar access is denied
         """
         self._verify_calendar_safety(name)
-        escaped = self._escape_applescript_string(name)
-        try:
-            run_applescript(f'tell application "Calendar" to delete calendar "{escaped}"')
-        except subprocess.CalledProcessError as e:
-            raise ValueError(f"Calendar '{name}' not found or could not be deleted") from e
-        return {"name": name}
+        return self._run_swift_helper_json("delete_calendar", ["--name", name])

--- a/src/apple_calendar_mcp/swift/create_calendar.swift
+++ b/src/apple_calendar_mcp/swift/create_calendar.swift
@@ -1,0 +1,125 @@
+import EventKit
+import Foundation
+
+// MARK: - JSON Output
+
+func outputError(_ error: String, _ message: String) {
+    let obj: [String: String] = ["error": error, "message": message]
+    if let data = try? JSONSerialization.data(withJSONObject: obj),
+       let str = String(data: data, encoding: .utf8) {
+        print(str)
+    }
+}
+
+// MARK: - Argument Parsing
+
+struct CreateCalendarArgs {
+    var name: String = ""
+    var source: String = ""  // optional: source/account name
+}
+
+func parseArgs() -> CreateCalendarArgs {
+    var result = CreateCalendarArgs()
+    let args = CommandLine.arguments
+    var i = 1
+    while i < args.count {
+        switch args[i] {
+        case "--name":
+            i += 1; if i < args.count { result.name = args[i] }
+        case "--source":
+            i += 1; if i < args.count { result.source = args[i] }
+        default:
+            break
+        }
+        i += 1
+    }
+    return result
+}
+
+// MARK: - Main
+
+let parsed = parseArgs()
+
+guard !parsed.name.isEmpty else {
+    outputError("invalid_args", "Required: --name <calendar_name>")
+    exit(1)
+}
+
+let store = EKEventStore()
+let semaphore = DispatchSemaphore(value: 0)
+var accessGranted = false
+var accessError: Error?
+
+store.requestFullAccessToEvents { granted, error in
+    accessGranted = granted
+    accessError = error
+    semaphore.signal()
+}
+
+semaphore.wait()
+
+if !accessGranted {
+    let msg = accessError?.localizedDescription ?? "Calendar access denied."
+    outputError("calendar_access_denied", msg)
+    exit(1)
+}
+
+store.refreshSourcesIfNecessary()
+
+// Build list of sources to try
+var sourcesToTry: [EKSource] = []
+
+if !parsed.source.isEmpty {
+    // User specified a source — try only that one
+    guard let source = store.sources.first(where: { $0.title == parsed.source }) else {
+        let available = store.sources.map { "\($0.title) (\($0.sourceType.rawValue))" }.joined(separator: ", ")
+        outputError("source_not_found", "Source '\(parsed.source)' not found. Available: \(available)")
+        exit(1)
+    }
+    sourcesToTry = [source]
+} else {
+    // Auto-select: prefer local, then iCloud, then other CalDAV, then any
+    if let local = store.sources.first(where: { $0.sourceType == .local }) {
+        sourcesToTry.append(local)
+    }
+    if let icloud = store.sources.first(where: { $0.title == "iCloud" && $0.sourceType == .calDAV }) {
+        sourcesToTry.append(icloud)
+    }
+    sourcesToTry += store.sources.filter { $0.sourceType == .calDAV && !sourcesToTry.contains($0) }
+    sourcesToTry += store.sources.filter { !sourcesToTry.contains($0) }
+}
+
+// Try each source until one works
+var savedCalendar: EKCalendar?
+var lastError: Error?
+
+for source in sourcesToTry {
+    let calendar = EKCalendar(for: .event, eventStore: store)
+    calendar.title = parsed.name
+    calendar.source = source
+    do {
+        try store.saveCalendar(calendar, commit: true)
+        savedCalendar = calendar
+        break
+    } catch {
+        lastError = error
+        continue
+    }
+}
+
+guard let calendar = savedCalendar else {
+    let msg = lastError?.localizedDescription ?? "No writable calendar source available."
+    outputError("save_failed", "Failed to create calendar: \(msg)")
+    exit(1)
+}
+
+// Output result
+let result: [String: Any] = [
+    "name": calendar.title,
+    "source": calendar.source.title,
+]
+
+if let data = try? JSONSerialization.data(withJSONObject: result, options: [.sortedKeys]),
+   let str = String(data: data, encoding: .utf8) {
+    print(str)
+}

--- a/src/apple_calendar_mcp/swift/delete_calendar.swift
+++ b/src/apple_calendar_mcp/swift/delete_calendar.swift
@@ -1,0 +1,88 @@
+import EventKit
+import Foundation
+
+// MARK: - JSON Output
+
+func outputError(_ error: String, _ message: String) {
+    let obj: [String: String] = ["error": error, "message": message]
+    if let data = try? JSONSerialization.data(withJSONObject: obj),
+       let str = String(data: data, encoding: .utf8) {
+        print(str)
+    }
+}
+
+// MARK: - Argument Parsing
+
+struct DeleteCalendarArgs {
+    var name: String = ""
+}
+
+func parseArgs() -> DeleteCalendarArgs {
+    var result = DeleteCalendarArgs()
+    let args = CommandLine.arguments
+    var i = 1
+    while i < args.count {
+        switch args[i] {
+        case "--name":
+            i += 1; if i < args.count { result.name = args[i] }
+        default:
+            break
+        }
+        i += 1
+    }
+    return result
+}
+
+// MARK: - Main
+
+let parsed = parseArgs()
+
+guard !parsed.name.isEmpty else {
+    outputError("invalid_args", "Required: --name <calendar_name>")
+    exit(1)
+}
+
+let store = EKEventStore()
+let semaphore = DispatchSemaphore(value: 0)
+var accessGranted = false
+var accessError: Error?
+
+store.requestFullAccessToEvents { granted, error in
+    accessGranted = granted
+    accessError = error
+    semaphore.signal()
+}
+
+semaphore.wait()
+
+if !accessGranted {
+    let msg = accessError?.localizedDescription ?? "Calendar access denied."
+    outputError("calendar_access_denied", msg)
+    exit(1)
+}
+
+store.refreshSourcesIfNecessary()
+
+// Find the calendar by name
+let calendars = store.calendars(for: .event).filter { $0.title == parsed.name }
+
+guard let calendar = calendars.first else {
+    let available = store.calendars(for: .event).map { $0.title }.joined(separator: ", ")
+    outputError("calendar_not_found", "Calendar '\(parsed.name)' not found. Available: \(available)")
+    exit(1)
+}
+
+do {
+    try store.removeCalendar(calendar, commit: true)
+} catch {
+    outputError("delete_failed", "Failed to delete calendar: \(error.localizedDescription)")
+    exit(1)
+}
+
+// Output result
+let result: [String: String] = ["name": parsed.name]
+
+if let data = try? JSONSerialization.data(withJSONObject: result, options: [.sortedKeys]),
+   let str = String(data: data, encoding: .utf8) {
+    print(str)
+}

--- a/tests/helpers/calendar_setup.py
+++ b/tests/helpers/calendar_setup.py
@@ -3,27 +3,34 @@
 Reusable from pytest fixtures, standalone scripts, or CI.
 """
 
-from apple_calendar_mcp.calendar_connector import run_applescript
+import json
+import os
+
+from apple_calendar_mcp.calendar_connector import run_applescript, run_swift_helper
 
 DEFAULT_CALENDAR_NAME = "MCP-Test-Calendar"
+DEFAULT_CALENDAR_SOURCE = os.environ.get("CALENDAR_TEST_SOURCE", "iCloud")
 
 
 def calendar_exists(name: str = DEFAULT_CALENDAR_NAME) -> bool:
     """Check if a calendar with the given name exists in Calendar.app."""
-    names = run_applescript('tell application "Calendar" to name of every calendar')
-    return name in [n.strip() for n in names.split(",")]
+    result = run_swift_helper("get_calendars", [])
+    calendars = json.loads(result)
+    return any(c["name"] == name for c in calendars)
 
 
 def create_test_calendar(name: str = DEFAULT_CALENDAR_NAME) -> bool:
     """Create the test calendar if it doesn't already exist.
 
+    Uses CALENDAR_TEST_SOURCE env var for the source (default: iCloud).
     Returns True if the calendar was created, False if it already existed.
     """
     if calendar_exists(name):
         return False
-    run_applescript(
-        f'tell application "Calendar" to make new calendar with properties {{name:"{name}"}}'
-    )
+    args = ["--name", name]
+    if DEFAULT_CALENDAR_SOURCE:
+        args += ["--source", DEFAULT_CALENDAR_SOURCE]
+    run_swift_helper("create_calendar", args)
     return True
 
 
@@ -34,7 +41,7 @@ def delete_test_calendar(name: str = DEFAULT_CALENDAR_NAME) -> bool:
     """
     if not calendar_exists(name):
         return False
-    run_applescript(f'tell application "Calendar" to delete calendar "{name}"')
+    run_swift_helper("delete_calendar", ["--name", name])
     return True
 
 

--- a/tests/unit/test_calendar_connector.py
+++ b/tests/unit/test_calendar_connector.py
@@ -125,32 +125,6 @@ class TestRunSwiftHelper:
 # ── _escape_applescript_string ───────────────────────────────────────────────
 
 
-class TestEscapeApplescriptString:
-    """Tests for string escaping before embedding in AppleScript."""
-
-    def setup_method(self):
-        self.connector = CalendarConnector()
-
-    def test_escapes_double_quotes(self):
-        assert self.connector._escape_applescript_string('say "hello"') == 'say \\"hello\\"'
-
-    def test_escapes_backslashes(self):
-        assert self.connector._escape_applescript_string("path\\to\\file") == "path\\\\to\\\\file"
-
-    def test_escapes_both(self):
-        result = self.connector._escape_applescript_string('a\\b"c')
-        assert result == 'a\\\\b\\"c'
-
-    def test_empty_string(self):
-        assert self.connector._escape_applescript_string("") == ""
-
-    def test_none_returns_empty(self):
-        assert self.connector._escape_applescript_string(None) == ""
-
-    def test_no_special_chars(self):
-        assert self.connector._escape_applescript_string("plain text") == "plain text"
-
-
 # ── _iso_to_applescript_date ─────────────────────────────────────────────────
 
 
@@ -278,21 +252,20 @@ class TestCreateCalendar:
     def setup_method(self):
         self.connector = CalendarConnector(enable_safety_checks=False)
 
-    @patch("apple_calendar_mcp.calendar_connector.run_applescript")
-    def test_creates_calendar(self, mock_run):
-        mock_run.return_value = "calendar id ABC-123"
+    @patch("apple_calendar_mcp.calendar_connector.run_swift_helper")
+    def test_creates_calendar(self, mock_swift):
+        mock_swift.return_value = json.dumps({"name": "New Calendar"})
         result = self.connector.create_calendar("New Calendar")
         assert result == {"name": "New Calendar"}
-        script = mock_run.call_args[0][0]
-        assert 'make new calendar' in script
-        assert 'name:"New Calendar"' in script
+        mock_swift.assert_called_once_with(
+            "create_calendar", ["--name", "New Calendar"], stdin_data=None
+        )
 
-    @patch("apple_calendar_mcp.calendar_connector.run_applescript")
-    def test_escapes_special_characters(self, mock_run):
-        mock_run.return_value = "calendar id ABC-123"
-        self.connector.create_calendar('Cal with "quotes"')
-        script = mock_run.call_args[0][0]
-        assert 'Cal with \\"quotes\\"' in script
+    @patch("apple_calendar_mcp.calendar_connector.run_swift_helper")
+    def test_returns_source_when_present(self, mock_swift):
+        mock_swift.return_value = json.dumps({"name": "New Calendar", "source": "iCloud"})
+        result = self.connector.create_calendar("New Calendar")
+        assert result == {"name": "New Calendar", "source": "iCloud"}
 
 
 # ── delete_calendar ─────────────────────────────────────────────────────────
@@ -304,18 +277,21 @@ class TestDeleteCalendar:
     def setup_method(self):
         self.connector = CalendarConnector(enable_safety_checks=False)
 
-    @patch("apple_calendar_mcp.calendar_connector.run_applescript")
-    def test_deletes_calendar(self, mock_run):
-        mock_run.return_value = ""
+    @patch("apple_calendar_mcp.calendar_connector.run_swift_helper")
+    def test_deletes_calendar(self, mock_swift):
+        mock_swift.return_value = json.dumps({"name": "Old Calendar"})
         result = self.connector.delete_calendar("Old Calendar")
         assert result == {"name": "Old Calendar"}
-        script = mock_run.call_args[0][0]
-        assert 'delete calendar "Old Calendar"' in script
+        mock_swift.assert_called_once_with(
+            "delete_calendar", ["--name", "Old Calendar"], stdin_data=None
+        )
 
-    @patch("apple_calendar_mcp.calendar_connector.run_applescript")
-    def test_not_found_raises_error(self, mock_run):
-        mock_run.side_effect = subprocess.CalledProcessError(
-            returncode=1, cmd="osascript", stderr="Calendar not found"
+    @patch("apple_calendar_mcp.calendar_connector.run_swift_helper")
+    def test_not_found_raises_error(self, mock_swift):
+        mock_swift.side_effect = subprocess.CalledProcessError(
+            returncode=1, cmd="swift",
+            output='{"error": "calendar_not_found", "message": "Calendar \'Nonexistent\' not found"}',
+            stderr=""
         )
         with pytest.raises(ValueError, match="not found"):
             self.connector.delete_calendar("Nonexistent")


### PR DESCRIPTION
## Summary

Fixes the test calendar infrastructure by migrating `create_calendar` and `delete_calendar` from AppleScript to Swift/EventKit with explicit source assignment.

**Root cause:** AppleScript's `make new calendar` doesn't specify which account/source to use. Without a local calendar source, calendars get created on cloud accounts that sync them away.

**Fix:** New Swift helpers (`create_calendar.swift`, `delete_calendar.swift`) use EventKit's `EKCalendar` with explicit `source` assignment. Auto-select prefers local → iCloud → other CalDAV sources, trying each until one accepts.

- Removed `_escape_applescript_string` (no longer needed)
- Test helpers now use `CALENDAR_TEST_SOURCE` env var (default: iCloud)
- Architecture fully migrated: all operations now use Swift/EventKit

## Test plan
- [x] `make test-unit` — 199 passed
- [x] `make test-integration` — **58 passed, 0 failed** (was 6/58 before this fix)

Closes #153

🤖 Generated with [Claude Code](https://claude.com/claude-code)