### PR TITLE
Expose organizer details and timestamps in get_events (#163, #164)

### DIFF
--- a/evals/agent_tool_usability/tool_descriptions.md
+++ b/evals/agent_tool_usability/tool_descriptions.md
@@ -101,7 +101,7 @@ Returns all events in the specified calendar that overlap with the given date ra
 - `start_date` (str, required): Start of date range in ISO 8601 format (e.g., "2026-03-15" or "2026-03-15T00:00:00")
 - `end_date` (str, required): End of date range in ISO 8601 format (exclusive — to include March 29, use "2026-03-30")
 
-**Returns:** Each event includes: uid, summary, start_date, end_date, allday_event, location, notes, url, status, calendar_name, availability. For all-day events, end_date is the last day of the event (inclusive). For recurring events: is_recurring, recurrence_rule, occurrence_date, is_detached. If alerts are set: alerts (list with minutes_before for each). If attendees exist: attendees (list with name, email, role, status for each). `uid` and `calendar_name` identify the event for update_events and delete_events. For recurring events, also use `occurrence_date` to target a specific occurrence.
+**Returns:** Each event includes: uid, summary, start_date, end_date, allday_event, location, notes, url, status, calendar_name, availability, created_date, modified_date. For all-day events, end_date is the last day of the event (inclusive). For recurring events: is_recurring, recurrence_rule, occurrence_date, is_detached. If alerts are set: alerts (list with minutes_before for each). If attendees exist: attendees (list with name, email, role, status for each). If organized by someone else: organizer_name, organizer_email, organizer_status. `uid` and `calendar_name` identify the event for update_events and delete_events. For recurring events, also use `occurrence_date` to target a specific occurrence.
 
 ---
 

--- a/src/apple_calendar_mcp/server_fastmcp.py
+++ b/src/apple_calendar_mcp/server_fastmcp.py
@@ -309,11 +309,12 @@ def get_events(
 
     Returns:
         Each event includes: uid, summary, start_date, end_date, allday_event, location, notes,
-        url, status, calendar_name, availability.
+        url, status, calendar_name, availability, created_date, modified_date.
         For all-day events, end_date is the last day of the event (inclusive).
         For recurring events: is_recurring, recurrence_rule, occurrence_date, is_detached.
         If alerts are set: alerts (list with minutes_before for each).
         If attendees exist: attendees (list with name, email, role, status for each).
+        If organized by someone else: organizer_name, organizer_email, organizer_status.
         `uid` and `calendar_name` identify the event for update_events and delete_events.
         For recurring events, also use `occurrence_date` to target a specific occurrence.
     """

--- a/src/apple_calendar_mcp/swift/get_events.swift
+++ b/src/apple_calendar_mcp/swift/get_events.swift
@@ -142,6 +142,21 @@ func eventToDict(_ event: EKEvent) -> [String: Any] {
     // Availability
     dict["availability"] = availabilityString(event.availability)
 
+    // Organizer details
+    if let organizer = event.organizer {
+        dict["organizer_name"] = organizer.name ?? ""
+        dict["organizer_email"] = organizer.url.absoluteString.replacingOccurrences(of: "mailto:", with: "")
+        dict["organizer_status"] = participantStatusString(organizer.participantStatus)
+    }
+
+    // Timestamps
+    if let created = event.creationDate {
+        dict["created_date"] = df.string(from: created)
+    }
+    if let modified = event.lastModifiedDate {
+        dict["modified_date"] = df.string(from: modified)
+    }
+
     return dict
 }
 


### PR DESCRIPTION
## Summary
- **Organizer details:** `organizer_name`, `organizer_email`, `organizer_status` — present when event has an external organizer
- **Timestamps:** `created_date`, `modified_date` — present when EventKit provides them

All new fields are optional (only included when data exists). No breaking changes.

## Test plan
- [x] `make test-unit` — 171 passed
- [ ] `make test-integration` — verify new fields present in real event data

Closes #163
Closes #164

🤖 Generated with [Claude Code](https://claude.com/claude-code)