### PR TITLE
Add calendar_name to event output for search chaining (#171)

### DIFF
--- a/src/apple_calendar_mcp/server_fastmcp.py
+++ b/src/apple_calendar_mcp/server_fastmcp.py
@@ -282,6 +282,7 @@ def _format_event(event: dict) -> str:
     """Format an event dict as human-readable text."""
     lines = [
         f"Title: {event['summary']}",
+        f"Calendar: {event['calendar_name']}",
         f"Start: {event['start_date']}",
         f"End: {event['end_date']}",
         *_format_event_details(event),


### PR DESCRIPTION
## Summary

Adds `Calendar:` line to formatted event output so search_events results show which calendar each event belongs to. Enables direct search → update/delete without extra round-trips.

## Test plan
- [x] `make test-unit` — 171 passed

Closes #171

🤖 Generated with [Claude Code](https://claude.com/claude-code)