### PR TITLE
Expose default calendar and make calendar_name optional (#165)

### DIFF
--- a/evals/agent_tool_usability/tool_descriptions.md
+++ b/evals/agent_tool_usability/tool_descriptions.md
@@ -28,7 +28,7 @@ Returns all calendars with their names, access level (read-write or read-only), 
 
 Note: Calendar names may not be unique across accounts. Use the source field (e.g., "iCloud", "Google") to distinguish calendars with the same name from different accounts.
 
-**Returns:** Each calendar includes: name, access level (read-write or read-only), source (account name like "iCloud" or "Google"), description, color. Use calendar names exactly as shown when calling other tools.
+**Returns:** Each calendar includes: name, access level (read-write or read-only), source (account name like "iCloud" or "Google"), description, color, is_default (boolean). The default calendar is used when create_events is called without a calendar_name. Use calendar names exactly as shown when calling other tools.
 
 **Parameters:** None
 
@@ -65,7 +65,7 @@ Create one or more events in a calendar.
 For a single event, pass an array with one element. All events go to the same calendar.
 
 **Parameters:**
-- `calendar_name` (str, required): Exact name of the target calendar
+- `calendar_name` (str, optional, default: ""): Name of the target calendar. If omitted, uses the system default calendar.
 - `events` (str, required): JSON array of event objects. Each object has keys: summary (required), start (required, ISO 8601), end (required, ISO 8601), and optional: location, notes, url, allday (bool), recurrence (RRULE string), alerts (list of minutes, e.g. [15, 60]), availability ("free"/"busy"/"tentative"), timezone (IANA identifier, e.g. "America/Los_Angeles" — use to schedule in a remote timezone rather than converting times manually). For all-day events, set allday=true and use date-only format. end is inclusive for all-day events.
 
 **Returns:** Each created event with title and UID. Use these UIDs with update_events or delete_events. Any per-event errors are listed separately. Partial success is possible — some events may be created while others fail.

--- a/src/apple_calendar_mcp/calendar_connector.py
+++ b/src/apple_calendar_mcp/calendar_connector.py
@@ -130,13 +130,14 @@ class CalendarConnector:
 
     def create_events(
         self,
-        calendar_name: str,
-        events: list[dict[str, Any]],
+        calendar_name: str = "",
+        events: list[dict[str, Any]] | None = None,
     ) -> dict[str, Any]:
-        """Create multiple events in a single batch operation.
+        """Create one or more events in a calendar.
 
         Args:
-            calendar_name: Name of the target calendar (all events go to same calendar)
+            calendar_name: Name of the target calendar. If empty, uses the system
+                          default calendar.
             events: List of event dicts, each with keys: summary, start, end,
                     and optional: location, notes, url, allday, recurrence,
                     alerts (list of int), availability, timezone
@@ -144,7 +145,8 @@ class CalendarConnector:
         Returns:
             Dict with 'created' (list of {uid, summary}) and 'errors' (list of {index, summary, error})
         """
-        self._verify_calendar_safety(calendar_name)
+        if calendar_name:
+            self._verify_calendar_safety(calendar_name)
 
         if not events:
             raise ValueError("At least one event must be provided")

--- a/src/apple_calendar_mcp/server_fastmcp.py
+++ b/src/apple_calendar_mcp/server_fastmcp.py
@@ -65,7 +65,8 @@ def get_calendars() -> str:
 
     Returns:
         Each calendar includes: name, access level (read-write or read-only), source
-        (account name like "iCloud" or "Google"), description, color.
+        (account name like "iCloud" or "Google"), description, color, is_default (boolean).
+        The default calendar is used when create_events is called without a calendar_name.
         Use calendar names exactly as shown when calling other tools.
     """
     client = get_client()
@@ -121,8 +122,8 @@ def delete_calendar(name: str) -> str:
 
 @mcp.tool()
 def create_events(
-    calendar_name: str,
-    events: str,
+    calendar_name: str = "",
+    events: str = "",
 ) -> str:
     """Create one or more events in a calendar.
 
@@ -130,7 +131,7 @@ def create_events(
     the same calendar.
 
     Args:
-        calendar_name: Exact name of the target calendar
+        calendar_name: Name of the target calendar. If omitted, uses the system default calendar.
         events: JSON array of event objects. Each object has keys: summary (required),
                 start (required, ISO 8601), end (required, ISO 8601), and optional:
                 location, notes, url, allday (bool), recurrence (RRULE string),

--- a/src/apple_calendar_mcp/swift/create_events.swift
+++ b/src/apple_calendar_mcp/swift/create_events.swift
@@ -110,10 +110,7 @@ func outputError(_ error: String, _ message: String) {
 
 // MARK: - Main
 
-guard let calendarName = parseArgs() else {
-    outputError("invalid_args", "Required: --calendar <name>. Event data is read from stdin as JSON array.")
-    exit(1)
-}
+let calendarName = parseArgs() ?? ""
 
 // Read JSON from stdin
 let stdinData = FileHandle.standardInput.readDataToEndOfFile()
@@ -138,10 +135,20 @@ if !accessGranted {
 
 store.refreshSourcesIfNecessary()
 
-guard let calendar = store.calendars(for: .event).first(where: { $0.title == calendarName }) else {
-    let available = store.calendars(for: .event).map { $0.title }.joined(separator: ", ")
-    outputError("calendar_not_found", "Calendar '\(calendarName)' not found. Available: \(available)")
-    exit(1)
+let calendar: EKCalendar
+if calendarName.isEmpty {
+    guard let defaultCal = store.defaultCalendarForNewEvents else {
+        outputError("no_default_calendar", "No default calendar configured.")
+        exit(1)
+    }
+    calendar = defaultCal
+} else {
+    guard let found = store.calendars(for: .event).first(where: { $0.title == calendarName }) else {
+        let available = store.calendars(for: .event).map { $0.title }.joined(separator: ", ")
+        outputError("calendar_not_found", "Calendar '\(calendarName)' not found. Available: \(available)")
+        exit(1)
+    }
+    calendar = found
 }
 
 // Create events

--- a/src/apple_calendar_mcp/swift/get_calendars.swift
+++ b/src/apple_calendar_mcp/swift/get_calendars.swift
@@ -59,6 +59,8 @@ func calendarTypeString(_ type: EKCalendarType) -> String {
     }
 }
 
+let defaultCal = store.defaultCalendarForNewEvents
+
 let calendarDicts: [[String: Any]] = calendars.map { cal in
     [
         "name": cal.title,
@@ -67,6 +69,7 @@ let calendarDicts: [[String: Any]] = calendars.map { cal in
         "color": cgColorToHex(cal.cgColor),
         "type": calendarTypeString(cal.type),
         "source": cal.source.title,
+        "is_default": cal == defaultCal,
     ]
 }
 


### PR DESCRIPTION
## Summary
- **get_calendars:** adds `is_default` boolean to each calendar (uses `defaultCalendarForNewEvents`)
- **create_events:** `calendar_name` is now optional — if omitted, events go to the system default calendar
- Updated docstrings and tool_descriptions.md

## Test plan
- [x] `make test-unit` — 171 passed
- [x] Manual: `is_default: true` on Work calendar, created event without calendar_name → landed on Work

Closes #165

🤖 Generated with [Claude Code](https://claude.com/claude-code)