### PR TITLE
Fix 4 doc/formatting issues from API critic review (#177, #181, #183, #184)

### DIFF
--- a/evals/agent_tool_usability/tool_descriptions.md
+++ b/evals/agent_tool_usability/tool_descriptions.md
@@ -6,7 +6,7 @@ This file contains exactly what an MCP-connected agent sees: the server instruct
 
 Apple Calendar is the built-in macOS calendar application. This MCP server provides tools to interact with it.
 
-CALENDARS: Each calendar has a name, writable status, type (caldav, subscription, birthday, local), description, and color. Calendar names are NOT guaranteed unique — the same name can appear across different accounts (e.g., two "Family" calendars from iCloud and Google). Use description to disambiguate when needed.
+CALENDARS: Each calendar has a name, writable status, type (caldav, subscription, birthday, local), source (account name like "iCloud" or "Google"), description, and color. Calendar names are NOT guaranteed unique — the same name can appear across different accounts (e.g., two "Family" calendars from iCloud and Google). Use the source field to disambiguate when needed.
 
 CALENDAR IDENTIFICATION: Calendars are identified by name (not UID — UIDs are not accessible via AppleScript). When specifying a calendar, use the exact name as returned by get_calendars.
 
@@ -134,10 +134,10 @@ Use get_calendars first to find available calendar names.
 - `start_date` (str, required): Start of range in ISO 8601 format (e.g., "2026-03-15T09:00:00")
 - `end_date` (str, required): End of range in ISO 8601 format (e.g., "2026-03-15T17:00:00")
 - `min_duration_minutes` (int | None, optional, default: None): Only return slots of at least this many minutes (e.g., 45)
-- `working_hours_start` (str | None, optional, default: None): Start of working hours as HH:MM (e.g., "09:00")
-- `working_hours_end` (str | None, optional, default: None): End of working hours as HH:MM (e.g., "17:00")
+- `working_hours_start` (str | None, optional, default: None): Start of working hours as HH:MM (e.g., "09:00"). Must be provided together with working_hours_end.
+- `working_hours_end` (str | None, optional, default: None): End of working hours as HH:MM (e.g., "17:00"). Must be provided together with working_hours_start.
 
-**Returns:** Each free slot includes: start_date, end_date, duration (formatted as hours and minutes). Slots are gaps between busy periods across all specified calendars. Overlapping events are merged. Returns "No free time" if the entire range is busy.
+**Returns:** Each free slot includes: start_date, end_date, duration_minutes (integer). Slots are gaps between busy periods across all specified calendars. Overlapping events are merged. Returns "No free time" if the entire range is busy.
 
 ---
 

--- a/src/apple_calendar_mcp/server_fastmcp.py
+++ b/src/apple_calendar_mcp/server_fastmcp.py
@@ -45,6 +45,8 @@ def _format_calendar(cal: dict) -> str:
     result += f"Access: {writable}\n"
     if cal.get("source"):
         result += f"Source: {cal['source']}\n"
+    if cal.get("is_default"):
+        result += "Default: yes\n"
     if cal.get("description"):
         result += f"Description: {cal['description']}\n"
     result += f"Color: {cal['color']}\n"
@@ -422,11 +424,11 @@ def get_availability(
         start_date: Start of range in ISO 8601 format (e.g., "2026-03-15T09:00:00")
         end_date: End of range in ISO 8601 format (e.g., "2026-03-15T17:00:00")
         min_duration_minutes: Only return slots of at least this many minutes (e.g., 45)
-        working_hours_start: Start of working hours as HH:MM (e.g., "09:00")
-        working_hours_end: End of working hours as HH:MM (e.g., "17:00")
+        working_hours_start: Start of working hours as HH:MM (e.g., "09:00"). Must be provided together with working_hours_end.
+        working_hours_end: End of working hours as HH:MM (e.g., "17:00"). Must be provided together with working_hours_start.
 
     Returns:
-        Each free slot includes: start_date, end_date, duration (formatted as hours and minutes).
+        Each free slot includes: start_date, end_date, duration_minutes (integer).
         Slots are gaps between busy periods across all specified calendars. Overlapping events
         are merged. Returns "No free time" if the entire range is busy.
     """


### PR DESCRIPTION
## Summary
- **#177:** Fix stale disambiguation guidance ("use description" → "use source field")
- **#181:** Fix get_availability Returns (duration_minutes, not "duration formatted")
- **#183:** Document working_hours paired requirement
- **#184:** Render is_default in _format_calendar output

## Test plan
- [x] `make test-unit` — 171 passed

Closes #177
Closes #181
Closes #183
Closes #184

🤖 Generated with [Claude Code](https://claude.com/claude-code)