### PR TITLE
Rename start/end to start_date/end_date in create_events/update_events (#178)

### DIFF
--- a/evals/agent_tool_usability/tool_descriptions.md
+++ b/evals/agent_tool_usability/tool_descriptions.md
@@ -66,7 +66,7 @@ For a single event, pass an array with one element. All events go to the same ca
 
 **Parameters:**
 - `calendar_name` (str, optional, default: ""): Name of the target calendar. If omitted, uses the system default calendar.
-- `events` (str, required): JSON array of event objects. Each object has keys: summary (required), start (required, ISO 8601), end (required, ISO 8601), and optional: location, notes, url, allday (bool), recurrence (RRULE string), alerts (list of minutes, e.g. [15, 60]), availability ("free"/"busy"/"tentative"), timezone (IANA identifier, e.g. "America/Los_Angeles" — use to schedule in a remote timezone rather than converting times manually), structured_location (object with title, latitude, longitude, radius — adds map pin and geo coordinates). For all-day events, set allday=true and use date-only format. end is inclusive for all-day events.
+- `events` (str, required): JSON array of event objects. Each object has keys: summary (required), start_date (required, ISO 8601), end_date (required, ISO 8601), and optional: location, notes, url, allday (bool), recurrence (RRULE string), alerts (list of minutes, e.g. [15, 60]), availability ("free"/"busy"/"tentative"), timezone (IANA identifier, e.g. "America/Los_Angeles" — use to schedule in a remote timezone rather than converting times manually), structured_location (object with title, latitude, longitude, radius — adds map pin and geo coordinates). For all-day events, set allday=true and use date-only format. end is inclusive for all-day events.
 
 **Returns:** Each created event with title and UID. Use these UIDs with update_events or delete_events. Any per-event errors are listed separately. Partial success is possible — some events may be created while others fail.
 
@@ -84,7 +84,7 @@ For recurring events: use occurrence_date to target a specific occurrence, and s
 
 **Parameters:**
 - `calendar_name` (str, required): Exact name of the calendar containing the events
-- `updates` (str, required): JSON array of update objects. Each object must have "uid" (required) and at least one field to update: summary, start (ISO 8601), end (ISO 8601), location, notes, url, allday (bool), alerts (list of minutes), availability ("free"/"busy"/"tentative"), timezone (IANA identifier), recurrence (RRULE string), clear_location (bool), clear_notes (bool), clear_url (bool), clear_alerts (bool), clear_recurrence (bool). For recurring events: occurrence_date (ISO 8601) to target specific occurrence, span ("this_event" or "future_events", default "this_event").
+- `updates` (str, required): JSON array of update objects. Each object must have "uid" (required) and at least one field to update: summary, start_date (ISO 8601), end_date (ISO 8601), location, notes, url, allday (bool), alerts (list of minutes), availability ("free"/"busy"/"tentative"), timezone (IANA identifier), recurrence (RRULE string), clear_location (bool), clear_notes (bool), clear_url (bool), clear_alerts (bool), clear_recurrence (bool). For recurring events: occurrence_date (ISO 8601) to target specific occurrence, span ("this_event" or "future_events", default "this_event").
 
 **Returns:** Summary of updated events, each with title and list of changed fields. Any per-event errors are listed separately. Partial success is possible. Note: when rescheduling a recurring event occurrence (changing dates with span="this_event"), a new standalone event is created — the returned UID may differ.
 

--- a/src/apple_calendar_mcp/server_fastmcp.py
+++ b/src/apple_calendar_mcp/server_fastmcp.py
@@ -135,7 +135,7 @@ def create_events(
     Args:
         calendar_name: Name of the target calendar. If omitted, uses the system default calendar.
         events: JSON array of event objects. Each object has keys: summary (required),
-                start (required, ISO 8601), end (required, ISO 8601), and optional:
+                start_date (required, ISO 8601), end_date (required, ISO 8601), and optional:
                 location, notes, url, allday (bool), recurrence (RRULE string),
                 alerts (list of minutes, e.g. [15, 60]), availability ("free"/"busy"/"tentative"),
                 timezone (IANA identifier, e.g. "America/Los_Angeles" — use this to schedule
@@ -194,7 +194,7 @@ def update_events(
     Args:
         calendar_name: Exact name of the calendar containing the events
         updates: JSON array of update objects. Each object must have "uid" (required)
-                 and at least one field to update: summary, start (ISO 8601), end (ISO 8601),
+                 and at least one field to update: summary, start_date (ISO 8601), end_date (ISO 8601),
                  location, notes, url, allday (bool), alerts (list of minutes),
                  availability ("free"/"busy"/"tentative"), timezone (IANA identifier —
                  use to schedule in a remote timezone rather than converting manually),

--- a/src/apple_calendar_mcp/swift/create_events.swift
+++ b/src/apple_calendar_mcp/swift/create_events.swift
@@ -158,9 +158,9 @@ var errors: [[String: Any]] = []
 
 for (index, eventData) in eventsJson.enumerated() {
     guard let summary = eventData["summary"] as? String,
-          let startStr = eventData["start"] as? String,
-          let endStr = eventData["end"] as? String else {
-        errors.append(["index": index, "summary": eventData["summary"] as? String ?? "unknown", "error": "Missing required fields: summary, start, end"])
+          let startStr = eventData["start_date"] as? String,
+          let endStr = eventData["end_date"] as? String else {
+        errors.append(["index": index, "summary": eventData["summary"] as? String ?? "unknown", "error": "Missing required fields: summary, start_date, end_date"])
         continue
     }
 

--- a/src/apple_calendar_mcp/swift/update_events.swift
+++ b/src/apple_calendar_mcp/swift/update_events.swift
@@ -183,8 +183,8 @@ for (index, updateData) in updatesJson.enumerated() {
     var updatedFields: [String] = []
 
     // Parse new start/end before applying
-    let newStartStr = updateData["start"] as? String
-    let newEndStr = updateData["end"] as? String
+    let newStartStr = updateData["start_date"] as? String
+    let newEndStr = updateData["end_date"] as? String
     let newStart: Date? = newStartStr.flatMap { parseISO8601($0, timeZone: tz) }
     let newEnd: Date? = newEndStr.flatMap { parseISO8601($0, timeZone: tz) }
 

--- a/tests/benchmarks/performance.py
+++ b/tests/benchmarks/performance.py
@@ -104,7 +104,7 @@ def run_benchmarks(read_calendar: str, test_calendar: str):
     def create_and_track():
         result = connector.create_events(
             calendar_name=test_calendar,
-            events=[{"summary": "Benchmark Event", "start": "2027-06-15T10:00:00", "end": "2027-06-15T11:00:00"}],
+            events=[{"summary": "Benchmark Event", "start_date": "2027-06-15T10:00:00", "end_date": "2027-06-15T11:00:00"}],
         )
         uid = result["created"][0]["uid"]
         created_uids.append(uid)
@@ -149,7 +149,7 @@ def run_benchmarks(read_calendar: str, test_calendar: str):
 
     # Batch delete benchmark (create 5, delete all)
     batch_events = [
-        {"summary": f"Batch Bench {i}", "start": "2027-07-01T10:00:00", "end": "2027-07-01T11:00:00"}
+        {"summary": f"Batch Bench {i}", "start_date": "2027-07-01T10:00:00", "end_date": "2027-07-01T11:00:00"}
         for i in range(5)
     ]
     batch_result = connector.create_events(calendar_name=test_calendar, events=batch_events)

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -34,7 +34,7 @@ def _update_single_event(connector, calendar_name, event_uid, **kwargs):
     """Update a single event via update_events and return the result."""
     update = {"uid": event_uid}
     field_map = {
-        "summary": "summary", "start_date": "start", "end_date": "end",
+        "summary": "summary", "start_date": "start_date", "end_date": "end_date",
         "location": "location", "notes": "notes", "url": "url",
         "allday_event": "allday", "availability": "availability",
         "timezone": "timezone", "recurrence_rule": "recurrence",
@@ -83,7 +83,7 @@ end tell'''
 
 def _create_single_event(connector, calendar_name, summary, start_date, end_date, **kwargs):
     """Create a single event via create_events and return the UID."""
-    event = {"summary": summary, "start": start_date, "end": end_date}
+    event = {"summary": summary, "start_date": start_date, "end_date": end_date}
     if kwargs.get("location"):
         event["location"] = kwargs["location"]
     if kwargs.get("notes"):
@@ -265,8 +265,8 @@ end tell'''
     def test_batch_creates_multiple_events(self, connector):
         """Batch create should handle multiple events in one call."""
         events = [
-            {"summary": "Batch Event 1", "start": "2026-06-20T10:00:00", "end": "2026-06-20T11:00:00"},
-            {"summary": "Batch Event 2", "start": "2026-06-20T14:00:00", "end": "2026-06-20T15:00:00"},
+            {"summary": "Batch Event 1", "start_date": "2026-06-20T10:00:00", "end_date": "2026-06-20T11:00:00"},
+            {"summary": "Batch Event 2", "start_date": "2026-06-20T14:00:00", "end_date": "2026-06-20T15:00:00"},
         ]
         result = connector.create_events(TEST_CALENDAR, events)
         uids = [c["uid"] for c in result["created"]]

--- a/tests/unit/test_calendar_connector.py
+++ b/tests/unit/test_calendar_connector.py
@@ -998,8 +998,8 @@ class TestCreateEvents:
             "errors": [],
         })
         events = [
-            {"summary": "Event 1", "start": "2026-03-15T10:00:00", "end": "2026-03-15T11:00:00"},
-            {"summary": "Event 2", "start": "2026-03-15T12:00:00", "end": "2026-03-15T13:00:00"},
+            {"summary": "Event 1", "start_date": "2026-03-15T10:00:00", "end_date": "2026-03-15T11:00:00"},
+            {"summary": "Event 2", "start_date": "2026-03-15T12:00:00", "end_date": "2026-03-15T13:00:00"},
         ]
         result = self.connector.create_events("MCP-Test-Calendar", events)
         assert len(result["created"]) == 2

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -534,8 +534,8 @@ class TestCreateEventsTool:
 
         from apple_calendar_mcp.server_fastmcp import create_events
         events_json = json.dumps([
-            {"summary": "Event A", "start": "2026-03-15T10:00:00", "end": "2026-03-15T11:00:00"},
-            {"summary": "Event B", "start": "2026-03-15T12:00:00", "end": "2026-03-15T13:00:00"},
+            {"summary": "Event A", "start_date": "2026-03-15T10:00:00", "end_date": "2026-03-15T11:00:00"},
+            {"summary": "Event B", "start_date": "2026-03-15T12:00:00", "end_date": "2026-03-15T13:00:00"},
         ])
         result = create_events(calendar_name="Work", events=events_json)
         assert "Created 2 event(s)" in result
@@ -552,7 +552,7 @@ class TestCreateEventsTool:
 
         from apple_calendar_mcp.server_fastmcp import create_events
         events_json = json.dumps([
-            {"summary": "Event A", "start": "2026-03-15T10:00:00", "end": "2026-03-15T11:00:00"},
+            {"summary": "Event A", "start_date": "2026-03-15T10:00:00", "end_date": "2026-03-15T11:00:00"},
         ])
         result = create_events(calendar_name="Nonexistent", events=events_json)
         assert "Error" in result
@@ -569,8 +569,8 @@ class TestCreateEventsTool:
 
         from apple_calendar_mcp.server_fastmcp import create_events
         events_json = json.dumps([
-            {"summary": "Event A", "start": "2026-03-15T10:00:00", "end": "2026-03-15T11:00:00"},
-            {"summary": "Event B", "start": "bad-date", "end": "bad-date"},
+            {"summary": "Event A", "start_date": "2026-03-15T10:00:00", "end_date": "2026-03-15T11:00:00"},
+            {"summary": "Event B", "start_date": "bad-date", "end_date": "bad-date"},
         ])
         result = create_events(calendar_name="Work", events=events_json)
         assert "Created 1 event(s)" in result
@@ -598,7 +598,7 @@ class TestUpdateEventsTool:
         mock_client = MagicMock()
         mock_client.update_events.return_value = {
             "updated": [
-                {"summary": "Event A", "updated_fields": ["start", "end"]},
+                {"summary": "Event A", "updated_fields": ["start_date", "end_date"]},
                 {"summary": "Event B", "updated_fields": ["location"]},
             ],
             "errors": [],
@@ -607,13 +607,13 @@ class TestUpdateEventsTool:
 
         from apple_calendar_mcp.server_fastmcp import update_events
         updates_json = json.dumps([
-            {"uid": "UID-A", "start": "2026-03-15T11:00:00", "end": "2026-03-15T12:00:00"},
+            {"uid": "UID-A", "start_date": "2026-03-15T11:00:00", "end_date": "2026-03-15T12:00:00"},
             {"uid": "UID-B", "location": "Room B"},
         ])
         result = update_events(calendar_name="Work", updates=updates_json)
         assert "Updated 2 event(s)" in result
         assert "Event A" in result
-        assert "start, end" in result
+        assert "start_date, end_date" in result
         assert "location" in result
         assert isinstance(result, str)
 


### PR DESCRIPTION
## Summary

JSON input fields for create_events and update_events now match get_events output. Agents can pass data from read to write without renaming fields.

**Before:** get_events returns `start_date`/`end_date`, create_events accepts `start`/`end` — mismatch
**After:** Both use `start_date`/`end_date` — consistent

Breaking change. Updated Swift helpers, docstrings, tool_descriptions, all tests, benchmarks.

## Test plan
- [x] `make test-unit` — 171 passed

Closes #178

🤖 Generated with [Claude Code](https://claude.com/claude-code)