### PR TITLE
Return resolved calendar name when create_events uses default (#179)

### DIFF
--- a/src/apple_calendar_mcp/server_fastmcp.py
+++ b/src/apple_calendar_mcp/server_fastmcp.py
@@ -170,7 +170,8 @@ def create_events(
     created = result.get("created", [])
     errors = result.get("errors", [])
 
-    parts = [f"Created {len(created)} event(s) in calendar '{calendar_name}'"]
+    resolved_calendar = created[0].get("calendar_name", calendar_name) if created else calendar_name
+    parts = [f"Created {len(created)} event(s) in calendar '{resolved_calendar}'"]
     for c in created:
         parts.append(f"  {c['summary']} (UID: {c['uid']})")
     if errors:

--- a/src/apple_calendar_mcp/swift/create_events.swift
+++ b/src/apple_calendar_mcp/swift/create_events.swift
@@ -209,7 +209,7 @@ for (index, eventData) in eventsJson.enumerated() {
 
     do {
         try store.save(event, span: .thisEvent, commit: false)
-        created.append(["uid": event.calendarItemIdentifier, "summary": summary])
+        created.append(["uid": event.calendarItemIdentifier, "summary": summary, "calendar_name": calendar.title])
     } catch {
         errors.append(["index": index, "summary": summary, "error": error.localizedDescription])
     }


### PR DESCRIPTION
## Summary

When create_events uses the default calendar (empty calendar_name), the success message now shows the actual calendar name: "Created 1 event in calendar 'Work'" instead of "in calendar ''".

Swift helper includes `calendar_name` in each created event result.

## Test plan
- [x] `make test-unit` — 171 passed

Closes #179

🤖 Generated with [Claude Code](https://claude.com/claude-code)