### PR TITLE
Align all query tools to calendar_names: list[str] (#185)

### DIFF
--- a/evals/agent_tool_usability/tool_descriptions.md
+++ b/evals/agent_tool_usability/tool_descriptions.md
@@ -92,12 +92,12 @@ For recurring events: use occurrence_date to target a specific occurrence, and s
 
 ### get_events
 
-Get events from a calendar within a date range.
+Get events from one or more calendars within a date range.
 
-Returns all events in the specified calendar that overlap with the given date range. Use get_calendars first to find available calendar names.
+Returns all events in the specified calendar(s) that overlap with the given date range. Use get_calendars first to find available calendar names.
 
 **Parameters:**
-- `calendar_name` (str, required): Exact name of the calendar to query (use get_calendars to find available names)
+- `calendar_names` (list[str], optional, default: []): List of calendar names to query (use get_calendars to find available names). If empty, queries all calendars.
 - `start_date` (str, required): Start of date range in ISO 8601 format (e.g., "2026-03-15" or "2026-03-15T00:00:00")
 - `end_date` (str, required): End of date range in ISO 8601 format (exclusive — to include March 29, use "2026-03-30")
 
@@ -107,13 +107,13 @@ Returns all events in the specified calendar that overlap with the given date ra
 
 ### search_events
 
-Search events by text across one or all calendars.
+Search events by text across one or more calendars.
 
-Searches event summaries, notes, and locations with case-insensitive matching. If no calendar is specified, searches all calendars. If no date range is specified, searches from 1 month ago to 6 months from now.
+Searches event summaries, notes, and locations with case-insensitive matching. If no calendars are specified, searches all calendars. If no date range is specified, searches from 1 month ago to 6 months from now.
 
 **Parameters:**
 - `query` (str, required): Text to search for in event titles, notes, and locations
-- `calendar_name` (str, optional, default: ""): Calendar to search (searches all calendars if empty)
+- `calendar_names` (list[str], optional, default: []): List of calendar names to search (searches all calendars if empty)
 - `start_date` (str, optional, default: ""): Start of date range in ISO 8601 format
 - `end_date` (str, optional, default: ""): End of date range in ISO 8601 format
 

--- a/src/apple_calendar_mcp/calendar_connector.py
+++ b/src/apple_calendar_mcp/calendar_connector.py
@@ -207,16 +207,19 @@ class CalendarConnector:
 
     def get_events(
         self,
-        calendar_name: str,
-        start_date: str,
-        end_date: str,
+        calendar_names: list[str] | str | None = None,
+        start_date: str = "",
+        end_date: str = "",
+        *,
+        calendar_name: str | None = None,  # backward compat alias
     ) -> list[dict[str, Any]]:
-        """Get events from a calendar within a date range.
+        """Get events from one or more calendars within a date range.
 
         Uses EventKit via Swift helper for fast native date-range queries.
 
         Args:
-            calendar_name: Name of the calendar to query
+            calendar_names: Calendar name(s) to query. Accepts a list of names,
+                a single name string, or None/empty list to query all calendars.
             start_date: Start of date range in ISO 8601 format
             end_date: End of date range in ISO 8601 format
 
@@ -228,10 +231,23 @@ class CalendarConnector:
             ValueError: If date format is invalid or calendar not found
             PermissionError: If EventKit calendar access is denied
         """
+        # Support backward compat: calendar_name= keyword alias
+        if calendar_name is not None and calendar_names is None:
+            calendar_names = [calendar_name] if calendar_name else []
+
+        # Normalize calendar_names to a list
+        if calendar_names is None:
+            calendar_names = []
+        elif isinstance(calendar_names, str):
+            calendar_names = [calendar_names] if calendar_names else []
+
         self._validate_date(start_date)
         self._validate_date(end_date)
 
-        args = ["--calendar", calendar_name, "--start", start_date, "--end", end_date]
+        args = []
+        for name in calendar_names:
+            args += ["--calendar", name]
+        args += ["--start", start_date, "--end", end_date]
         events = self._run_swift_helper_json("get_events", args)
         for event in events:
             if event.get("allday_event"):
@@ -241,24 +257,37 @@ class CalendarConnector:
     def search_events(
         self,
         query: str,
-        calendar_name: Optional[str] = None,
+        calendar_names: list[str] | str | None = None,
         start_date: Optional[str] = None,
         end_date: Optional[str] = None,
+        *,
+        calendar_name: str | None = None,  # backward compat alias
     ) -> list[dict[str, Any]]:
-        """Search events by text across one or all calendars.
+        """Search events by text across one or more calendars.
 
         Searches event summaries, notes, and locations with
         case-insensitive matching.
 
         Args:
             query: Text to search for
-            calendar_name: Calendar to search (optional — searches all if omitted)
+            calendar_names: Calendar name(s) to search. Accepts a list of names,
+                a single name string, or None/empty list to search all calendars.
             start_date: Start of date range (optional — defaults to 1 month ago)
             end_date: End of date range (optional — defaults to 6 months from now)
 
         Returns:
             List of matching event dicts.
         """
+        # Normalize calendar_names to a list
+        # Support backward compat: calendar_name= keyword alias
+        if calendar_name is not None and calendar_names is None:
+            calendar_names = [calendar_name] if calendar_name else []
+
+        if calendar_names is None:
+            calendar_names = []
+        elif isinstance(calendar_names, str):
+            calendar_names = [calendar_names] if calendar_names else []
+
         if not start_date:
             start_date = (datetime.now() - timedelta(days=30)).strftime("%Y-%m-%dT00:00:00")
         if not end_date:
@@ -267,26 +296,16 @@ class CalendarConnector:
         self._validate_date(start_date)
         self._validate_date(end_date)
 
-        if calendar_name:
-            calendars = [calendar_name]
-        else:
-            cal_list = self.get_calendars()
-            calendars = [c["name"] for c in cal_list]
-
-        all_results = []
-        for cal in calendars:
-            args = ["--calendar", cal, "--start", start_date, "--end", end_date, "--query", query]
-            try:
-                events = self._run_swift_helper_json("get_events", args)
-                if isinstance(events, list):
-                    for event in events:
-                        if event.get("allday_event"):
-                            event["end_date"] = self._allday_end_from_eventkit(event["end_date"])
-                    all_results.extend(events)
-            except ValueError:
-                continue  # skip calendars that error (e.g., not found)
-
-        return all_results
+        args = []
+        for name in calendar_names:
+            args += ["--calendar", name]
+        args += ["--start", start_date, "--end", end_date, "--query", query]
+        events = self._run_swift_helper_json("get_events", args)
+        if isinstance(events, list):
+            for event in events:
+                if event.get("allday_event"):
+                    event["end_date"] = self._allday_end_from_eventkit(event["end_date"])
+        return events if isinstance(events, list) else []
 
     def delete_events(
         self,
@@ -499,9 +518,7 @@ class CalendarConnector:
         range_start = self._parse_iso_datetime(start_date)
         range_end = self._parse_iso_datetime(end_date)
 
-        all_events = []
-        for cal_name in calendar_names:
-            all_events.extend(self.get_events(cal_name, start_date, end_date))
+        all_events = self.get_events(calendar_names, start_date, end_date)
 
         # Only busy/tentative events block availability — free events are excluded
         busy_events = [e for e in all_events if e.get("availability", "busy") != "free"]
@@ -569,9 +586,7 @@ class CalendarConnector:
         if not calendar_names:
             raise ValueError("At least one calendar name must be provided")
 
-        all_events = []
-        for cal_name in calendar_names:
-            all_events.extend(self.get_events(cal_name, start_date, end_date))
+        all_events = self.get_events(calendar_names, start_date, end_date)
 
         # Filter out free events — only busy/tentative can conflict
         busy_events = [

--- a/src/apple_calendar_mcp/server_fastmcp.py
+++ b/src/apple_calendar_mcp/server_fastmcp.py
@@ -302,17 +302,18 @@ def _format_event(event: dict) -> str:
 
 @mcp.tool()
 def get_events(
-    calendar_name: str,
-    start_date: str,
-    end_date: str,
+    calendar_names: list[str] = [],
+    start_date: str = "",
+    end_date: str = "",
 ) -> str:
-    """Get events from a calendar within a date range.
+    """Get events from one or more calendars within a date range.
 
-    Returns all events in the specified calendar that overlap with the given
+    Returns all events in the specified calendar(s) that overlap with the given
     date range. Use get_calendars first to find available calendar names.
 
     Args:
-        calendar_name: Exact name of the calendar to query (use get_calendars to find available names)
+        calendar_names: List of calendar names to query (use get_calendars to find available names).
+                       If empty, queries all calendars.
         start_date: Start of date range in ISO 8601 format (e.g., "2026-03-15" or "2026-03-15T00:00:00")
         end_date: End of date range in ISO 8601 format (exclusive — to include March 29, use "2026-03-30")
 
@@ -332,39 +333,41 @@ def get_events(
     client = get_client()
     try:
         events = client.get_events(
-            calendar_name=calendar_name,
+            calendar_names=calendar_names,
             start_date=start_date,
             end_date=end_date,
         )
     except Exception as e:
         return f"Error getting events: {e}"
 
+    cal_desc = ", ".join(f"'{c}'" for c in calendar_names) if calendar_names else "all calendars"
+
     if not events:
-        return f"No events found in '{calendar_name}' between {start_date} and {end_date}."
+        return f"No events found in {cal_desc} between {start_date} and {end_date}."
 
     lines = []
     for event in events:
         lines.append(_format_event(event))
 
-    return f"Found {len(events)} event(s) in '{calendar_name}':\n\n" + "\n".join(lines)
+    return f"Found {len(events)} event(s) in {cal_desc}:\n\n" + "\n".join(lines)
 
 
 @mcp.tool()
 def search_events(
     query: str,
-    calendar_name: str = "",
+    calendar_names: list[str] = [],
     start_date: str = "",
     end_date: str = "",
 ) -> str:
-    """Search events by text across one or all calendars.
+    """Search events by text across one or more calendars.
 
     Searches event summaries, notes, and locations with case-insensitive
-    matching. If no calendar is specified, searches all calendars. If no date
+    matching. If no calendars are specified, searches all calendars. If no date
     range is specified, searches from 1 month ago to 6 months from now.
 
     Args:
         query: Text to search for in event titles, notes, and locations
-        calendar_name: Calendar to search (optional — searches all calendars if empty)
+        calendar_names: List of calendar names to search (optional — searches all calendars if empty)
         start_date: Start of date range in ISO 8601 format (optional)
         end_date: End of date range in ISO 8601 format (optional)
 
@@ -376,19 +379,22 @@ def search_events(
     try:
         events = client.search_events(
             query=query,
-            calendar_name=calendar_name or None,
+            calendar_names=calendar_names or None,
             start_date=start_date or None,
             end_date=end_date or None,
         )
     except Exception as e:
         return f"Error searching events: {e}"
 
+    if calendar_names:
+        scope = "in " + ", ".join(f"'{c}'" for c in calendar_names)
+    else:
+        scope = "across all calendars"
+
     if not events:
-        scope = f"in '{calendar_name}'" if calendar_name else "across all calendars"
         return f"No events matching '{query}' found {scope}."
 
     lines = [_format_event(event) for event in events]
-    scope = f"in '{calendar_name}'" if calendar_name else "across all calendars"
     return f"Found {len(events)} event(s) matching '{query}' {scope}:\n\n" + "\n".join(lines)
 
 

--- a/src/apple_calendar_mcp/swift/get_events.swift
+++ b/src/apple_calendar_mcp/swift/get_events.swift
@@ -6,17 +6,18 @@ import Foundation
 
 func printUsage() {
     let msg = """
-    Usage: get_events.swift --calendar <name> --start <ISO8601> --end <ISO8601>
+    Usage: get_events.swift [--calendar <name> ...] --start <ISO8601> --end <ISO8601>
 
     Queries Apple Calendar events using EventKit.
+    Multiple --calendar flags can be provided. If none, queries all calendars.
     Outputs JSON array to stdout.
     """
     FileHandle.standardError.write(Data(msg.utf8))
 }
 
-func parseArgs() -> (calendar: String, start: String, end: String, query: String?)? {
+func parseArgs() -> (calendars: [String], start: String, end: String, query: String?)? {
     let args = CommandLine.arguments
-    var calendar: String?
+    var calendars: [String] = []
     var start: String?
     var end: String?
     var query: String?
@@ -25,7 +26,7 @@ func parseArgs() -> (calendar: String, start: String, end: String, query: String
     while i < args.count {
         switch args[i] {
         case "--calendar":
-            i += 1; if i < args.count { calendar = args[i] }
+            i += 1; if i < args.count { calendars.append(args[i]) }
         case "--start":
             i += 1; if i < args.count { start = args[i] }
         case "--end":
@@ -38,10 +39,10 @@ func parseArgs() -> (calendar: String, start: String, end: String, query: String
         i += 1
     }
 
-    guard let cal = calendar, let s = start, let e = end else {
+    guard let s = start, let e = end else {
         return nil
     }
-    return (cal, s, e, query)
+    return (calendars, s, e, query)
 }
 
 // MARK: - Date Parsing
@@ -216,7 +217,7 @@ func participantStatusString(_ status: EKParticipantStatus) -> String {
 // MARK: - Main
 
 guard let parsed = parseArgs() else {
-    outputError("invalid_args", "Required: --calendar <name> --start <ISO8601> --end <ISO8601>")
+    outputError("invalid_args", "Required: --start <ISO8601> --end <ISO8601> [--calendar <name> ...]")
     exit(1)
 }
 
@@ -252,16 +253,27 @@ if !accessGranted {
 // Refresh sources to pick up recently-created events
 store.refreshSourcesIfNecessary()
 
-// Find the calendar by name
+// Resolve calendars: nil means all calendars, otherwise look up each by name
 let allCalendars = store.calendars(for: .event)
-guard let calendar = allCalendars.first(where: { $0.title == parsed.calendar }) else {
-    let available = allCalendars.map { $0.title }.joined(separator: ", ")
-    outputError("calendar_not_found", "Calendar '\(parsed.calendar)' not found. Available: \(available)")
-    exit(1)
+let calendarArray: [EKCalendar]?
+
+if parsed.calendars.isEmpty {
+    calendarArray = nil  // EventKit queries all calendars
+} else {
+    var resolved: [EKCalendar] = []
+    for calName in parsed.calendars {
+        guard let cal = allCalendars.first(where: { $0.title == calName }) else {
+            let available = allCalendars.map { $0.title }.joined(separator: ", ")
+            outputError("calendar_not_found", "Calendar '\(calName)' not found. Available: \(available)")
+            exit(1)
+        }
+        resolved.append(cal)
+    }
+    calendarArray = resolved
 }
 
 // Query events
-let predicate = store.predicateForEvents(withStart: startDate, end: endDate, calendars: [calendar])
+let predicate = store.predicateForEvents(withStart: startDate, end: endDate, calendars: calendarArray)
 var events = store.events(matching: predicate)
 
 // Filter by query text (case-insensitive match on title, notes, location)

--- a/tests/unit/test_calendar_connector.py
+++ b/tests/unit/test_calendar_connector.py
@@ -315,13 +315,69 @@ class TestGetEvents:
     def test_calls_swift_helper_with_correct_args(self, mock_swift):
         mock_swift.return_value = "[]"
         self.connector.get_events(
-            calendar_name="Work",
+            calendar_names=["Work"],
             start_date="2026-03-15T00:00:00",
             end_date="2026-03-16T00:00:00",
         )
         mock_swift.assert_called_once_with(
             "get_events",
             ["--calendar", "Work", "--start", "2026-03-15T00:00:00", "--end", "2026-03-16T00:00:00"],
+            stdin_data=None,
+        )
+
+    @patch("apple_calendar_mcp.calendar_connector.run_swift_helper")
+    def test_calls_swift_helper_with_multiple_calendars(self, mock_swift):
+        mock_swift.return_value = "[]"
+        self.connector.get_events(
+            calendar_names=["Work", "Personal"],
+            start_date="2026-03-15T00:00:00",
+            end_date="2026-03-16T00:00:00",
+        )
+        mock_swift.assert_called_once_with(
+            "get_events",
+            ["--calendar", "Work", "--calendar", "Personal", "--start", "2026-03-15T00:00:00", "--end", "2026-03-16T00:00:00"],
+            stdin_data=None,
+        )
+
+    @patch("apple_calendar_mcp.calendar_connector.run_swift_helper")
+    def test_calls_swift_helper_with_no_calendars_queries_all(self, mock_swift):
+        mock_swift.return_value = "[]"
+        self.connector.get_events(
+            calendar_names=[],
+            start_date="2026-03-15T00:00:00",
+            end_date="2026-03-16T00:00:00",
+        )
+        mock_swift.assert_called_once_with(
+            "get_events",
+            ["--start", "2026-03-15T00:00:00", "--end", "2026-03-16T00:00:00"],
+            stdin_data=None,
+        )
+
+    @patch("apple_calendar_mcp.calendar_connector.run_swift_helper")
+    def test_string_calendar_name_backward_compat(self, mock_swift):
+        mock_swift.return_value = "[]"
+        self.connector.get_events(
+            calendar_names="Work",
+            start_date="2026-03-15T00:00:00",
+            end_date="2026-03-16T00:00:00",
+        )
+        mock_swift.assert_called_once_with(
+            "get_events",
+            ["--calendar", "Work", "--start", "2026-03-15T00:00:00", "--end", "2026-03-16T00:00:00"],
+            stdin_data=None,
+        )
+
+    @patch("apple_calendar_mcp.calendar_connector.run_swift_helper")
+    def test_none_calendar_names_queries_all(self, mock_swift):
+        mock_swift.return_value = "[]"
+        self.connector.get_events(
+            calendar_names=None,
+            start_date="2026-03-15T00:00:00",
+            end_date="2026-03-16T00:00:00",
+        )
+        mock_swift.assert_called_once_with(
+            "get_events",
+            ["--start", "2026-03-15T00:00:00", "--end", "2026-03-16T00:00:00"],
             stdin_data=None,
         )
 
@@ -485,17 +541,10 @@ class TestGetAvailability:
     @patch("apple_calendar_mcp.calendar_connector.run_swift_helper")
     def test_overlapping_events_merged(self, mock_swift):
         """Two overlapping events across calendars should merge into one busy block."""
-        def swift_side_effect(script_name, args, stdin_data=None):
-            cal = args[args.index("--calendar") + 1]
-            if cal == "Work":
-                return json.dumps([
-                    self._make_event("2026-03-15T09:00:00", "2026-03-15T11:00:00", calendar="Work"),
-                ])
-            else:
-                return json.dumps([
-                    self._make_event("2026-03-15T10:00:00", "2026-03-15T12:00:00", calendar="Personal"),
-                ])
-        mock_swift.side_effect = swift_side_effect
+        mock_swift.return_value = json.dumps([
+            self._make_event("2026-03-15T09:00:00", "2026-03-15T11:00:00", calendar="Work"),
+            self._make_event("2026-03-15T10:00:00", "2026-03-15T12:00:00", calendar="Personal"),
+        ])
         result = self.connector.get_availability(
             ["Work", "Personal"], "2026-03-15T08:00:00", "2026-03-15T14:00:00"
         )
@@ -552,17 +601,10 @@ class TestGetAvailability:
     @patch("apple_calendar_mcp.calendar_connector.run_swift_helper")
     def test_multiple_calendars_combined(self, mock_swift):
         """Events from multiple calendars should be merged for availability."""
-        def swift_side_effect(script_name, args, stdin_data=None):
-            cal = args[args.index("--calendar") + 1]
-            if cal == "Work":
-                return json.dumps([
-                    self._make_event("2026-03-15T09:00:00", "2026-03-15T10:00:00", calendar="Work"),
-                ])
-            else:
-                return json.dumps([
-                    self._make_event("2026-03-15T14:00:00", "2026-03-15T15:00:00", calendar="Personal"),
-                ])
-        mock_swift.side_effect = swift_side_effect
+        mock_swift.return_value = json.dumps([
+            self._make_event("2026-03-15T09:00:00", "2026-03-15T10:00:00", calendar="Work"),
+            self._make_event("2026-03-15T14:00:00", "2026-03-15T15:00:00", calendar="Personal"),
+        ])
         result = self.connector.get_availability(
             ["Work", "Personal"], "2026-03-15T08:00:00", "2026-03-15T16:00:00"
         )
@@ -825,11 +867,10 @@ class TestGetConflicts:
 
     @patch.object(CalendarConnector, "get_events")
     def test_multi_calendar(self, mock_get):
-        def side_effect(cal_name, start, end):
-            if cal_name == "Work":
-                return [self._make_event("A", "Meeting", "2026-03-15T10:00:00", "2026-03-15T11:00:00", "Work")]
-            return [self._make_event("B", "Dentist", "2026-03-15T10:30:00", "2026-03-15T11:30:00", "Personal")]
-        mock_get.side_effect = side_effect
+        mock_get.return_value = [
+            self._make_event("A", "Meeting", "2026-03-15T10:00:00", "2026-03-15T11:00:00", "Work"),
+            self._make_event("B", "Dentist", "2026-03-15T10:30:00", "2026-03-15T11:30:00", "Personal"),
+        ]
         result = self.connector.get_conflicts(["Work", "Personal"], "2026-03-15", "2026-03-16")
         assert len(result) == 1
         assert result[0]["event_a"]["calendar_name"] == "Work"
@@ -1088,60 +1129,57 @@ class TestSearchEvents:
             {"uid": "UID-1", "summary": "Team Lunch", "start_date": "2026-03-15T12:00:00",
              "end_date": "2026-03-15T13:00:00", "calendar_name": "Work"},
         ])
-        results = self.connector.search_events("lunch", calendar_name="Work",
+        results = self.connector.search_events("lunch", calendar_names=["Work"],
                                                 start_date="2026-03-01", end_date="2026-04-01")
         assert len(results) == 1
         assert results[0]["summary"] == "Team Lunch"
         args = mock_swift.call_args[0][1]
         assert "--query" in args
         assert "lunch" in args
+        assert "--calendar" in args
+        assert "Work" in args
+
+    @patch("apple_calendar_mcp.calendar_connector.run_swift_helper")
+    def test_searches_multiple_calendars(self, mock_swift):
+        """When multiple calendars specified, passes all to Swift helper."""
+        mock_swift.return_value = json.dumps([])
+        self.connector.search_events("lunch", calendar_names=["Work", "Personal"],
+                                      start_date="2026-03-01", end_date="2026-04-01")
+        args = mock_swift.call_args[0][1]
+        assert args.count("--calendar") == 2
+        assert "Work" in args
+        assert "Personal" in args
 
     @patch("apple_calendar_mcp.calendar_connector.run_swift_helper")
     def test_searches_all_calendars(self, mock_swift):
-        """When no calendar_name, searches all calendars."""
-        # get_calendars returns two calendars
-        def side_effect(script, args, **kwargs):
-            if script == "get_calendars":
-                return json.dumps([
-                    {"name": "Work", "writable": True, "description": "", "color": "#FF0000", "source": "iCloud"},
-                    {"name": "Personal", "writable": True, "description": "", "color": "#0000FF"},
-                ])
-            # get_events returns for each calendar
-            return json.dumps([])
-        mock_swift.side_effect = side_effect
+        """When no calendar_names, searches all calendars (no --calendar flags)."""
+        mock_swift.return_value = json.dumps([])
         results = self.connector.search_events("lunch", start_date="2026-03-01", end_date="2026-04-01")
         assert results == []
-        # Should have called get_calendars + get_events for each calendar
-        assert mock_swift.call_count == 3  # get_calendars + 2x get_events
+        # Single call with no --calendar flags
+        assert mock_swift.call_count == 1
+        args = mock_swift.call_args[0][1]
+        assert "--calendar" not in args
 
     @patch("apple_calendar_mcp.calendar_connector.run_swift_helper")
     def test_default_date_range(self, mock_swift):
         """When no dates, defaults to 1 month ago to 6 months from now."""
         mock_swift.return_value = json.dumps([])
-        self.connector.search_events("test", calendar_name="Work")
+        self.connector.search_events("test", calendar_names=["Work"])
         args = mock_swift.call_args[0][1]
         # Should have --start and --end with auto-generated dates
         assert "--start" in args
         assert "--end" in args
 
     @patch("apple_calendar_mcp.calendar_connector.run_swift_helper")
-    def test_skips_calendar_not_found(self, mock_swift):
-        """Calendar not found errors should be silently skipped."""
-        def side_effect(script, args, **kwargs):
-            if script == "get_calendars":
-                return json.dumps([
-                    {"name": "Work", "writable": True, "description": "", "color": "#FF0000", "source": "iCloud"},
-                    {"name": "Missing", "writable": True, "description": "", "color": "#00FF00"},
-                ])
-            # Work returns events, Missing raises ValueError
-            cal_arg_idx = args.index("--calendar") + 1 if "--calendar" in args else -1
-            if cal_arg_idx >= 0 and args[cal_arg_idx] == "Missing":
-                return json.dumps({"error": "calendar_not_found", "message": "not found"})
-            return json.dumps([{"uid": "UID-1", "summary": "Found", "start_date": "2026-03-15T10:00:00",
-                                "end_date": "2026-03-15T11:00:00", "calendar_name": "Work"}])
-        mock_swift.side_effect = side_effect
-        results = self.connector.search_events("found", start_date="2026-03-01", end_date="2026-04-01")
-        assert len(results) == 1
+    def test_string_calendar_name_backward_compat(self, mock_swift):
+        """A single string calendar_names value is accepted for backward compat."""
+        mock_swift.return_value = json.dumps([])
+        self.connector.search_events("test", calendar_names="Work",
+                                      start_date="2026-03-01", end_date="2026-04-01")
+        args = mock_swift.call_args[0][1]
+        assert "--calendar" in args
+        assert "Work" in args
 
 
 # ── all-day inclusive end_date helpers ─────────────────────────────────────

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -159,7 +159,7 @@ class TestGetEventsTool:
         mock_get_client.return_value = mock_client
 
         from apple_calendar_mcp.server_fastmcp import get_events
-        result = get_events(calendar_name="Work", start_date="2026-03-15T00:00:00", end_date="2026-03-16T00:00:00")
+        result = get_events(calendar_names=["Work"], start_date="2026-03-15T00:00:00", end_date="2026-03-16T00:00:00")
         assert "Team Meeting" in result
         assert "Room 4" in result
         assert isinstance(result, str)
@@ -177,7 +177,7 @@ class TestGetEventsTool:
         mock_get_client.return_value = mock_client
 
         from apple_calendar_mcp.server_fastmcp import get_events
-        result = get_events(calendar_name="Work", start_date="2026-07-01", end_date="2026-07-02")
+        result = get_events(calendar_names=["Work"], start_date="2026-07-01", end_date="2026-07-02")
         assert "Recurring" in result
         assert "FREQ=WEEKLY" in result
 
@@ -196,7 +196,7 @@ class TestGetEventsTool:
         mock_get_client.return_value = mock_client
 
         from apple_calendar_mcp.server_fastmcp import get_events
-        result = get_events(calendar_name="Work", start_date="2026-07-01", end_date="2026-07-02")
+        result = get_events(calendar_names=["Work"], start_date="2026-07-01", end_date="2026-07-02")
         assert "Attendees (2)" in result
         assert "Alice" in result
         assert "bob@example.com" in result
@@ -208,7 +208,7 @@ class TestGetEventsTool:
         mock_get_client.return_value = mock_client
 
         from apple_calendar_mcp.server_fastmcp import get_events
-        result = get_events(calendar_name="Work", start_date="2026-03-15T00:00:00", end_date="2026-03-16T00:00:00")
+        result = get_events(calendar_names=["Work"], start_date="2026-03-15T00:00:00", end_date="2026-03-16T00:00:00")
         assert "No events found" in result
 
     @patch("apple_calendar_mcp.server_fastmcp.get_client")
@@ -218,7 +218,7 @@ class TestGetEventsTool:
         mock_get_client.return_value = mock_client
 
         from apple_calendar_mcp.server_fastmcp import get_events
-        result = get_events(calendar_name="Foo", start_date="2026-03-15T00:00:00", end_date="2026-03-16T00:00:00")
+        result = get_events(calendar_names=["Foo"], start_date="2026-03-15T00:00:00", end_date="2026-03-16T00:00:00")
         assert "Error" in result
         assert isinstance(result, str)
 
@@ -229,7 +229,7 @@ class TestGetEventsTool:
         mock_get_client.return_value = mock_client
 
         from apple_calendar_mcp.server_fastmcp import get_events
-        result = get_events(calendar_name="Work", start_date="2026-03-15T00:00:00", end_date="2026-03-16T00:00:00")
+        result = get_events(calendar_names=["Work"], start_date="2026-03-15T00:00:00", end_date="2026-03-16T00:00:00")
         assert "Error" in result
 
 
@@ -675,7 +675,7 @@ class TestSearchEventsTool:
         mock_get_client.return_value = mock_client
 
         from apple_calendar_mcp.server_fastmcp import search_events
-        result = search_events(query="standup", calendar_name="Work")
+        result = search_events(query="standup", calendar_names=["Work"])
         assert "Found 1 event(s)" in result
         assert "Team Standup" in result
         assert "in 'Work'" in result
@@ -688,7 +688,7 @@ class TestSearchEventsTool:
         mock_get_client.return_value = mock_client
 
         from apple_calendar_mcp.server_fastmcp import search_events
-        result = search_events(query="nonexistent", calendar_name="Work")
+        result = search_events(query="nonexistent", calendar_names=["Work"])
         assert "No events matching" in result
         assert "in 'Work'" in result
 
@@ -724,7 +724,7 @@ class TestSearchEventsTool:
         search_events(query="test")
         mock_client.search_events.assert_called_once_with(
             query="test",
-            calendar_name=None,
+            calendar_names=None,
             start_date=None,
             end_date=None,
         )


### PR DESCRIPTION
## Summary

All 4 query tools now use `calendar_names: list[str]` (optional, empty = all calendars):

- **get_events:** `calendar_name: str` → `calendar_names: list[str]`. Swift queries multiple calendars natively via EventKit predicate.
- **search_events:** Same change. Single Swift call instead of Python loop per calendar.
- **get_availability:** Now calls get_events once instead of looping per calendar.
- **get_conflicts:** Same simplification.

Swift `get_events.swift` updated to accept multiple `--calendar` flags or none (nil = all calendars). Performance improvement: single subprocess call for multi-calendar queries.

Backward compat: `calendar_name=` keyword still accepted on get_events and search_events.

## Test plan
- [x] `make test-unit` — 176 passed
- [x] `make test-integration` — 57/58 passed (1 pre-existing flaky test)

Closes #185

🤖 Generated with [Claude Code](https://claude.com/claude-code)