### PR TITLE
release: v0.8.0

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -3,7 +3,7 @@
 An MCP server bridging Claude and Apple Calendar via AppleScript and EventKit on macOS.
 
 **Stack:** Python 3.10+, FastMCP, AppleScript (via `osascript`), Swift/EventKit (via `swift`)
-**Version:** v0.7.0 | **Tests:** 176 unit, 58 integration | **Coverage:** 98%
+**Version:** v0.8.0 | **Tests:** 176 unit, 58 integration | **Coverage:** 98%
 
 ## Commands
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,38 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.0] - 2026-03-22
+
+### Added
+
+- Structured location support: geo coordinates, radius, map pins via `EKStructuredLocation` (#175, #176)
+- Event organizer details: `organizer_name`, `organizer_email`, `organizer_status` (#163, #169)
+- Creation/modification timestamps: `created_date`, `modified_date` (#164, #169)
+- Event timezone read-back: returns IANA identifier for cross-timezone events (#166, #174)
+- Default calendar: `is_default` field in `get_calendars`, `calendar_name` optional on `create_events` (#165, #173)
+- Calendar name in `_format_event` output for search → update/delete chaining (#171, #172)
+- Cross-calendar queries: `get_events` and `search_events` accept `calendar_names: list[str]` (#185, #191)
+- Unimplemented capabilities audit in gap analysis (#161, #162)
+
+### Changed
+
+- **Breaking:** `get_events` and `search_events`: `calendar_name` → `calendar_names` (list, optional, empty = all calendars) (#185, #191)
+- **Breaking:** `create_events`/`update_events` JSON input: `start`/`end` → `start_date`/`end_date` (matches get_events output) (#178, #187)
+- **Breaking:** `delete_events`: `event_uid` → `event_uids` (matches connector, plural behavior) (#180, #189)
+- `get_availability` and `get_conflicts` now use single Swift call instead of per-calendar Python loop (#185, #191)
+- Cyclomatic complexity reduced: `get_availability` 19→6, `search_events` 14→4, via 6 extracted helpers (#158, #193)
+- Release skill expanded to 12 phases with test coverage, code review, and documentation review gates (#160, #196)
+
+### Fixed
+
+- Stale disambiguation guidance in `tool_descriptions.md`: "use description" → "use source field" (#177, #186)
+- `get_availability` Returns docstring: "duration formatted" → `duration_minutes` (integer) (#181, #186)
+- `working_hours_start`/`working_hours_end` paired requirement documented (#183, #186)
+- `is_default` rendered in `_format_calendar` output (#184, #186)
+- "UID in wrong calendar" error recovery path documented (#182, #190)
+- Resolved calendar name shown in success message when using default (#179, #188)
+- Blind eval scoring: scenarios 23/27 accept `clear_*` flags (both approaches valid) (#192, #197)
+
 ## [0.7.0] - 2026-03-21
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "apple-calendar-mcp"
-version = "0.7.0"
+version = "0.8.0"
 description = "MCP server for Apple Calendar integration"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/apple_calendar_mcp/__init__.py
+++ b/src/apple_calendar_mcp/__init__.py
@@ -1,3 +1,3 @@
 """Apple Calendar MCP Server."""
 
-__version__ = "0.7.0"
+__version__ = "0.8.0"


### PR DESCRIPTION
## Release v0.8.0

Breaking API changes for consistency, plus new features and infrastructure improvements.

### Highlights (36 issues closed)

**Breaking API Changes:**
- `get_events`/`search_events`: `calendar_name` → `calendar_names: list[str]` (optional, empty = all calendars)
- `create_events`/`update_events` JSON: `start`/`end` → `start_date`/`end_date` (matches get_events output)
- `delete_events`: `event_uid` → `event_uids`

**New Features:**
- Structured location: geo coordinates, radius, map pins via EKStructuredLocation
- Cross-calendar queries: single Swift call for multi-calendar events
- Default calendar: `is_default` field, optional `calendar_name` on create_events
- Event timezone read-back, organizer details, creation/modification timestamps

**Quality:**
- Cyclomatic complexity: get_availability 19→6, search_events 14→4
- Release skill expanded to 12 phases with review gates
- Blind eval scores: Claude 100%, DeepSeek 93%, Mistral 92%, Qwen 91%, Llama 83%

### Validation
- [x] Version sync: 0.8.0 across pyproject.toml, CLAUDE.md, __init__.py
- [x] Complexity: all functions within threshold
- [x] Parity: 10 connector functions = 10 MCP tools
- [x] Coverage: 98.10% (176 unit tests)
- [x] Integration: 57/58 passed (1 pre-existing flaky test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)