### PR TITLE
Add source-aware disambiguation to write operations (#200)

### DIFF
--- a/evals/agent_tool_usability/tool_descriptions.md
+++ b/evals/agent_tool_usability/tool_descriptions.md
@@ -67,6 +67,7 @@ For a single event, pass an array with one element. All events go to the same ca
 **Parameters:**
 - `calendar_name` (str, optional, default: ""): Name of the target calendar. If omitted, uses the system default calendar.
 - `events` (str, required): JSON array of event objects. Each object has keys: summary (required), start_date (required, ISO 8601), end_date (required, ISO 8601), and optional: location, notes, url, allday (bool), recurrence (RRULE string), alerts (list of minutes, e.g. [15, 60]), availability ("free"/"busy"/"tentative"), timezone (IANA identifier, e.g. "America/Los_Angeles" — use to schedule in a remote timezone rather than converting times manually), structured_location (object with title, latitude, longitude, radius — adds map pin and geo coordinates). For all-day events, set allday=true and use date-only format. end is inclusive for all-day events.
+- `calendar_source` (str, optional, default: ""): Source/account name to disambiguate calendars with the same name (e.g., "iCloud", "Google"). Use get_calendars to see source values.
 
 **Returns:** Each created event with title and UID. Use these UIDs with update_events or delete_events. Any per-event errors are listed separately. Partial success is possible — some events may be created while others fail.
 
@@ -85,6 +86,7 @@ For recurring events: use occurrence_date to target a specific occurrence, and s
 **Parameters:**
 - `calendar_name` (str, required): Exact name of the calendar containing the events. If a UID exists in a different calendar, use search_events to find the correct calendar_name.
 - `updates` (str, required): JSON array of update objects. Each object must have "uid" (required) and at least one field to update: summary, start_date (ISO 8601), end_date (ISO 8601), location, notes, url, allday (bool), alerts (list of minutes), availability ("free"/"busy"/"tentative"), timezone (IANA identifier), recurrence (RRULE string), clear_location (bool), clear_notes (bool), clear_url (bool), clear_alerts (bool), clear_recurrence (bool). For recurring events: occurrence_date (ISO 8601) to target specific occurrence, span ("this_event" or "future_events", default "this_event").
+- `calendar_source` (str, optional, default: ""): Source/account name to disambiguate calendars with the same name (e.g., "iCloud", "Google"). Use get_calendars to see source values.
 
 **Returns:** Summary of updated events, each with title and list of changed fields. Any per-event errors are listed separately. Partial success is possible. Note: when rescheduling a recurring event occurrence (changing dates with span="this_event"), a new standalone event is created — the returned UID may differ.
 
@@ -173,5 +175,6 @@ For recurring events: use occurrence_date to target a specific occurrence, and s
 - `event_uids` (str | list[str], required): UID of a single event (str) or list of UIDs to delete
 - `span` (str, optional, default: "this_event"): "this_event" to delete one occurrence, "future_events" to delete the series from this point onward
 - `occurrence_date` (str, optional, default: ""): For recurring events, the occurrence_date from get_events to target a specific occurrence
+- `calendar_source` (str, optional, default: ""): Source/account name to disambiguate calendars with the same name (e.g., "iCloud", "Google"). Use get_calendars to see source values.
 
 **Returns:** Count of deleted events. Any UIDs not found are listed separately — these don't cause the operation to fail.

--- a/src/apple_calendar_mcp/calendar_connector.py
+++ b/src/apple_calendar_mcp/calendar_connector.py
@@ -132,6 +132,7 @@ class CalendarConnector:
         self,
         calendar_name: str = "",
         events: list[dict[str, Any]] | None = None,
+        calendar_source: str = "",
     ) -> dict[str, Any]:
         """Create one or more events in a calendar.
 
@@ -141,6 +142,8 @@ class CalendarConnector:
             events: List of event dicts, each with keys: summary, start, end,
                     and optional: location, notes, url, allday, recurrence,
                     alerts (list of int), availability, timezone
+            calendar_source: Source/account name to disambiguate calendars with
+                           the same name (e.g., 'iCloud', 'Google').
 
         Returns:
             Dict with 'created' (list of {uid, summary}) and 'errors' (list of {index, summary, error})
@@ -151,15 +154,20 @@ class CalendarConnector:
         if not events:
             raise ValueError("At least one event must be provided")
 
+        args = ["--calendar", calendar_name]
+        if calendar_source:
+            args += ["--source", calendar_source]
+
         stdin_data = json.dumps(events)
         return self._run_swift_helper_json(
-            "create_events", ["--calendar", calendar_name], stdin_data=stdin_data
+            "create_events", args, stdin_data=stdin_data
         )
 
     def update_events(
         self,
         calendar_name: str,
         updates: list[dict[str, Any]],
+        calendar_source: str = "",
     ) -> dict[str, Any]:
         """Update one or more events in a single batch operation.
 
@@ -171,6 +179,8 @@ class CalendarConnector:
                      clear_notes, clear_url, clear_alerts, clear_recurrence.
                      For recurring events: occurrence_date (ISO 8601) to target a specific
                      occurrence, span ("this_event" or "future_events", default "this_event").
+            calendar_source: Source/account name to disambiguate calendars with
+                           the same name (e.g., 'iCloud', 'Google').
 
         Returns:
             Dict with 'updated' (list of {uid, summary, updated_fields}) and 'errors'.
@@ -183,9 +193,13 @@ class CalendarConnector:
         if not updates:
             raise ValueError("At least one update must be provided")
 
+        args = ["--calendar", calendar_name]
+        if calendar_source:
+            args += ["--source", calendar_source]
+
         stdin_data = json.dumps(updates)
         return self._run_swift_helper_json(
-            "update_events", ["--calendar", calendar_name], stdin_data=stdin_data
+            "update_events", args, stdin_data=stdin_data
         )
 
     def _normalize_calendar_names(
@@ -399,6 +413,7 @@ class CalendarConnector:
         event_uids: str | list[str],
         span: str = "this_event",
         occurrence_date: Optional[str] = None,
+        calendar_source: str = "",
     ) -> dict[str, Any]:
         """Delete one or more events by UID.
 
@@ -407,6 +422,8 @@ class CalendarConnector:
             event_uids: Single UID string or list of UIDs to delete
             span: "this_event" to delete one occurrence, "future_events" to delete series from this point (default: "this_event")
             occurrence_date: For recurring events, the date of the specific occurrence to delete (optional)
+            calendar_source: Source/account name to disambiguate calendars with
+                           the same name (e.g., 'iCloud', 'Google').
 
         Returns:
             Dict with 'deleted_uids' and 'not_found_uids' keys
@@ -422,6 +439,8 @@ class CalendarConnector:
             raise ValueError("At least one event UID must be provided")
 
         args = ["--calendar", calendar_name]
+        if calendar_source:
+            args += ["--source", calendar_source]
         for uid in uids:
             args += ["--uid", uid]
         if span != "this_event":

--- a/src/apple_calendar_mcp/server_fastmcp.py
+++ b/src/apple_calendar_mcp/server_fastmcp.py
@@ -126,6 +126,7 @@ def delete_calendar(name: str) -> str:
 def create_events(
     calendar_name: str = "",
     events: str = "",
+    calendar_source: str = "",
 ) -> str:
     """Create one or more events in a calendar.
 
@@ -144,6 +145,8 @@ def create_events(
                 map pin and geo coordinates to the event).
                 For all-day events, set allday=true and use date-only format.
                 end is inclusive for all-day events.
+        calendar_source: Source/account name to disambiguate calendars with the same name
+                        (e.g., "iCloud", "Google"). Use get_calendars to see source values.
 
     Returns:
         Each created event with title and UID. Use these UIDs with update_events or
@@ -163,6 +166,7 @@ def create_events(
         result = client.create_events(
             calendar_name=calendar_name,
             events=event_list,
+            calendar_source=calendar_source,
         )
     except Exception as e:
         return f"Error creating events: {e}"
@@ -185,6 +189,7 @@ def create_events(
 def update_events(
     calendar_name: str,
     updates: str,
+    calendar_source: str = "",
 ) -> str:
     """Update one or more events in a calendar.
 
@@ -205,6 +210,8 @@ def update_events(
                  clear_url (bool), clear_alerts (bool), clear_recurrence (bool).
                  For recurring events: occurrence_date (ISO 8601) to target specific occurrence,
                  span ("this_event" or "future_events", default "this_event").
+        calendar_source: Source/account name to disambiguate calendars with the same name
+                        (e.g., "iCloud", "Google"). Use get_calendars to see source values.
 
     Returns:
         Summary of updated events, each with title and list of changed fields. Any per-event
@@ -225,6 +232,7 @@ def update_events(
         result = client.update_events(
             calendar_name=calendar_name,
             updates=update_list,
+            calendar_source=calendar_source,
         )
     except Exception as e:
         return f"Error updating events: {e}"
@@ -530,6 +538,7 @@ def delete_events(
     event_uids: str | list[str] = "",
     span: str = "this_event",
     occurrence_date: str = "",
+    calendar_source: str = "",
 ) -> str:
     """Delete one or more events from a calendar by UID.
 
@@ -549,6 +558,8 @@ def delete_events(
         event_uids: UID of a single event (str) or list of UIDs to delete
         span: "this_event" to delete one occurrence, "future_events" to delete the series from this point onward (default: "this_event")
         occurrence_date: For recurring events, the occurrence_date from get_events to target a specific occurrence (optional)
+        calendar_source: Source/account name to disambiguate calendars with the same name
+                        (e.g., "iCloud", "Google"). Use get_calendars to see source values.
 
     Returns:
         Count of deleted events. Any UIDs not found are listed separately — these don't cause
@@ -561,6 +572,7 @@ def delete_events(
             event_uids=event_uids,
             span=span,
             occurrence_date=occurrence_date or None,
+            calendar_source=calendar_source,
         )
     except Exception as e:
         return f"Error deleting event(s): {e}"

--- a/src/apple_calendar_mcp/swift/create_events.swift
+++ b/src/apple_calendar_mcp/swift/create_events.swift
@@ -4,18 +4,27 @@ import Foundation
 
 // MARK: - Argument Parsing
 
-func parseArgs() -> String? {
-    let args = CommandLine.arguments
-    var calendar: String?
+struct CreateEventsArgs {
+    var calendar: String = ""
+    var source: String = ""
+}
 
+func parseArgs() -> CreateEventsArgs {
+    var result = CreateEventsArgs()
+    let args = CommandLine.arguments
     var i = 1
     while i < args.count {
-        if args[i] == "--calendar" {
-            i += 1; if i < args.count { calendar = args[i] }
+        switch args[i] {
+        case "--calendar":
+            i += 1; if i < args.count { result.calendar = args[i] }
+        case "--source":
+            i += 1; if i < args.count { result.source = args[i] }
+        default:
+            break
         }
         i += 1
     }
-    return calendar
+    return result
 }
 
 // MARK: - Date Parsing
@@ -111,7 +120,9 @@ func outputError(_ error: String, _ message: String) {
 
 // MARK: - Main
 
-let calendarName = parseArgs() ?? ""
+let parsed = parseArgs()
+let calendarName = parsed.calendar
+let sourceName = parsed.source
 
 // Read JSON from stdin
 let stdinData = FileHandle.standardInput.readDataToEndOfFile()
@@ -144,9 +155,10 @@ if calendarName.isEmpty {
     }
     calendar = defaultCal
 } else {
-    guard let found = store.calendars(for: .event).first(where: { $0.title == calendarName }) else {
-        let available = store.calendars(for: .event).map { $0.title }.joined(separator: ", ")
-        outputError("calendar_not_found", "Calendar '\(calendarName)' not found. Available: \(available)")
+    guard let found = store.calendars(for: .event).first(where: { $0.title == calendarName && (sourceName.isEmpty || $0.source.title == sourceName) }) else {
+        let displayName = sourceName.isEmpty ? calendarName : "\(calendarName) (\(sourceName))"
+        let available = store.calendars(for: .event).map { "\($0.title) (\($0.source.title))" }.joined(separator: ", ")
+        outputError("calendar_not_found", "Calendar '\(displayName)' not found. Available: \(available)")
         exit(1)
     }
     calendar = found

--- a/src/apple_calendar_mcp/swift/delete_events.swift
+++ b/src/apple_calendar_mcp/swift/delete_events.swift
@@ -3,34 +3,41 @@ import Foundation
 
 // MARK: - Argument Parsing
 
-func parseArgs() -> (calendar: String, uids: [String], span: EKSpan, occurrenceDate: String?)? {
-    let args = CommandLine.arguments
-    var calendar: String?
+struct DeleteEventsArgs {
+    var calendar: String = ""
+    var source: String = ""
     var uids: [String] = []
     var span: EKSpan = .thisEvent
     var occurrenceDate: String?
+}
+
+func parseArgs() -> DeleteEventsArgs? {
+    var result = DeleteEventsArgs()
+    let args = CommandLine.arguments
 
     var i = 1
     while i < args.count {
         switch args[i] {
         case "--calendar":
-            i += 1; if i < args.count { calendar = args[i] }
+            i += 1; if i < args.count { result.calendar = args[i] }
+        case "--source":
+            i += 1; if i < args.count { result.source = args[i] }
         case "--uid":
-            i += 1; if i < args.count { uids.append(args[i]) }
+            i += 1; if i < args.count { result.uids.append(args[i]) }
         case "--span":
-            i += 1; if i < args.count { span = args[i] == "future_events" ? .futureEvents : .thisEvent }
+            i += 1; if i < args.count { result.span = args[i] == "future_events" ? .futureEvents : .thisEvent }
         case "--occurrence-date":
-            i += 1; if i < args.count { occurrenceDate = args[i] }
+            i += 1; if i < args.count { result.occurrenceDate = args[i] }
         default:
             break
         }
         i += 1
     }
 
-    guard let cal = calendar, !uids.isEmpty else {
+    guard !result.calendar.isEmpty, !result.uids.isEmpty else {
         return nil
     }
-    return (cal, uids, span, occurrenceDate)
+    return result
 }
 
 // MARK: - Date Parsing
@@ -87,11 +94,12 @@ if !accessGranted {
 
 store.refreshSourcesIfNecessary()
 
-// Find the calendar by name
+// Find the calendar by name (and optionally source)
 let allCalendars = store.calendars(for: .event)
-guard let calendar = allCalendars.first(where: { $0.title == parsed.calendar }) else {
-    let available = allCalendars.map { $0.title }.joined(separator: ", ")
-    outputError("calendar_not_found", "Calendar '\(parsed.calendar)' not found. Available: \(available)")
+guard let calendar = allCalendars.first(where: { $0.title == parsed.calendar && (parsed.source.isEmpty || $0.source.title == parsed.source) }) else {
+    let displayName = parsed.source.isEmpty ? parsed.calendar : "\(parsed.calendar) (\(parsed.source))"
+    let available = allCalendars.map { "\($0.title) (\($0.source.title))" }.joined(separator: ", ")
+    outputError("calendar_not_found", "Calendar '\(displayName)' not found. Available: \(available)")
     exit(1)
 }
 

--- a/src/apple_calendar_mcp/swift/update_events.swift
+++ b/src/apple_calendar_mcp/swift/update_events.swift
@@ -4,15 +4,27 @@ import Foundation
 
 // MARK: - Argument Parsing
 
-func parseArgs() -> String? {
+struct UpdateEventsArgs {
+    var calendar: String = ""
+    var source: String = ""
+}
+
+func parseArgs() -> UpdateEventsArgs {
+    var result = UpdateEventsArgs()
     let args = CommandLine.arguments
-    var calendar: String?
     var i = 1
     while i < args.count {
-        if args[i] == "--calendar" { i += 1; if i < args.count { calendar = args[i] } }
+        switch args[i] {
+        case "--calendar":
+            i += 1; if i < args.count { result.calendar = args[i] }
+        case "--source":
+            i += 1; if i < args.count { result.source = args[i] }
+        default:
+            break
+        }
         i += 1
     }
-    return calendar
+    return result
 }
 
 // MARK: - Date Parsing
@@ -108,7 +120,11 @@ func outputError(_ error: String, _ message: String) {
 
 // MARK: - Main
 
-guard let calendarName = parseArgs() else {
+let parsed = parseArgs()
+let calendarName = parsed.calendar
+let sourceName = parsed.source
+
+guard !calendarName.isEmpty else {
     outputError("invalid_args", "Required: --calendar <name>. Update data is read from stdin as JSON array.")
     exit(1)
 }
@@ -135,9 +151,10 @@ if !accessGranted {
 
 store.refreshSourcesIfNecessary()
 
-guard let calendar = store.calendars(for: .event).first(where: { $0.title == calendarName }) else {
-    let available = store.calendars(for: .event).map { $0.title }.joined(separator: ", ")
-    outputError("calendar_not_found", "Calendar '\(calendarName)' not found. Available: \(available)")
+guard let calendar = store.calendars(for: .event).first(where: { $0.title == calendarName && (sourceName.isEmpty || $0.source.title == sourceName) }) else {
+    let displayName = sourceName.isEmpty ? calendarName : "\(calendarName) (\(sourceName))"
+    let available = store.calendars(for: .event).map { "\($0.title) (\($0.source.title))" }.joined(separator: ", ")
+    outputError("calendar_not_found", "Calendar '\(displayName)' not found. Available: \(available)")
     exit(1)
 }
 

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -433,6 +433,7 @@ class TestDeleteEventsTool:
             event_uids=["UID-1", "UID-2"],
             span="this_event",
             occurrence_date=None,
+            calendar_source="",
         )
 
 
@@ -813,6 +814,7 @@ class TestDeleteEventsToolBranches:
             event_uids="UID-1",
             span="this_event",
             occurrence_date=None,
+            calendar_source="",
         )
         assert "Deleted 1 event(s)" in result
 


### PR DESCRIPTION
## Summary

All write operations now accept optional `calendar_source` to disambiguate when multiple calendars share a name.

- `create_events(calendar_source="iCloud")` — targets the iCloud "Family" calendar, not the Google one
- `update_events(calendar_source="Google")` — same
- `delete_events(calendar_source="iCloud")` — same

Swift helpers filter by both `title` and `source.title` when `--source` is provided. Backward compatible — omitting source matches any account (existing behavior).

## Test plan
- [x] `make test-unit` — 176 passed

Closes #200

🤖 Generated with [Claude Code](https://claude.com/claude-code)