### PR TITLE
Make get_conflicts and get_availability accept empty calendar_names (#202)

### DIFF
--- a/evals/agent_tool_usability/tool_descriptions.md
+++ b/evals/agent_tool_usability/tool_descriptions.md
@@ -132,7 +132,7 @@ Queries all specified calendars, merges busy periods, and returns available (fre
 Use get_calendars first to find available calendar names.
 
 **Parameters:**
-- `calendar_names` (list[str], required): List of calendar names to check for combined availability
+- `calendar_names` (list[str], optional, default: []): List of calendar names to check for combined availability. If empty, checks all calendars.
 - `start_date` (str, required): Start of range in ISO 8601 format (e.g., "2026-03-15T09:00:00")
 - `end_date` (str, required): End of range in ISO 8601 format (e.g., "2026-03-15T17:00:00")
 - `min_duration_minutes` (int | None, optional, default: None): Only return slots of at least this many minutes (e.g., 45)
@@ -152,7 +152,7 @@ Finds all pairs of events that overlap in time within the date range. Useful for
 Use get_calendars first to find available calendar names.
 
 **Parameters:**
-- `calendar_names` (list[str], required): List of calendar names to check for conflicts
+- `calendar_names` (list[str], optional, default: []): List of calendar names to check for conflicts. If empty, checks all calendars.
 - `start_date` (str, required): Start of range in ISO 8601 format (e.g., "2026-03-15T00:00:00")
 - `end_date` (str, required): End of range in ISO 8601 format (e.g., "2026-03-22T00:00:00")
 

--- a/src/apple_calendar_mcp/calendar_connector.py
+++ b/src/apple_calendar_mcp/calendar_connector.py
@@ -605,9 +605,6 @@ class CalendarConnector:
 
         wh = self._validate_working_hours(working_hours_start, working_hours_end)
 
-        if not calendar_names:
-            raise ValueError("At least one calendar name must be provided")
-
         range_start = self._parse_iso_datetime(start_date)
         range_end = self._parse_iso_datetime(end_date)
 
@@ -645,10 +642,7 @@ class CalendarConnector:
             ValueError: If date format is invalid, calendar not found, or no calendars provided
             PermissionError: If EventKit calendar access is denied
         """
-        if not calendar_names:
-            raise ValueError("At least one calendar name must be provided")
-
-        all_events = self.get_events(calendar_names, start_date, end_date)
+        all_events = self.get_events(calendar_names or [], start_date, end_date)
 
         # Filter out free events — only busy/tentative can conflict
         busy_events = [

--- a/src/apple_calendar_mcp/server_fastmcp.py
+++ b/src/apple_calendar_mcp/server_fastmcp.py
@@ -436,7 +436,7 @@ def get_availability(
     Use get_calendars first to find available calendar names.
 
     Args:
-        calendar_names: List of calendar names to check for combined availability
+        calendar_names: List of calendar names to check for combined availability. If empty, checks all calendars.
         start_date: Start of range in ISO 8601 format (e.g., "2026-03-15T09:00:00")
         end_date: End of range in ISO 8601 format (e.g., "2026-03-15T17:00:00")
         min_duration_minutes: Only return slots of at least this many minutes (e.g., 45)
@@ -503,7 +503,7 @@ def get_conflicts(
     Use get_calendars first to find available calendar names.
 
     Args:
-        calendar_names: List of calendar names to check for conflicts
+        calendar_names: List of calendar names to check for conflicts. If empty, checks all calendars.
         start_date: Start of range in ISO 8601 format (e.g., "2026-03-15T00:00:00")
         end_date: End of range in ISO 8601 format (e.g., "2026-03-22T00:00:00")
 

--- a/tests/unit/test_calendar_connector.py
+++ b/tests/unit/test_calendar_connector.py
@@ -594,10 +594,6 @@ class TestGetAvailability:
         with pytest.raises(ValueError, match="Invalid date format"):
             self.connector.get_availability(["Work"], "2026-03-15T00:00:00", "not-a-date")
 
-    def test_empty_calendar_list_raises(self):
-        with pytest.raises(ValueError, match="At least one calendar"):
-            self.connector.get_availability([], "2026-03-15T00:00:00", "2026-03-16T00:00:00")
-
     @patch("apple_calendar_mcp.calendar_connector.run_swift_helper")
     def test_multiple_calendars_combined(self, mock_swift):
         """Events from multiple calendars should be merged for availability."""
@@ -884,11 +880,6 @@ class TestGetConflicts:
         ]
         result = self.connector.get_conflicts(["Work"], "2026-03-15", "2026-03-16")
         assert result == []
-
-    def test_empty_calendar_list_raises(self):
-        with pytest.raises(ValueError, match="At least one calendar"):
-            self.connector.get_conflicts([], "2026-03-15", "2026-03-16")
-
 
 class TestParseTimeString:
     """Tests for CalendarConnector._parse_time_string()."""


### PR DESCRIPTION
## Summary

Empty `calendar_names` now means "all calendars" for get_conflicts and get_availability, matching get_events and search_events. Consistent pattern across all 4 query tools.

## Test plan
- [x] `make test-unit` — 174 passed

Closes #202

🤖 Generated with [Claude Code](https://claude.com/claude-code)