### PR TITLE
release: v0.8.1

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -3,7 +3,7 @@
 An MCP server bridging Claude and Apple Calendar via AppleScript and EventKit on macOS.
 
 **Stack:** Python 3.10+, FastMCP, AppleScript (via `osascript`), Swift/EventKit (via `swift`)
-**Version:** v0.8.0 | **Tests:** 176 unit, 58 integration | **Coverage:** 98%
+**Version:** v0.8.1 | **Tests:** 174 unit, 58 integration | **Coverage:** 98%
 
 ## Commands
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.1] - 2026-03-22
+
+### Added
+
+- Source-aware disambiguation: `calendar_source` parameter on `create_events`, `update_events`, `delete_events` for targeting specific accounts when calendar names are duplicated (#200, #205)
+- `get_conflicts` and `get_availability` accept empty `calendar_names` for all-calendar queries, matching `get_events` pattern (#202, #206)
+
+### Fixed
+
+- Recurring event deletion warning strengthened: "may affect" → "WILL delete all occurrences." Added guidance to check `is_recurring` before deleting (#199, #204)
+- Documented `allday=true` requirement when updating dates on all-day events (#201, #207)
+
 ## [0.8.0] - 2026-03-22
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "apple-calendar-mcp"
-version = "0.8.0"
+version = "0.8.1"
 description = "MCP server for Apple Calendar integration"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/apple_calendar_mcp/__init__.py
+++ b/src/apple_calendar_mcp/__init__.py
@@ -1,3 +1,3 @@
 """Apple Calendar MCP Server."""
 
-__version__ = "0.8.0"
+__version__ = "0.8.1"


### PR DESCRIPTION
## Release v0.8.1

Adversarial API review fixes — usability hardening for benevolent agents.

### Changes (10 issues closed)
- Source-aware disambiguation on write operations (#200)
- Consistent empty calendar_names = all calendars (#202)
- Recurring deletion warning strengthened (#199)
- Allday flag requirement documented (#201)

### Validation
- [x] Version sync, complexity, unit tests all pass
- [x] Coverage: 97.48% (above 90% threshold)