### PR TITLE
Remove calendar enumeration from error messages (#211)

### DIFF
--- a/src/apple_calendar_mcp/swift/create_calendar.swift
+++ b/src/apple_calendar_mcp/swift/create_calendar.swift
@@ -72,8 +72,7 @@ var sourcesToTry: [EKSource] = []
 if !parsed.source.isEmpty {
     // User specified a source — try only that one
     guard let source = store.sources.first(where: { $0.title == parsed.source }) else {
-        let available = store.sources.map { "\($0.title) (\($0.sourceType.rawValue))" }.joined(separator: ", ")
-        outputError("source_not_found", "Source '\(parsed.source)' not found. Available: \(available)")
+        outputError("source_not_found", "Source '\(parsed.source)' not found. Use get_calendars to see available sources.")
         exit(1)
     }
     sourcesToTry = [source]

--- a/src/apple_calendar_mcp/swift/create_events.swift
+++ b/src/apple_calendar_mcp/swift/create_events.swift
@@ -157,8 +157,7 @@ if calendarName.isEmpty {
 } else {
     guard let found = store.calendars(for: .event).first(where: { $0.title == calendarName && (sourceName.isEmpty || $0.source.title == sourceName) }) else {
         let displayName = sourceName.isEmpty ? calendarName : "\(calendarName) (\(sourceName))"
-        let available = store.calendars(for: .event).map { "\($0.title) (\($0.source.title))" }.joined(separator: ", ")
-        outputError("calendar_not_found", "Calendar '\(displayName)' not found. Available: \(available)")
+        outputError("calendar_not_found", "Calendar '\(displayName)' not found. Use get_calendars to see available names.")
         exit(1)
     }
     calendar = found

--- a/src/apple_calendar_mcp/swift/delete_calendar.swift
+++ b/src/apple_calendar_mcp/swift/delete_calendar.swift
@@ -67,8 +67,7 @@ store.refreshSourcesIfNecessary()
 let calendars = store.calendars(for: .event).filter { $0.title == parsed.name }
 
 guard let calendar = calendars.first else {
-    let available = store.calendars(for: .event).map { $0.title }.joined(separator: ", ")
-    outputError("calendar_not_found", "Calendar '\(parsed.name)' not found. Available: \(available)")
+    outputError("calendar_not_found", "Calendar '\(parsed.name)' not found. Use get_calendars to see available names.")
     exit(1)
 }
 

--- a/src/apple_calendar_mcp/swift/delete_events.swift
+++ b/src/apple_calendar_mcp/swift/delete_events.swift
@@ -98,8 +98,7 @@ store.refreshSourcesIfNecessary()
 let allCalendars = store.calendars(for: .event)
 guard let calendar = allCalendars.first(where: { $0.title == parsed.calendar && (parsed.source.isEmpty || $0.source.title == parsed.source) }) else {
     let displayName = parsed.source.isEmpty ? parsed.calendar : "\(parsed.calendar) (\(parsed.source))"
-    let available = allCalendars.map { "\($0.title) (\($0.source.title))" }.joined(separator: ", ")
-    outputError("calendar_not_found", "Calendar '\(displayName)' not found. Available: \(available)")
+    outputError("calendar_not_found", "Calendar '\(displayName)' not found. Use get_calendars to see available names.")
     exit(1)
 }
 

--- a/src/apple_calendar_mcp/swift/get_events.swift
+++ b/src/apple_calendar_mcp/swift/get_events.swift
@@ -263,8 +263,7 @@ if parsed.calendars.isEmpty {
     var resolved: [EKCalendar] = []
     for calName in parsed.calendars {
         guard let cal = allCalendars.first(where: { $0.title == calName }) else {
-            let available = allCalendars.map { $0.title }.joined(separator: ", ")
-            outputError("calendar_not_found", "Calendar '\(calName)' not found. Available: \(available)")
+            outputError("calendar_not_found", "Calendar '\(calName)' not found. Use get_calendars to see available names.")
             exit(1)
         }
         resolved.append(cal)

--- a/src/apple_calendar_mcp/swift/update_events.swift
+++ b/src/apple_calendar_mcp/swift/update_events.swift
@@ -153,8 +153,7 @@ store.refreshSourcesIfNecessary()
 
 guard let calendar = store.calendars(for: .event).first(where: { $0.title == calendarName && (sourceName.isEmpty || $0.source.title == sourceName) }) else {
     let displayName = sourceName.isEmpty ? calendarName : "\(calendarName) (\(sourceName))"
-    let available = store.calendars(for: .event).map { "\($0.title) (\($0.source.title))" }.joined(separator: ", ")
-    outputError("calendar_not_found", "Calendar '\(displayName)' not found. Available: \(available)")
+    outputError("calendar_not_found", "Calendar '\(displayName)' not found. Use get_calendars to see available names.")
     exit(1)
 }
 


### PR DESCRIPTION
## Summary
- Removed "Available: ..." lists from all 6 calendar/source-not-found error messages across 5 Swift helpers
- Replaced with "Use get_calendars to see available names." — actionable guidance without leaking private calendar names
- A bogus calendar_name no longer triggers full calendar enumeration via MCP

## Files changed
- `get_events.swift`, `create_events.swift`, `update_events.swift`, `delete_events.swift`, `delete_calendar.swift`, `create_calendar.swift`

## Test plan
- [x] `make test` — 174 passed

Closes #211

🤖 Generated with [Claude Code](https://claude.com/claude-code)