### PR TITLE
Fix create_events safety bypass when calendar_name is empty (#213)

### DIFF
--- a/src/apple_calendar_mcp/calendar_connector.py
+++ b/src/apple_calendar_mcp/calendar_connector.py
@@ -149,6 +149,11 @@ class CalendarConnector:
         Returns:
             Dict with 'created' (list of {uid, summary}) and 'errors' (list of {index, summary, error})
         """
+        if self.enable_safety_checks and not calendar_name:
+            raise CalendarSafetyError(
+                "calendar_name is required when safety checks are enabled "
+                "(empty name would target the default calendar)"
+            )
         if calendar_name:
             self._verify_calendar_safety(calendar_name)
 

--- a/tests/unit/test_calendar_connector.py
+++ b/tests/unit/test_calendar_connector.py
@@ -1066,6 +1066,11 @@ class TestCreateEvents:
         with pytest.raises(CalendarSafetyError):
             connector.create_events("Personal", [{"summary": "Test"}])
 
+    def test_safety_blocks_empty_calendar_name(self):
+        connector = CalendarConnector(enable_safety_checks=True)
+        with pytest.raises(CalendarSafetyError, match="calendar_name is required"):
+            connector.create_events("", [{"summary": "Test"}])
+
 
 # ── update_events (batch) ─────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- Empty `calendar_name` now raises `CalendarSafetyError` when safety checks are enabled
- Previously `if calendar_name:` was falsy for `""`, skipping the safety check and writing to the system default calendar in test mode

## Test plan
- [x] `make test` — 176 passed (1 new test)

Closes #213

🤖 Generated with [Claude Code](https://claude.com/claude-code)