### PR TITLE
Add per-call batch size limits to create, update, and delete (#214)

### DIFF
--- a/src/apple_calendar_mcp/calendar_connector.py
+++ b/src/apple_calendar_mcp/calendar_connector.py
@@ -87,6 +87,7 @@ class CalendarConnector:
         "MCP-Test-Calendar",
         "MCP-Test-Calendar-2",
     }
+    MAX_BATCH_SIZE = 50
 
     def __init__(self, enable_safety_checks: bool = True):
         self.enable_safety_checks = enable_safety_checks
@@ -159,6 +160,11 @@ class CalendarConnector:
 
         if not events:
             raise ValueError("At least one event must be provided")
+        if len(events) > self.MAX_BATCH_SIZE:
+            raise ValueError(
+                f"Batch size {len(events)} exceeds limit of {self.MAX_BATCH_SIZE}. "
+                f"Split into multiple calls."
+            )
 
         args = ["--calendar", calendar_name]
         if calendar_source:
@@ -198,6 +204,11 @@ class CalendarConnector:
 
         if not updates:
             raise ValueError("At least one update must be provided")
+        if len(updates) > self.MAX_BATCH_SIZE:
+            raise ValueError(
+                f"Batch size {len(updates)} exceeds limit of {self.MAX_BATCH_SIZE}. "
+                f"Split into multiple calls."
+            )
 
         args = ["--calendar", calendar_name]
         if calendar_source:
@@ -443,6 +454,11 @@ class CalendarConnector:
         uids = [event_uids] if isinstance(event_uids, str) else event_uids
         if not uids:
             raise ValueError("At least one event UID must be provided")
+        if len(uids) > self.MAX_BATCH_SIZE:
+            raise ValueError(
+                f"Batch size {len(uids)} exceeds limit of {self.MAX_BATCH_SIZE}. "
+                f"Split into multiple calls."
+            )
 
         args = ["--calendar", calendar_name]
         if calendar_source:

--- a/tests/unit/test_calendar_connector.py
+++ b/tests/unit/test_calendar_connector.py
@@ -986,6 +986,11 @@ class TestDeleteEvents:
         args = mock_swift.call_args[0][1]
         assert "--span" not in args
 
+    def test_exceeds_batch_limit(self):
+        uids = [f"UID-{i}" for i in range(51)]
+        with pytest.raises(ValueError, match="exceeds limit of 50"):
+            self.connector.delete_events("MCP-Test-Calendar", uids)
+
 
 # ── _run_swift_helper_json error handling ─────────────────────────────────
 
@@ -1071,6 +1076,11 @@ class TestCreateEvents:
         with pytest.raises(CalendarSafetyError, match="calendar_name is required"):
             connector.create_events("", [{"summary": "Test"}])
 
+    def test_exceeds_batch_limit(self):
+        events = [{"summary": f"Event {i}"} for i in range(51)]
+        with pytest.raises(ValueError, match="exceeds limit of 50"):
+            self.connector.create_events("MCP-Test-Calendar", events)
+
 
 # ── update_events (batch) ─────────────────────────────────────────────────
 
@@ -1118,6 +1128,11 @@ class TestUpdateEvents:
         connector = CalendarConnector(enable_safety_checks=True)
         with pytest.raises(CalendarSafetyError):
             connector.update_events("Personal", [{"uid": "UID-1", "summary": "Test"}])
+
+    def test_exceeds_batch_limit(self):
+        updates = [{"uid": f"UID-{i}", "summary": f"Event {i}"} for i in range(51)]
+        with pytest.raises(ValueError, match="exceeds limit of 50"):
+            self.connector.update_events("MCP-Test-Calendar", updates)
 
 
 # ── search_events ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Added `MAX_BATCH_SIZE = 50` class constant to `CalendarConnector`
- `create_events`, `update_events`, and `delete_events` now raise `ValueError` if batch exceeds 50 items
- Error message tells the caller the limit and suggests splitting into multiple calls

## Test plan
- [x] `make test` — 179 passed (3 new tests)

Closes #214

🤖 Generated with [Claude Code](https://claude.com/claude-code)