### PR TITLE
release: v0.8.2

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -3,7 +3,7 @@
 An MCP server bridging Claude and Apple Calendar via AppleScript and EventKit on macOS.
 
 **Stack:** Python 3.10+, FastMCP, AppleScript (via `osascript`), Swift/EventKit (via `swift`)
-**Version:** v0.8.1 | **Tests:** 174 unit, 58 integration | **Coverage:** 98%
+**Version:** v0.8.2 | **Tests:** 184 unit, 59 integration | **Coverage:** 97%
 
 ## Commands
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.2] - 2026-03-22
+
+### Added
+
+- SECURITY.md: threat model, operational security, prompt injection risk, architecture security properties (#210, #215, #216, #219, #224, #225)
+- Ambiguous calendar rejection: write operations fail when duplicate calendar names exist without `calendar_source` (#212, #221)
+- `calendar_source` parameter on `delete_calendar` for source disambiguation (#212, #221)
+- Per-call batch size limit of 50 for `create_events`, `update_events`, `delete_events` (#214, #223)
+- CLI argument prefix validation: calendar names and UIDs starting with `--` are rejected (#217, #226)
+- `EVENT CONTENT` warning in server instructions about untrusted event data (#215, #224)
+
+### Fixed
+
+- `create_events` safety bypass when `calendar_name` is empty — now blocked in test mode (#213, #222)
+
+### Changed
+
+- OpenRouter API key moved from `.env` to macOS Keychain in eval runner (#209, #218)
+- Calendar-not-found errors no longer enumerate all available calendars (#211, #220)
+- `ambiguous_calendar` error mapped to `ValueError` in Swift helper error handling (#212, #221)
+
 ## [0.8.1] - 2026-03-22
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Apple Calendar MCP Server
 
 [![CI](https://github.com/s-morgan-jeffries/apple-calendar-mcp/actions/workflows/test.yml/badge.svg)](https://github.com/s-morgan-jeffries/apple-calendar-mcp/actions/workflows/test.yml)
-[![Coverage](https://img.shields.io/badge/coverage-98%25-brightgreen)](https://github.com/s-morgan-jeffries/apple-calendar-mcp)
+[![Coverage](https://img.shields.io/badge/coverage-97%25-brightgreen)](https://github.com/s-morgan-jeffries/apple-calendar-mcp)
 [![Python](https://img.shields.io/badge/python-3.10%2B-blue)](https://www.python.org)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 
@@ -28,7 +28,7 @@ All event operations use Swift/EventKit via native subprocess for sub-second per
 
 ### Reliable
 
-98% code coverage from 176 unit tests. 58 integration tests run against real Calendar.app — covering round-trip data integrity, recurring event edge cases, special characters, alerts, year-boundary queries, and more. Calendar safety guards prevent accidental writes to real calendars during testing.
+97% code coverage from 184 unit tests. 59 integration tests run against real Calendar.app — covering round-trip data integrity, recurring event edge cases, special characters, alerts, year-boundary queries, and more. Calendar safety guards prevent accidental writes to real calendars during testing.
 
 ### Agent-Friendly
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "apple-calendar-mcp"
-version = "0.8.1"
+version = "0.8.2"
 description = "MCP server for Apple Calendar integration"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/apple_calendar_mcp/__init__.py
+++ b/src/apple_calendar_mcp/__init__.py
@@ -1,3 +1,3 @@
 """Apple Calendar MCP Server."""
 
-__version__ = "0.8.1"
+__version__ = "0.8.2"

--- a/src/apple_calendar_mcp/calendar_connector.py
+++ b/src/apple_calendar_mcp/calendar_connector.py
@@ -433,6 +433,8 @@ class CalendarConnector:
         self._validate_date(start_date)
         self._validate_date(end_date)
 
+        self._validate_cli_arg(query, "query")
+
         args = []
         for name in calendar_names:
             args += ["--calendar", name]


### PR DESCRIPTION
## Release v0.8.2 — Security Hardening

Security hardening release addressing all findings from the adversarial security review (#195).

### Changes (9 PRs)

**Security fixes:**
- Ambiguous calendar rejection: write ops fail when duplicate names exist without `calendar_source` (#212)
- `create_events` safety bypass fix for empty `calendar_name` (#213)
- Per-call batch size limits (50) for create/update/delete (#214)
- CLI arg prefix validation: reject `--` prefixed calendar names and UIDs (#217)
- Calendar enumeration removed from error messages (#211)

**Credential management:**
- OpenRouter API key moved from `.env` to macOS Keychain (#209)

**Documentation:**
- SECURITY.md: threat model, destructive ops, prompt injection risk, architecture properties (#210, #215, #216)
- `EVENT CONTENT` warning added to server instructions (#215)

**API additions:**
- `calendar_source` parameter on `delete_calendar` (#212)

### Code Review Notes
- `search_events` `query` parameter now validated (fixed during release review)
- `get_events.swift` still uses `.first(where:)` for reads — intentional, reads are non-destructive
- One flaky integration test (`test_reschedule_single_occurrence`) — pre-existing, not related to this release

### Test results
- 184 unit tests passed
- 58/59 integration tests passed (1 pre-existing flaky test)
- 97% code coverage (threshold: 90%)