### PR TITLE
Update unit test mocks to match real Swift helper output

### DIFF
--- a/tests/unit/test_calendar_connector.py
+++ b/tests/unit/test_calendar_connector.py
@@ -206,8 +206,8 @@ class TestGetCalendars:
     @patch("apple_calendar_mcp.calendar_connector.run_swift_helper")
     def test_returns_list_of_calendar_dicts(self, mock_swift):
         mock_swift.return_value = json.dumps([
-            {"name": "Personal", "writable": True, "description": "", "color": "#0072FF", "source": "iCloud"},
-            {"name": "Work", "writable": True, "description": "", "color": "#FF0023", "source": "Google"},
+            {"name": "Personal", "writable": True, "description": "", "color": "#0072FF", "source": "iCloud", "type": "caldav", "is_default": True},
+            {"name": "Work", "writable": True, "description": "", "color": "#FF0023", "source": "Google", "type": "caldav", "is_default": False},
         ])
         result = self.connector.get_calendars()
         assert isinstance(result, list)
@@ -218,7 +218,7 @@ class TestGetCalendars:
     @patch("apple_calendar_mcp.calendar_connector.run_swift_helper")
     def test_calendar_has_expected_keys(self, mock_swift):
         mock_swift.return_value = json.dumps([
-            {"name": "Personal", "writable": True, "description": "my cal", "color": "#0072FF", "source": "iCloud"},
+            {"name": "Personal", "writable": True, "description": "my cal", "color": "#0072FF", "source": "iCloud", "type": "caldav", "is_default": False},
         ])
         result = self.connector.get_calendars()
         cal = result[0]
@@ -226,6 +226,8 @@ class TestGetCalendars:
         assert "writable" in cal
         assert "description" in cal
         assert "color" in cal
+        assert "type" in cal
+        assert "is_default" in cal
 
     @patch("apple_calendar_mcp.calendar_connector.run_swift_helper")
     def test_empty_calendar_list(self, mock_swift):
@@ -236,7 +238,7 @@ class TestGetCalendars:
     @patch("apple_calendar_mcp.calendar_connector.run_swift_helper")
     def test_read_only_calendar(self, mock_swift):
         mock_swift.return_value = json.dumps([
-            {"name": "Holidays", "writable": False, "description": "US Holidays", "color": "#8882FE", "source": "Other"},
+            {"name": "Holidays", "writable": False, "description": "US Holidays", "color": "#8882FE", "source": "Other", "type": "local", "is_default": False},
         ])
         result = self.connector.get_calendars()
         assert result[0]["writable"] is False
@@ -244,7 +246,7 @@ class TestGetCalendars:
     @patch("apple_calendar_mcp.calendar_connector.run_swift_helper")
     def test_calendar_with_empty_description(self, mock_swift):
         mock_swift.return_value = json.dumps([
-            {"name": "Work", "writable": True, "description": "", "color": "#FF0000", "source": "iCloud"},
+            {"name": "Work", "writable": True, "description": "", "color": "#FF0000", "source": "iCloud", "type": "caldav", "is_default": False},
         ])
         result = self.connector.get_calendars()
         assert result[0]["description"] == ""
@@ -1063,7 +1065,7 @@ class TestCreateEvents:
     @patch("apple_calendar_mcp.calendar_connector.run_swift_helper")
     def test_creates_batch_events(self, mock_swift):
         mock_swift.return_value = json.dumps({
-            "created": [{"uid": "UID-1", "summary": "Event 1"}, {"uid": "UID-2", "summary": "Event 2"}],
+            "created": [{"uid": "UID-1", "summary": "Event 1", "calendar_name": "MCP-Test-Calendar"}, {"uid": "UID-2", "summary": "Event 2", "calendar_name": "MCP-Test-Calendar"}],
             "errors": [],
         })
         events = [
@@ -1077,7 +1079,7 @@ class TestCreateEvents:
     @patch("apple_calendar_mcp.calendar_connector.run_swift_helper")
     def test_partial_success(self, mock_swift):
         mock_swift.return_value = json.dumps({
-            "created": [{"uid": "UID-1", "summary": "Event 1"}],
+            "created": [{"uid": "UID-1", "summary": "Event 1", "calendar_name": "MCP-Test-Calendar"}],
             "errors": [{"index": 1, "summary": "Bad Event", "error": "invalid date"}],
         })
         result = self.connector.create_events("MCP-Test-Calendar", [{"summary": "Event 1"}, {"summary": "Bad Event"}])

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -58,8 +58,8 @@ class TestGetCalendarsTool:
     def test_returns_formatted_calendar_list(self, mock_get_client):
         mock_client = MagicMock()
         mock_client.get_calendars.return_value = [
-            {"name": "Personal", "writable": True, "description": "", "color": "#0072FF", "source": "iCloud"},
-            {"name": "Work", "writable": True, "description": "", "color": "#FF0023", "source": "Google"},
+            {"name": "Personal", "writable": True, "description": "", "color": "#0072FF", "source": "iCloud", "type": "caldav", "is_default": True},
+            {"name": "Work", "writable": True, "description": "", "color": "#FF0023", "source": "Google", "type": "caldav", "is_default": False},
         ]
         mock_get_client.return_value = mock_client
 
@@ -74,7 +74,7 @@ class TestGetCalendarsTool:
     def test_returns_string(self, mock_get_client):
         mock_client = MagicMock()
         mock_client.get_calendars.return_value = [
-            {"name": "Test", "writable": True, "description": "", "color": "#000000", "source": "iCloud"},
+            {"name": "Test", "writable": True, "description": "", "color": "#000000", "source": "iCloud", "type": "caldav", "is_default": False},
         ]
         mock_get_client.return_value = mock_client
 
@@ -454,17 +454,30 @@ class TestFormatCalendarDescription:
 
     def test_calendar_with_description(self):
         from apple_calendar_mcp.server_fastmcp import _format_calendar
-        cal = {"name": "Work", "writable": True, "description": "My work calendar", "color": "#FF0000", "source": "iCloud"}
+        cal = {"name": "Work", "writable": True, "description": "My work calendar", "color": "#FF0000", "source": "iCloud", "type": "caldav", "is_default": False}
         result = _format_calendar(cal)
         assert "Description: My work calendar" in result
         assert "Source: iCloud" in result
+        assert "Default" not in result
 
     def test_calendar_without_description(self):
         from apple_calendar_mcp.server_fastmcp import _format_calendar
-        cal = {"name": "Work", "writable": True, "description": "", "color": "#FF0000", "source": "Google"}
+        cal = {"name": "Work", "writable": True, "description": "", "color": "#FF0000", "source": "Google", "type": "caldav", "is_default": False}
         result = _format_calendar(cal)
         assert "Description" not in result
         assert "Source: Google" in result
+
+    def test_default_calendar(self):
+        from apple_calendar_mcp.server_fastmcp import _format_calendar
+        cal = {"name": "Personal", "writable": True, "description": "", "color": "#0072FF", "source": "iCloud", "type": "caldav", "is_default": True}
+        result = _format_calendar(cal)
+        assert "Default: yes" in result
+
+    def test_non_default_calendar(self):
+        from apple_calendar_mcp.server_fastmcp import _format_calendar
+        cal = {"name": "Work", "writable": True, "description": "", "color": "#FF0000", "source": "Google", "type": "caldav", "is_default": False}
+        result = _format_calendar(cal)
+        assert "Default" not in result
 
 
 class TestFormatEventDetails:
@@ -526,8 +539,8 @@ class TestCreateEventsTool:
         mock_client = MagicMock()
         mock_client.create_events.return_value = {
             "created": [
-                {"summary": "Event A", "uid": "UID-A"},
-                {"summary": "Event B", "uid": "UID-B"},
+                {"summary": "Event A", "uid": "UID-A", "calendar_name": "Work"},
+                {"summary": "Event B", "uid": "UID-B", "calendar_name": "Work"},
             ],
             "errors": [],
         }
@@ -563,7 +576,7 @@ class TestCreateEventsTool:
     def test_batch_create_partial_success(self, mock_get_client):
         mock_client = MagicMock()
         mock_client.create_events.return_value = {
-            "created": [{"summary": "Event A", "uid": "UID-A"}],
+            "created": [{"summary": "Event A", "uid": "UID-A", "calendar_name": "Work"}],
             "errors": [{"index": 1, "summary": "Event B", "error": "Invalid date"}],
         }
         mock_get_client.return_value = mock_client
@@ -589,6 +602,24 @@ class TestCreateEventsTool:
         result = create_events(calendar_name="Work", events='{"summary": "test"}')
         assert "Error" in result
         assert "JSON array" in result
+
+    @patch("apple_calendar_mcp.server_fastmcp.get_client")
+    def test_resolved_calendar_from_swift_result(self, mock_get_client):
+        """When Swift returns a calendar_name, it should be used in the output message."""
+        mock_client = MagicMock()
+        mock_client.create_events.return_value = {
+            "created": [{"summary": "Event A", "uid": "UID-A", "calendar_name": "Default Calendar"}],
+            "errors": [],
+        }
+        mock_get_client.return_value = mock_client
+
+        from apple_calendar_mcp.server_fastmcp import create_events
+        events_json = json.dumps([
+            {"summary": "Event A", "start_date": "2026-03-15T10:00:00", "end_date": "2026-03-15T11:00:00"},
+        ])
+        result = create_events(calendar_name="", events=events_json)
+        assert "Default Calendar" in result
+        assert "'Default Calendar'" in result
 
 
 class TestUpdateEventsTool:


### PR DESCRIPTION
## Summary

Closes #228

- Add missing `type` and `is_default` fields to all `get_calendars` mock payloads
- Add missing `calendar_name` field to all `create_events` mock payloads
- Add tests for `_format_calendar` `is_default` branch (previously untested)
- Add test for `resolved_calendar` logic reading `calendar_name` from Swift result

## Test plan

- [x] `make test-unit` passes (187 tests, +3 new)
- [ ] Verify no integration test regressions (`make test-integration`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)