### PR TITLE
Add missing unit test coverage for untested code paths

### DIFF
--- a/tests/unit/test_calendar_connector.py
+++ b/tests/unit/test_calendar_connector.py
@@ -402,6 +402,19 @@ class TestGetEvents:
         )
 
     @patch("apple_calendar_mcp.calendar_connector.run_swift_helper")
+    def test_calendar_name_kwarg_backward_compat(self, mock_swift):
+        """The calendar_name= kwarg alias resolves to --calendar in Swift args."""
+        mock_swift.return_value = "[]"
+        self.connector.get_events(
+            calendar_name="Work",
+            start_date="2026-03-15T00:00:00",
+            end_date="2026-03-16T00:00:00",
+        )
+        args = mock_swift.call_args[0][1]
+        assert "--calendar" in args
+        assert "Work" in args
+
+    @patch("apple_calendar_mcp.calendar_connector.run_swift_helper")
     def test_none_calendar_names_queries_all(self, mock_swift):
         mock_swift.return_value = "[]"
         self.connector.get_events(
@@ -656,6 +669,20 @@ class TestGetAvailability:
         # Entire range should be free since the event is marked "free"
         assert len(result) == 1
         assert result[0]["duration_minutes"] == 480
+
+    @patch("apple_calendar_mcp.calendar_connector.run_swift_helper")
+    def test_tentative_events_block_availability(self, mock_swift):
+        """Events with availability='tentative' should block availability like busy."""
+        event = self._make_event("2026-03-15T10:00:00", "2026-03-15T11:00:00")
+        event["availability"] = "tentative"
+        mock_swift.return_value = json.dumps([event])
+        result = self.connector.get_availability(
+            ["Work"], "2026-03-15T09:00:00", "2026-03-15T17:00:00"
+        )
+        # Should have two free slots (before and after the tentative event)
+        assert len(result) == 2
+        assert result[0]["end_date"] == "2026-03-15T10:00:00"
+        assert result[1]["start_date"] == "2026-03-15T11:00:00"
 
 
 # ── get_availability: smart filtering ──────────────────────────────────────
@@ -1015,6 +1042,16 @@ class TestDeleteEvents:
         with pytest.raises(ValueError, match="exceeds limit of 50"):
             self.connector.delete_events("MCP-Test-Calendar", uids)
 
+    @patch("apple_calendar_mcp.calendar_connector.run_swift_helper")
+    def test_passes_occurrence_date_to_swift(self, mock_swift):
+        mock_swift.return_value = json.dumps({"deleted_uids": ["REC-123"], "not_found_uids": []})
+        self.connector.delete_events(
+            "MCP-Test-Calendar", "REC-123", occurrence_date="2026-03-15T10:00:00"
+        )
+        args = mock_swift.call_args[0][1]
+        assert "--occurrence-date" in args
+        assert "2026-03-15T10:00:00" in args
+
 
 # ── _run_swift_helper_json error handling ─────────────────────────────────
 
@@ -1050,6 +1087,33 @@ class TestRunSwiftHelperJson:
         error.stdout = None
         mock_swift.side_effect = error
         with pytest.raises(RuntimeError, match="failed with no output"):
+            self.connector._run_swift_helper_json("test_script", [])
+
+    @patch("apple_calendar_mcp.calendar_connector.run_swift_helper")
+    def test_ambiguous_calendar_raises_value_error(self, mock_swift):
+        """ambiguous_calendar error code should raise ValueError."""
+        error = subprocess.CalledProcessError(1, "swift")
+        error.stdout = json.dumps({"error": "ambiguous_calendar", "message": "Multiple calendars named 'Family'"})
+        mock_swift.side_effect = error
+        with pytest.raises(ValueError, match="Multiple calendars named 'Family'"):
+            self.connector._run_swift_helper_json("test_script", [])
+
+    @patch("apple_calendar_mcp.calendar_connector.run_swift_helper")
+    def test_event_not_found_raises_value_error(self, mock_swift):
+        """event_not_found error code should raise ValueError."""
+        error = subprocess.CalledProcessError(1, "swift")
+        error.stdout = json.dumps({"error": "event_not_found", "message": "Event 'ABC' not found"})
+        mock_swift.side_effect = error
+        with pytest.raises(ValueError, match="Event 'ABC' not found"):
+            self.connector._run_swift_helper_json("test_script", [])
+
+    @patch("apple_calendar_mcp.calendar_connector.run_swift_helper")
+    def test_unknown_error_raises_runtime_error(self, mock_swift):
+        """Unmapped error codes should raise RuntimeError."""
+        error = subprocess.CalledProcessError(1, "swift")
+        error.stdout = json.dumps({"error": "unexpected_error", "message": "Something went wrong"})
+        mock_swift.side_effect = error
+        with pytest.raises(RuntimeError, match="Something went wrong"):
             self.connector._run_swift_helper_json("test_script", [])
 
 
@@ -1105,6 +1169,29 @@ class TestCreateEvents:
         with pytest.raises(ValueError, match="exceeds limit of 50"):
             self.connector.create_events("MCP-Test-Calendar", events)
 
+    @patch("apple_calendar_mcp.calendar_connector.run_swift_helper")
+    def test_passes_calendar_source_to_swift(self, mock_swift):
+        mock_swift.return_value = json.dumps({
+            "created": [{"uid": "UID-1", "summary": "Event 1", "calendar_name": "MCP-Test-Calendar"}],
+            "errors": [],
+        })
+        self.connector.create_events(
+            "MCP-Test-Calendar",
+            [{"summary": "Event 1", "start_date": "2026-03-15T10:00:00", "end_date": "2026-03-15T11:00:00"}],
+            calendar_source="iCloud",
+        )
+        args = mock_swift.call_args[0][1]
+        assert "--source" in args
+        assert "iCloud" in args
+
+    def test_rejects_invalid_calendar_source(self):
+        with pytest.raises(ValueError, match="must not start with '--'"):
+            self.connector.create_events(
+                "MCP-Test-Calendar",
+                [{"summary": "Test"}],
+                calendar_source="--evil",
+            )
+
 
 # ── update_events (batch) ─────────────────────────────────────────────────
 
@@ -1157,6 +1244,29 @@ class TestUpdateEvents:
         updates = [{"uid": f"UID-{i}", "summary": f"Event {i}"} for i in range(51)]
         with pytest.raises(ValueError, match="exceeds limit of 50"):
             self.connector.update_events("MCP-Test-Calendar", updates)
+
+    @patch("apple_calendar_mcp.calendar_connector.run_swift_helper")
+    def test_passes_calendar_source_to_swift(self, mock_swift):
+        mock_swift.return_value = json.dumps({
+            "updated": [{"uid": "UID-1", "summary": "Updated", "updated_fields": ["summary"]}],
+            "errors": [],
+        })
+        self.connector.update_events(
+            "MCP-Test-Calendar",
+            [{"uid": "UID-1", "summary": "Updated"}],
+            calendar_source="iCloud",
+        )
+        args = mock_swift.call_args[0][1]
+        assert "--source" in args
+        assert "iCloud" in args
+
+    def test_rejects_invalid_calendar_source(self):
+        with pytest.raises(ValueError, match="must not start with '--'"):
+            self.connector.update_events(
+                "MCP-Test-Calendar",
+                [{"uid": "UID-1", "summary": "Test"}],
+                calendar_source="--evil",
+            )
 
 
 # ── search_events ─────────────────────────────────────────────────────────
@@ -1221,6 +1331,16 @@ class TestSearchEvents:
         """A single string calendar_names value is accepted for backward compat."""
         mock_swift.return_value = json.dumps([])
         self.connector.search_events("test", calendar_names="Work",
+                                      start_date="2026-03-01", end_date="2026-04-01")
+        args = mock_swift.call_args[0][1]
+        assert "--calendar" in args
+        assert "Work" in args
+
+    @patch("apple_calendar_mcp.calendar_connector.run_swift_helper")
+    def test_calendar_name_kwarg_backward_compat(self, mock_swift):
+        """The calendar_name= kwarg alias resolves to --calendar in Swift args."""
+        mock_swift.return_value = json.dumps([])
+        self.connector.search_events("test", calendar_name="Work",
                                       start_date="2026-03-01", end_date="2026-04-01")
         args = mock_swift.call_args[0][1]
         assert "--calendar" in args

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -530,6 +530,24 @@ class TestFormatEventDetails:
         lines = _format_recurrence(event)
         assert any("detached" in line.lower() for line in lines)
 
+    def test_format_event_details_location(self):
+        from apple_calendar_mcp.server_fastmcp import _format_event_details
+        event = {"location": "Room 4"}
+        lines = _format_event_details(event)
+        assert any("Location: Room 4" in line for line in lines)
+
+    def test_format_event_details_notes(self):
+        from apple_calendar_mcp.server_fastmcp import _format_event_details
+        event = {"notes": "Bring laptop"}
+        lines = _format_event_details(event)
+        assert any("Notes: Bring laptop" in line for line in lines)
+
+    def test_format_event_details_url(self):
+        from apple_calendar_mcp.server_fastmcp import _format_event_details
+        event = {"url": "https://meet.example.com"}
+        lines = _format_event_details(event)
+        assert any("URL: https://meet.example.com" in line for line in lines)
+
 
 class TestCreateEventsTool:
     """Tests for the create_events MCP tool (batch)."""
@@ -802,6 +820,11 @@ class TestGetConflictsTool:
         assert "Meeting B" in result
         assert "30 min overlap" in result
         assert isinstance(result, str)
+        # Verify calendar name and time range are included in formatting
+        assert "Work" in result
+        assert "2026-03-15T10:00:00" in result
+        assert "2026-03-15T11:00:00" in result
+        assert "2026-03-15T10:30:00" in result
 
     @patch("apple_calendar_mcp.server_fastmcp.get_client")
     def test_no_conflicts(self, mock_get_client):


### PR DESCRIPTION
## Summary

Closes #229

Adds 14 new unit tests covering 6 previously-untested code paths identified by the #149 critic review:

- **F-U-4:** `calendar_name` backward-compat kwarg alias in `get_events` and `search_events`
- **F-U-5:** `ambiguous_calendar`, `event_not_found`, and unknown error codes in `_run_swift_helper_json`
- **F-U-6:** `calendar_source` pass-through and validation in `create_events` and `update_events`
- **F-U-9:** `delete_events` `occurrence_date` → `--occurrence-date` CLI arg translation
- **F-U-10:** Tentative events blocking availability (opposite of free exclusion)
- **F-U-11:** Location/notes/url rendering in `_format_event_details`, calendar/time assertions in `_format_conflict`

## Test plan

- [x] `make test-unit` passes (201 tests, +14 new)
- [ ] Verify no integration test regressions (`make test-integration`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)