### PR TITLE
Add batch size boundary tests at exactly 50 items

### DIFF
--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -12,7 +12,7 @@ import uuid
 
 import pytest
 
-from apple_calendar_mcp.calendar_connector import CalendarConnector, run_applescript
+from apple_calendar_mcp.calendar_connector import CalendarConnector, run_applescript, run_swift_helper
 
 
 # Skip entire module if not in test mode
@@ -1324,3 +1324,26 @@ class TestAmbiguousCalendarIntegration:
                             break
                         except Exception:
                             pass
+
+
+# ── batch size limits ──────────────────────────────────────────────────────
+
+
+class TestBatchLimitsIntegration:
+    """Integration tests for per-call batch size limits."""
+
+    def test_create_events_exceeds_batch_limit(self, connector):
+        events = [{"summary": f"Event {i}", "start_date": "2026-06-15T10:00:00",
+                    "end_date": "2026-06-15T11:00:00"} for i in range(51)]
+        with pytest.raises(ValueError, match="exceeds limit of 50"):
+            connector.create_events(TEST_CALENDAR, events)
+
+    def test_update_events_exceeds_batch_limit(self, connector):
+        updates = [{"uid": f"UID-{i}", "summary": f"Event {i}"} for i in range(51)]
+        with pytest.raises(ValueError, match="exceeds limit of 50"):
+            connector.update_events(TEST_CALENDAR, updates)
+
+    def test_delete_events_exceeds_batch_limit(self, connector):
+        uids = [f"UID-{i}" for i in range(51)]
+        with pytest.raises(ValueError, match="exceeds limit of 50"):
+            connector.delete_events(TEST_CALENDAR, uids)

--- a/tests/unit/test_calendar_connector.py
+++ b/tests/unit/test_calendar_connector.py
@@ -1043,6 +1043,14 @@ class TestDeleteEvents:
             self.connector.delete_events("MCP-Test-Calendar", uids)
 
     @patch("apple_calendar_mcp.calendar_connector.run_swift_helper")
+    def test_batch_limit_boundary_succeeds(self, mock_swift):
+        """Exactly 50 UIDs should succeed (boundary of MAX_BATCH_SIZE)."""
+        uids = [f"UID-{i}" for i in range(50)]
+        mock_swift.return_value = json.dumps({"deleted_uids": uids, "not_found_uids": []})
+        result = self.connector.delete_events("MCP-Test-Calendar", uids)
+        assert len(result["deleted_uids"]) == 50
+
+    @patch("apple_calendar_mcp.calendar_connector.run_swift_helper")
     def test_passes_occurrence_date_to_swift(self, mock_swift):
         mock_swift.return_value = json.dumps({"deleted_uids": ["REC-123"], "not_found_uids": []})
         self.connector.delete_events(
@@ -1170,6 +1178,15 @@ class TestCreateEvents:
             self.connector.create_events("MCP-Test-Calendar", events)
 
     @patch("apple_calendar_mcp.calendar_connector.run_swift_helper")
+    def test_batch_limit_boundary_succeeds(self, mock_swift):
+        """Exactly 50 events should succeed (boundary of MAX_BATCH_SIZE)."""
+        created = [{"uid": f"UID-{i}", "summary": f"Event {i}", "calendar_name": "MCP-Test-Calendar"} for i in range(50)]
+        mock_swift.return_value = json.dumps({"created": created, "errors": []})
+        events = [{"summary": f"Event {i}", "start_date": "2026-03-15T10:00:00", "end_date": "2026-03-15T11:00:00"} for i in range(50)]
+        result = self.connector.create_events("MCP-Test-Calendar", events)
+        assert len(result["created"]) == 50
+
+    @patch("apple_calendar_mcp.calendar_connector.run_swift_helper")
     def test_passes_calendar_source_to_swift(self, mock_swift):
         mock_swift.return_value = json.dumps({
             "created": [{"uid": "UID-1", "summary": "Event 1", "calendar_name": "MCP-Test-Calendar"}],
@@ -1244,6 +1261,15 @@ class TestUpdateEvents:
         updates = [{"uid": f"UID-{i}", "summary": f"Event {i}"} for i in range(51)]
         with pytest.raises(ValueError, match="exceeds limit of 50"):
             self.connector.update_events("MCP-Test-Calendar", updates)
+
+    @patch("apple_calendar_mcp.calendar_connector.run_swift_helper")
+    def test_batch_limit_boundary_succeeds(self, mock_swift):
+        """Exactly 50 updates should succeed (boundary of MAX_BATCH_SIZE)."""
+        updated = [{"uid": f"UID-{i}", "summary": f"Event {i}", "updated_fields": ["summary"]} for i in range(50)]
+        mock_swift.return_value = json.dumps({"updated": updated, "errors": []})
+        updates = [{"uid": f"UID-{i}", "summary": f"Event {i}"} for i in range(50)]
+        result = self.connector.update_events("MCP-Test-Calendar", updates)
+        assert len(result["updated"]) == 50
 
     @patch("apple_calendar_mcp.calendar_connector.run_swift_helper")
     def test_passes_calendar_source_to_swift(self, mock_swift):


### PR DESCRIPTION
## Summary

Closes #230

- Unit tests: verify `create_events`, `update_events`, `delete_events` succeed with exactly 50 items (the `MAX_BATCH_SIZE` boundary), pinning the `>` vs `>=` distinction
- Integration tests: verify batch-size limit is enforced (51 items → `ValueError`) for all three operations

## Test plan

- [x] `make test-unit` passes (204 tests, +3 boundary tests)
- [ ] `make test-integration` passes (3 new batch limit tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)