### PR TITLE
Add get_conflicts integration tests, benchmark, and eval scenario

### DIFF
--- a/evals/agent_tool_usability/scenarios.py
+++ b/evals/agent_tool_usability/scenarios.py
@@ -882,4 +882,27 @@ SCENARIOS = [
         ),
         "safety_critical": False,
     },
+    # =========================================================================
+    # Category 12: Conflict Detection
+    # =========================================================================
+    {
+        "id": 39,
+        "category": "Conflict Detection",
+        "name": "Check for double-bookings",
+        "prompt": "Do I have any double-bookings on my Work calendar this week?",
+        "expected": {
+            "tools": ["get_conflicts"],
+            "key_params": {
+                "get_conflicts": {
+                    "calendar_names": ["Work"],
+                }
+            },
+        },
+        "scoring_notes": (
+            "PASS: Uses get_conflicts with calendar_names=['Work'] and appropriate date range. "
+            "PARTIAL: Uses get_events and manually scans for overlaps. "
+            "FAIL: Uses get_availability or wrong tool."
+        ),
+        "safety_critical": False,
+    },
 ]

--- a/tests/benchmarks/performance.py
+++ b/tests/benchmarks/performance.py
@@ -96,6 +96,21 @@ def run_benchmarks(read_calendar: str, test_calendar: str):
         iterations=3,
     )
 
+    # --- get_conflicts ---
+    print(f"\n[get_conflicts] (calendar: {read_calendar})")
+
+    benchmark(
+        lambda: connector.get_conflicts([read_calendar], "2026-03-01", "2026-03-31"),
+        "1-month range",
+        iterations=3,
+    )
+
+    benchmark(
+        lambda: connector.get_conflicts([read_calendar], "2026-01-01", "2026-12-31"),
+        "1-year range",
+        iterations=3,
+    )
+
     # --- Write operations (test calendar only) ---
     print(f"\n[create_events] (calendar: {test_calendar})")
 

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -1326,6 +1326,91 @@ class TestAmbiguousCalendarIntegration:
                             pass
 
 
+# ── get_conflicts ──────────────────────────────────────────────────────────
+
+
+class TestGetConflictsIntegration:
+    """Integration tests for get_conflicts."""
+
+    def test_overlapping_events_detected(self, connector):
+        """Two overlapping events should produce a conflict."""
+        tag = uuid.uuid4().hex[:8]
+        uid1 = _create_single_event(
+            connector, TEST_CALENDAR, f"Conflict-A-{tag}",
+            "2028-09-15T10:00:00", "2028-09-15T11:00:00",
+        )
+        uid2 = _create_single_event(
+            connector, TEST_CALENDAR, f"Conflict-B-{tag}",
+            "2028-09-15T10:30:00", "2028-09-15T11:30:00",
+        )
+        try:
+            conflicts = connector.get_conflicts(
+                [TEST_CALENDAR], "2028-09-15T00:00:00", "2028-09-16T00:00:00"
+            )
+            # Find the conflict involving our events
+            our_conflict = [
+                c for c in conflicts
+                if {c["event_a"]["summary"], c["event_b"]["summary"]}
+                == {f"Conflict-A-{tag}", f"Conflict-B-{tag}"}
+            ]
+            assert len(our_conflict) == 1
+            assert our_conflict[0]["overlap_minutes"] == 30
+        finally:
+            _delete_event_by_uid(uid1)
+            _delete_event_by_uid(uid2)
+
+    def test_adjacent_events_no_conflict(self, connector):
+        """Two adjacent (non-overlapping) events should produce no conflict."""
+        tag = uuid.uuid4().hex[:8]
+        uid1 = _create_single_event(
+            connector, TEST_CALENDAR, f"Adjacent-A-{tag}",
+            "2028-09-16T10:00:00", "2028-09-16T11:00:00",
+        )
+        uid2 = _create_single_event(
+            connector, TEST_CALENDAR, f"Adjacent-B-{tag}",
+            "2028-09-16T11:00:00", "2028-09-16T12:00:00",
+        )
+        try:
+            conflicts = connector.get_conflicts(
+                [TEST_CALENDAR], "2028-09-16T00:00:00", "2028-09-17T00:00:00"
+            )
+            our_conflicts = [
+                c for c in conflicts
+                if f"Adjacent-A-{tag}" in (c["event_a"]["summary"], c["event_b"]["summary"])
+                or f"Adjacent-B-{tag}" in (c["event_a"]["summary"], c["event_b"]["summary"])
+            ]
+            assert len(our_conflicts) == 0
+        finally:
+            _delete_event_by_uid(uid1)
+            _delete_event_by_uid(uid2)
+
+    def test_free_event_excluded_from_conflicts(self, connector):
+        """An event marked availability='free' should not produce conflicts."""
+        tag = uuid.uuid4().hex[:8]
+        uid1 = _create_single_event(
+            connector, TEST_CALENDAR, f"Busy-{tag}",
+            "2028-09-17T10:00:00", "2028-09-17T11:00:00",
+        )
+        uid2 = _create_single_event(
+            connector, TEST_CALENDAR, f"Free-{tag}",
+            "2028-09-17T10:30:00", "2028-09-17T11:30:00",
+            availability="free",
+        )
+        try:
+            conflicts = connector.get_conflicts(
+                [TEST_CALENDAR], "2028-09-17T00:00:00", "2028-09-18T00:00:00"
+            )
+            our_conflicts = [
+                c for c in conflicts
+                if f"Busy-{tag}" in (c["event_a"]["summary"], c["event_b"]["summary"])
+                or f"Free-{tag}" in (c["event_a"]["summary"], c["event_b"]["summary"])
+            ]
+            assert len(our_conflicts) == 0
+        finally:
+            _delete_event_by_uid(uid1)
+            _delete_event_by_uid(uid2)
+
+
 # ── batch size limits ──────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

Closes #231

`get_conflicts` was the least-tested of all 10 tools — zero integration tests, zero benchmarks, zero eval scenarios.

- **Integration tests:** overlapping events detected (with correct `overlap_minutes`), adjacent events produce no conflict, free-availability events excluded
- **Benchmark:** `get_conflicts` for 1-month and 1-year ranges
- **Eval:** scenario 39 — "Do I have any double-bookings this week?"

## Test plan

- [x] `make test-unit` passes (204 tests)
- [ ] `make test-integration` passes (3 new get_conflicts tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)