### PR TITLE
Expand search_events test coverage across all test layers

### DIFF
--- a/evals/agent_tool_usability/scenarios.py
+++ b/evals/agent_tool_usability/scenarios.py
@@ -905,4 +905,50 @@ SCENARIOS = [
         ),
         "safety_critical": False,
     },
+    # =========================================================================
+    # Category 13: Search vs Query Discrimination
+    # =========================================================================
+    {
+        "id": 40,
+        "category": "Search",
+        "name": "Text search across calendars",
+        "prompt": (
+            "Find all events mentioning 'budget review' across my calendars "
+            "in the next 6 months."
+        ),
+        "expected": {
+            "tools": ["search_events"],
+            "key_params": {
+                "search_events": {
+                    "query": "budget review",
+                }
+            },
+        },
+        "scoring_notes": (
+            "PASS: Uses search_events with query='budget review' and appropriate date range. "
+            "PARTIAL: Uses get_events and manually scans results for 'budget review'. "
+            "FAIL: Uses get_availability or wrong tool entirely."
+        ),
+        "safety_critical": False,
+    },
+    {
+        "id": 41,
+        "category": "Search",
+        "name": "Date query should use get_events not search",
+        "prompt": "What meetings do I have tomorrow on my Work calendar?",
+        "expected": {
+            "tools": ["get_events"],
+            "key_params": {
+                "get_events": {
+                    "calendar_names": ["Work"],
+                }
+            },
+        },
+        "scoring_notes": (
+            "PASS: Uses get_events with calendar_names=['Work'] and tomorrow's date range. "
+            "PARTIAL: Uses search_events with query='meetings' — wrong tool for a date-only query. "
+            "FAIL: Uses get_availability, get_conflicts, or wrong tool."
+        ),
+        "safety_critical": False,
+    },
 ]

--- a/tests/benchmarks/performance.py
+++ b/tests/benchmarks/performance.py
@@ -111,6 +111,23 @@ def run_benchmarks(read_calendar: str, test_calendar: str):
         iterations=3,
     )
 
+    # --- search_events ---
+    print(f"\n[search_events] (calendar: {read_calendar})")
+
+    benchmark(
+        lambda: connector.search_events("Meeting", calendar_names=[read_calendar],
+                                         start_date="2026-03-01", end_date="2026-03-31"),
+        "1-month range",
+        iterations=3,
+    )
+
+    benchmark(
+        lambda: connector.search_events("Meeting", calendar_names=[read_calendar],
+                                         start_date="2026-01-01", end_date="2026-12-31"),
+        "1-year range",
+        iterations=3,
+    )
+
     # --- Write operations (test calendar only) ---
     print(f"\n[create_events] (calendar: {test_calendar})")
 

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -1263,12 +1263,84 @@ class TestSearchEventsIntegration:
         try:
             results = connector.search_events(
                 query=keyword,
-                calendar_name=TEST_CALENDAR,
+                calendar_names=[TEST_CALENDAR],
                 start_date="2027-10-01",
                 end_date="2028-04-01",
             )
             assert len(results) >= 1, f"Expected to find event with keyword '{keyword}'"
             assert any(keyword in e["summary"] for e in results)
+        finally:
+            _delete_event_by_uid(uid)
+
+    def test_search_finds_event_by_notes(self, connector):
+        """Search should match keywords in event notes."""
+        keyword = f"NotesKey{uuid.uuid4().hex[:8]}"
+        uid = _create_single_event(connector,
+            calendar_name=TEST_CALENDAR,
+            summary="Generic Meeting",
+            start_date="2028-01-20T10:00:00",
+            end_date="2028-01-20T11:00:00",
+            notes=f"Remember to discuss {keyword} topic",
+        )
+        try:
+            results = connector.search_events(
+                query=keyword,
+                calendar_names=[TEST_CALENDAR],
+                start_date="2028-01-01",
+                end_date="2028-02-01",
+            )
+            assert len(results) >= 1, f"Expected to find event with notes keyword '{keyword}'"
+        finally:
+            _delete_event_by_uid(uid)
+
+    def test_search_finds_event_by_location(self, connector):
+        """Search should match keywords in event location."""
+        keyword = f"LocKey{uuid.uuid4().hex[:8]}"
+        uid = _create_single_event(connector,
+            calendar_name=TEST_CALENDAR,
+            summary="Office Meeting",
+            start_date="2028-02-20T10:00:00",
+            end_date="2028-02-20T11:00:00",
+            location=f"Building {keyword}",
+        )
+        try:
+            results = connector.search_events(
+                query=keyword,
+                calendar_names=[TEST_CALENDAR],
+                start_date="2028-02-01",
+                end_date="2028-03-01",
+            )
+            assert len(results) >= 1, f"Expected to find event with location keyword '{keyword}'"
+        finally:
+            _delete_event_by_uid(uid)
+
+    def test_search_returns_empty_for_no_match(self, connector):
+        """Search for a nonexistent keyword should return empty results."""
+        nonsense = f"ZZZZZ{uuid.uuid4().hex}"
+        results = connector.search_events(
+            query=nonsense,
+            calendar_names=[TEST_CALENDAR],
+            start_date="2028-01-01",
+            end_date="2028-12-31",
+        )
+        assert results == []
+
+    def test_search_across_all_calendars(self, connector):
+        """Search without specifying calendar_names should search all calendars."""
+        keyword = f"AllCalSearch{uuid.uuid4().hex[:8]}"
+        uid = _create_single_event(connector,
+            calendar_name=TEST_CALENDAR,
+            summary=f"Findme {keyword}",
+            start_date="2028-03-20T10:00:00",
+            end_date="2028-03-20T11:00:00",
+        )
+        try:
+            results = connector.search_events(
+                query=keyword,
+                start_date="2028-03-01",
+                end_date="2028-04-01",
+            )
+            assert len(results) >= 1, f"Expected to find event across all calendars"
         finally:
             _delete_event_by_uid(uid)
 


### PR DESCRIPTION
## Summary

Closes #232

- **Integration tests:** Fix deprecated `calendar_name` kwarg to `calendar_names`, add notes/location matching, zero-result query, and all-calendars search tests (+4 new, 1 fixed)
- **Benchmark:** `search_events` for 1-month and 1-year ranges
- **Evals:** scenario 40 (text search) and 41 (search vs get discrimination)

## Test plan

- [x] `make test-unit` passes (204 tests)
- [ ] `make test-integration` passes (5 search_events tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)