### PR TITLE
Add GitHub Actions to Dependabot monitoring

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,8 @@ updates:
     schedule:
       interval: "monthly"
     open-pull-requests-limit: 5
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 5


### PR DESCRIPTION
## Summary

Closes #110

Dependabot already monitors pip dependencies monthly. This adds `github-actions` ecosystem monitoring to keep workflow action versions (`actions/checkout`, `actions/setup-python`, etc.) up to date.

## Test plan

- [x] Valid YAML syntax
- [x] `make test-unit` passes (204 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)