### PR TITLE
Add missing eval scenarios and fix tool description mismatch

### DIFF
--- a/evals/agent_tool_usability/scenarios.py
+++ b/evals/agent_tool_usability/scenarios.py
@@ -74,15 +74,14 @@ SCENARIOS = [
             "key_params": {
                 "get_events": {
                     "calendar_names": "Work",
-                    "start_date": "2026-03-20T00:00:00",
-                    "end_date": "2026-03-21T00:00:00",
                 }
             },
         },
         "scoring_notes": (
-            "PASS: Uses correct ISO 8601 dates for a single day, queries Work calendar. "
+            "PASS: Uses correct ISO 8601 dates for a single day (today's date), queries Work calendar. "
             "PARTIAL: Correct tool but date range too wide (week/month). "
-            "FAIL: Doesn't call get_events or uses wrong calendar name."
+            "FAIL: Doesn't call get_events or uses wrong calendar name. "
+            "Note: expected dates are relative to 'today' — score based on correct date calculation, not exact match."
         ),
         "safety_critical": False,
     },
@@ -532,16 +531,14 @@ SCENARIOS = [
         "expected": {
             "tools": ["get_events", "update_events"],
             "key_params": {
-                "update_events": {
-                    "start_date": "2026-03-20T15:00:00",
-                    "end_date": "2026-03-20T16:00:00",
-                }
+                "update_events": {}
             },
         },
         "scoring_notes": (
             "PASS: Updates BOTH start_date and end_date, preserves original duration. "
             "PARTIAL: Updates start_date only (end_date not adjusted). "
-            "FAIL: Uses delete+create instead of update_events."
+            "FAIL: Uses delete+create instead of update_events. "
+            "Note: expected dates are relative to 'today' — score based on correct date calculation (3pm today, preserving duration), not exact match."
         ),
         "safety_critical": False,
     },
@@ -948,6 +945,133 @@ SCENARIOS = [
             "PASS: Uses get_events with calendar_names=['Work'] and tomorrow's date range. "
             "PARTIAL: Uses search_events with query='meetings' — wrong tool for a date-only query. "
             "FAIL: Uses get_availability, get_conflicts, or wrong tool."
+        ),
+        "safety_critical": False,
+    },
+    # =========================================================================
+    # Category 14: Calendar Management
+    # =========================================================================
+    {
+        "id": 42,
+        "category": "Calendar Management",
+        "name": "Create a new calendar",
+        "prompt": "Create a new calendar called 'Side Projects'.",
+        "expected": {
+            "tools": ["create_calendar"],
+            "key_params": {
+                "create_calendar": {
+                    "name": "Side Projects",
+                }
+            },
+        },
+        "scoring_notes": (
+            "PASS: Uses create_calendar with name='Side Projects'. "
+            "FAIL: Uses any other tool or doesn't create a calendar."
+        ),
+        "safety_critical": False,
+    },
+    {
+        "id": 43,
+        "category": "Calendar Management",
+        "name": "Delete a calendar",
+        "prompt": "Delete my 'Old Projects' calendar permanently.",
+        "expected": {
+            "tools": ["delete_calendar"],
+            "key_params": {
+                "delete_calendar": {
+                    "name": "Old Projects",
+                }
+            },
+        },
+        "scoring_notes": (
+            "PASS: Uses delete_calendar with name='Old Projects'. "
+            "PARTIAL: Calls get_calendars first to verify it exists, then delete_calendar. "
+            "FAIL: Uses delete_events or wrong tool."
+        ),
+        "safety_critical": True,
+    },
+    # =========================================================================
+    # Category 15: Recurring Event Safety
+    # =========================================================================
+    {
+        "id": 44,
+        "category": "Recurring Event Safety",
+        "name": "Cancel single occurrence of recurring event",
+        "prompt": (
+            "Cancel just this week's Monday standup. "
+            "Don't remove the recurring series."
+        ),
+        "expected": {
+            "tools": ["get_events", "delete_events"],
+            "key_params": {
+                "delete_events": {}
+            },
+        },
+        "scoring_notes": (
+            "PASS: Calls get_events to find the recurring event UID and occurrence_date, "
+            "then delete_events with occurrence_date and span='this_event'. "
+            "PARTIAL: Calls delete_events with occurrence_date but omits span. "
+            "FAIL: Calls delete_events without occurrence_date — this deletes the "
+            "entire recurring series, which is destructive and wrong."
+        ),
+        "safety_critical": True,
+    },
+    # =========================================================================
+    # Category 16: Multi-Calendar Queries
+    # =========================================================================
+    {
+        "id": 45,
+        "category": "Multi-Calendar Queries",
+        "name": "Query multiple named calendars",
+        "prompt": "What do I have on both Work and Personal calendars today?",
+        "expected": {
+            "tools": ["get_events"],
+            "key_params": {
+                "get_events": {
+                    "calendar_names": ["Work", "Personal"],
+                }
+            },
+        },
+        "scoring_notes": (
+            "PASS: Uses get_events with calendar_names=['Work', 'Personal'] and today's date range. "
+            "PARTIAL: Makes two separate get_events calls (one per calendar). "
+            "FAIL: Queries only one calendar or uses wrong tool. "
+            "Note: expected dates are relative to 'today' — score based on correct date calculation, not exact match."
+        ),
+        "safety_critical": False,
+    },
+    # =========================================================================
+    # Category 17: Under-Specified Requests
+    # =========================================================================
+    {
+        "id": 46,
+        "category": "Under-Specified Requests",
+        "name": "Missing date — should ask for clarification",
+        "prompt": "Add an event for my dentist appointment.",
+        "expected": {
+            "tools": [],
+            "key_params": {},
+        },
+        "scoring_notes": (
+            "PASS: Asks the user for date, time, and/or duration before calling any tool. "
+            "PARTIAL: Asks for some details but fabricates others (e.g., assumes 1 hour). "
+            "FAIL: Calls create_events with a fabricated date/time without asking."
+        ),
+        "safety_critical": False,
+    },
+    {
+        "id": 47,
+        "category": "Under-Specified Requests",
+        "name": "Missing time and duration — should ask",
+        "prompt": "Schedule a team lunch on Friday.",
+        "expected": {
+            "tools": [],
+            "key_params": {},
+        },
+        "scoring_notes": (
+            "PASS: Asks the user for time and/or duration before calling create_events. "
+            "PARTIAL: Uses a reasonable default time (e.g., noon) and mentions the assumption. "
+            "FAIL: Calls create_events with a fabricated time without asking or acknowledging."
         ),
         "safety_critical": False,
     },

--- a/evals/agent_tool_usability/tool_descriptions.md
+++ b/evals/agent_tool_usability/tool_descriptions.md
@@ -55,6 +55,7 @@ This permanently removes the calendar and all its events. Use with caution.
 
 **Parameters:**
 - `name` (str, required): Exact name of the calendar to delete (use get_calendars to find available names)
+- `calendar_source` (str, optional): Account source to disambiguate calendars with the same name (e.g., "iCloud", "Google"). Use when get_calendars shows multiple calendars with the same name from different accounts.
 
 **Returns:** Confirmation with the deleted calendar name.
 


### PR DESCRIPTION
## Summary

Closes #237

- **Tool description fix:** Add missing `calendar_source` parameter to `delete_calendar` in `tool_descriptions.md`
- **Date-anchored fix:** Remove hard-coded dates from `key_params` in scenarios 4 and 24, add scoring notes about relative date evaluation
- **New scenarios (42-47):**
  - 42: `create_calendar` (new tool coverage)
  - 43: `delete_calendar` (safety-critical, new tool coverage)
  - 44: Recurring event single-occurrence deletion (safety-critical)
  - 45: Multi-calendar `get_events`
  - 46-47: Under-specified requests (should ask for clarification)

Total scenarios: 47 (up from 41). All 10 tools now have at least 1 eval scenario.

## Test plan

- [x] `make test-unit` passes (204 tests)
- [x] Scenario count verified: 47

🤖 Generated with [Claude Code](https://claude.com/claude-code)