### PR TITLE
Harden fresh_calendar fixture against teardown failure

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -38,9 +38,15 @@ def fresh_calendar():
 
     Used by recurring event tests where events can't be fully deleted
     via the API — the calendar must be recreated to ensure clean state.
+
+    WARNING: Not compatible with parallel test execution (pytest-xdist).
     """
     delete_test_calendar(TEST_CALENDAR)
     create_test_calendar(TEST_CALENDAR)
     yield
-    delete_test_calendar(TEST_CALENDAR)
-    create_test_calendar(TEST_CALENDAR)
+    try:
+        delete_test_calendar(TEST_CALENDAR)
+    finally:
+        # Always recreate, even if delete failed or was partial
+        if not calendar_exists(TEST_CALENDAR):
+            create_test_calendar(TEST_CALENDAR)


### PR DESCRIPTION
## Summary

Closes #239

Wraps the `fresh_calendar` fixture teardown in `try/finally` so the test calendar is always recreated even if the delete step fails. Adds a `calendar_exists` guard and documents `pytest-xdist` incompatibility.

## Test plan

- [x] `make test-unit` passes (204 tests)
- [ ] `make test-integration` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)