### PR TITLE
Add passthrough assertion for get_calendars return value

### DIFF
--- a/tests/unit/test_calendar_connector.py
+++ b/tests/unit/test_calendar_connector.py
@@ -266,6 +266,17 @@ class TestGetCalendars:
         with pytest.raises(PermissionError, match="Access denied"):
             self.connector.get_calendars()
 
+    @patch("apple_calendar_mcp.calendar_connector.run_swift_helper")
+    def test_returns_exact_data_from_swift_helper(self, mock_swift):
+        """get_calendars() should return the exact list from the Swift helper unmodified."""
+        expected = [
+            {"name": "Work", "writable": True, "description": "Work cal", "color": "#FF0000", "source": "iCloud", "type": "caldav", "is_default": True},
+            {"name": "Personal", "writable": False, "description": "", "color": "#00FF00", "source": "Google", "type": "caldav", "is_default": False},
+        ]
+        mock_swift.return_value = json.dumps(expected)
+        result = self.connector.get_calendars()
+        assert result == expected
+
 
 # ── create_calendar ─────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Closes #240

Adds a test verifying `get_calendars()` returns the exact list from the Swift helper unmodified (equality assertion), not just `isinstance(result, list)`.

## Test plan

- [x] `make test-unit` passes (205 tests, +1 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)